### PR TITLE
queue: show all queues in summary table

### DIFF
--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -312,7 +312,6 @@ export default function QueuePage() {
             </thead>
             <tbody>
               {allLatest
-                .filter((q) => q.agents_total > 0 || q.jobs_total > 0)
                 .sort((a, b) => {
                   if (sortCol === "waiting") {
                     const aw = effectiveWaiting(a.queue, a.jobs_scheduled, a.jobs_waiting);
@@ -350,7 +349,7 @@ export default function QueuePage() {
                     </td>
                   </tr>
                 ))}
-              {allLatest.filter((q) => q.agents_total > 0 || q.jobs_total > 0).length === 0 && (
+              {allLatest.length === 0 && (
                 <tr>
                   <td colSpan={8} className="px-5 py-8 text-center text-zinc-400">
                     No queue data found


### PR DESCRIPTION
## Summary
- Removed the `.filter((q) => q.agents_total > 0 || q.jobs_total > 0)` from the Queue Summary Table
- Queues like `arm64_cpu_queue_release` use Docker-plugin auto-scaled VMs that are idle most of the time, so they always had 0 agents/0 jobs at poll time and were hidden from the table
- Now all queues with data in the selected time window are shown

## Test plan
- [ ] Verify `arm64_cpu_queue_release` appears in the Queue Summary Table on the /queue page
- [ ] Verify other queues still display correctly
- [ ] Verify the "No queue data found" empty state still works when there's genuinely no data

🤖 Generated with [Claude Code](https://claude.com/claude-code)