### PR TITLE
eval: prefer vllm_commit over buildkite_commit in commit display

### DIFF
--- a/src/app/api/eval/route.ts
+++ b/src/app/api/eval/route.ts
@@ -36,6 +36,7 @@ export interface EvalRow {
   buildkite_build_url: string | null;
   buildkite_commit: string | null;
   buildkite_branch: string | null;
+  vllm_commit: string | null;
   workload: string | null;
 }
 
@@ -72,6 +73,7 @@ interface LmEvalMessage extends LmEvalCore {
   buildkite_commit?: string;
   buildkite_branch?: string;
   buildkite_pipeline_slug?: string;
+  vllm_commit?: string;
   [key: string]: unknown;
 }
 
@@ -190,6 +192,7 @@ export async function GET(request: NextRequest) {
           buildkite_build_url: raw.buildkite_build_url ?? null,
           buildkite_commit: raw.buildkite_commit ?? null,
           buildkite_branch: raw.buildkite_branch ?? null,
+          vllm_commit: raw.vllm_commit ?? null,
           workload,
         };
 

--- a/src/app/eval/page.tsx
+++ b/src/app/eval/page.tsx
@@ -46,6 +46,7 @@ interface EvalRow {
   buildkite_build_url: string | null;
   buildkite_commit: string | null;
   buildkite_branch: string | null;
+  vllm_commit: string | null;
   workload: string | null;
 }
 
@@ -134,8 +135,15 @@ function formatTime(iso: string): string {
   return `${month} ${d.getDate()} ${timeStr}`;
 }
 
-function shortCommit(sha: string | null, fallback: string | null): string {
-  const s = sha ?? fallback;
+function shortCommit(row: {
+  vllm_commit: string | null;
+  buildkite_commit: string | null;
+  git_hash: string | null;
+}): string {
+  // Prefer the actual vLLM commit (sent by perf-eval ingest when the build
+  // pinned VLLM_COMMIT). Fall back to buildkite_commit, which is the
+  // perf-eval pipeline SHA, and finally to git_hash from lm_eval.
+  const s = row.vllm_commit ?? row.buildkite_commit ?? row.git_hash;
   return s ? s.slice(0, 7) : "—";
 }
 
@@ -191,7 +199,7 @@ function ScoreChart({
         line: { color, width: 2, shape: "spline" },
         marker: { color, size: 8, line: { color: dark ? "#18181b" : "#ffffff", width: 1.5 } },
         customdata: points.map((p) => [
-          shortCommit(p.r.buildkite_commit, p.r.git_hash),
+          shortCommit(p.r),
           p.r.n_shot,
           p.r.n_samples,
           p.r.lm_eval_version ?? "—",
@@ -446,7 +454,7 @@ function SamplesDrawer({
                   buildkite #{row.buildkite_build_number}
                 </a>
               ) : null}
-              <span className="font-mono">{shortCommit(row.buildkite_commit, row.git_hash)}</span>
+              <span className="font-mono">{shortCommit(row)}</span>
               {row.image ? (
                 <span className="font-mono" title={row.image}>
                   image: {row.image}
@@ -591,10 +599,10 @@ function LeaderboardTable({
                         onClick={(e) => e.stopPropagation()}
                         className="text-blue-600 hover:underline dark:text-blue-400"
                       >
-                        {shortCommit(r.buildkite_commit, r.git_hash)}
+                        {shortCommit(r)}
                       </a>
                     ) : (
-                      shortCommit(r.buildkite_commit, r.git_hash)
+                      shortCommit(r)
                     )}
                   </td>
                   <td className="max-w-[260px] px-4 py-2 font-mono text-xs text-zinc-500">
@@ -674,7 +682,7 @@ function LatestStatCards({
       {cards.map((c) => {
         if (!c.m) return null;
         let color: "default" | "green" | "red" | "yellow" = "default";
-        const commit = shortCommit(c.latest.buildkite_commit, c.latest.git_hash);
+        const commit = shortCommit(c.latest);
         let detail = `n=${c.latest.n_samples}, ${c.latest.n_shot}-shot, ${commit}`;
         if (c.prevM) {
           const delta = c.m.value - c.prevM.value;


### PR DESCRIPTION
## Summary
- Read `vllm_commit` from the ingest payload and prefer it over `buildkite_commit` when displaying the "commit" on the eval page.
- Falls through to `buildkite_commit`, then `git_hash`, so historical rows without `vllm_commit` keep working.

## Context
The eval page used to display the perf-eval pipeline SHA from `buildkite_commit` as the "commit". For builds that pin a vLLM image via `VLLM_COMMIT`, the actually relevant commit is the vLLM one. `perf-eval` now sends both:
- `image` — the resolved docker URI, picked up by the existing `imageFromMessage` priority chain (`raw.image` is the first key checked) so the dashboard stops falling back to `vllm/vllm-openai:latest` via the workload-yaml round-trip.
- `vllm_commit` — the pinned commit, consumed by this PR.

See vllm-project/perf-eval@9ebe031.

## Changes
- `src/app/api/eval/route.ts`: add `vllm_commit` to `EvalRow` and `LmEvalMessage`, plumb it through from the ingest message.
- `src/app/eval/page.tsx`: add `vllm_commit` to the row interface; rework `shortCommit` to take a row and prefer `vllm_commit > buildkite_commit > git_hash`. Update all callsites.

## Test plan
- [ ] `npm run build` / type-check passes locally
- [ ] Eval page renders without errors after pulling the branch
- [ ] For a recent build that pinned `VLLM_COMMIT`, the displayed commit is the vLLM SHA (not the perf-eval pipeline SHA)
- [ ] Older rows without `vllm_commit` still show `buildkite_commit` (or `git_hash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR was authored with assistance from Claude Code.