### PR TITLE
Fix Jobs/Queue tabs empty for historical date ranges

### DIFF
--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -35,6 +35,10 @@ export async function GET(request: NextRequest) {
       conditions.push(`b.created_at < DATE_ADD('${endDate.replace(/'/g, "''")}', 1)`);
     }
     const where = conditions.join(" AND ");
+    const hasDateRange = startDate || endDate;
+    const recencyHaving = hasDateRange
+      ? ""
+      : "\n          AND MAX(b.created_at) >= CURRENT_DATE - INTERVAL 7 DAY";
 
     const [failureRanking, durationStats] = await Promise.all([
       queryDatabricks(`
@@ -55,8 +59,7 @@ export async function GET(request: NextRequest) {
         WHERE ${where}
           AND j.state IN ('passed', 'failed', 'failing', 'broken', 'timed_out')
         GROUP BY j.name
-        HAVING SUM(CASE WHEN j.state IN ('failed', 'failing', 'broken', 'timed_out') THEN 1 ELSE 0 END) > 0
-          AND MAX(b.created_at) >= CURRENT_DATE - INTERVAL 7 DAY
+        HAVING SUM(CASE WHEN j.state IN ('failed', 'failing', 'broken', 'timed_out') THEN 1 ELSE 0 END) > 0${recencyHaving}
         ORDER BY failure_rate DESC, failures DESC
       `),
       queryDatabricks(`
@@ -75,7 +78,7 @@ export async function GET(request: NextRequest) {
           AND j.finished_at IS NOT NULL
           AND j.state = 'passed'
         GROUP BY j.name
-        HAVING MAX(b.created_at) >= CURRENT_DATE - INTERVAL 7 DAY
+        HAVING COUNT(*) > 0${recencyHaving}
         ORDER BY p50_duration DESC
       `),
     ]);

--- a/src/app/api/queue/route.ts
+++ b/src/app/api/queue/route.ts
@@ -37,6 +37,10 @@ export async function GET(request: NextRequest) {
       conditions.push(`b.created_at < DATE_ADD('${endDate.replace(/'/g, "''")}', 1)`);
     }
     const where = conditions.join(" AND ");
+    const hasDateRange = startDate || endDate;
+    const recencyHaving = hasDateRange
+      ? ""
+      : "\n        HAVING MAX(b.created_at) >= CURRENT_DATE - INTERVAL 7 DAY";
 
     const joinClause = `
       FROM vllm_data_warehouse.buildkite.build_job AS j
@@ -89,8 +93,7 @@ export async function GET(request: NextRequest) {
           ROUND(MAX(TIMESTAMPDIFF(SECOND, j.runnable_at, j.started_at))) AS max_wait
         ${joinClause}
         WHERE ${where}
-        GROUP BY SUBSTRING(r.rule, 7)
-        HAVING MAX(b.created_at) >= CURRENT_DATE - INTERVAL 7 DAY
+        GROUP BY SUBSTRING(r.rule, 7)${recencyHaving}
         ORDER BY p50_wait DESC
       `),
       // Wait time trend with adaptive intervals (per queue)


### PR DESCRIPTION
## Summary
- The `HAVING MAX(b.created_at) >= CURRENT_DATE - INTERVAL 7 DAY` clause in the Jobs and Queue API routes unconditionally filtered out all grouped results older than 7 days — even when the user explicitly selected a historical date range (e.g., 04-26 to 04-29)
- Now the 7-day recency filter only applies when **no** date range is specified, preserving the default behavior while allowing historical queries to return data

## Affected routes
- `src/app/api/jobs/route.ts` — both failureRanking and durationStats queries
- `src/app/api/queue/route.ts` — queueStats query

## Test plan
- [ ] Select a date range more than 7 days in the past on the Jobs tab — verify results appear
- [ ] Select the 04-26 to 04-29 range specifically — verify jobs are listed
- [ ] Use the Jobs tab with no date range selected — verify the default 7-day recency filter still applies
- [ ] Check the Queue tab with historical date ranges as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)