### PR TITLE
feat: GPU utilization monitoring

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -13,3 +13,6 @@ DATABASE_URL=postgres://user:pass@host:5432/dbname
 
 # Buildkite Agent Metrics API (required for agent metrics polling)
 BUILDKITE_AGENT_TOKEN=your-agent-registration-token
+
+# GPU reporting auth (must match GPU_REPORT_SECRET on the node-side script)
+GPU_REPORT_SECRET=your-gpu-report-secret

--- a/scripts/gpu-reporter.py
+++ b/scripts/gpu-reporter.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Lightweight GPU utilization reporter for vLLM Dashboard.
+
+Queries nvidia-smi and POSTs GPU metrics to the dashboard API.
+Run via cron or systemd timer every 30-60 seconds.
+
+Usage:
+  GPU_REPORT_URL=https://your-dashboard.vercel.app/api/gpu/report \
+  GPU_REPORT_SECRET=your-secret \
+  python3 gpu-reporter.py
+
+Environment variables:
+  GPU_REPORT_URL    - Dashboard API endpoint (required)
+  GPU_REPORT_SECRET - Bearer token for auth (optional, must match dashboard's GPU_REPORT_SECRET)
+  GPU_HOSTNAME      - Override hostname (default: system hostname)
+"""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import urllib.request
+
+REPORT_URL = os.environ.get("GPU_REPORT_URL", "")
+REPORT_SECRET = os.environ.get("GPU_REPORT_SECRET", "")
+HOSTNAME = os.environ.get("GPU_HOSTNAME", socket.gethostname())
+
+NVIDIA_SMI_QUERY = (
+    "index,name,utilization.gpu,memory.used,memory.total,"
+    "temperature.gpu,power.draw,power.limit"
+)
+
+
+def query_gpus():
+    result = subprocess.run(
+        [
+            "nvidia-smi",
+            f"--query-gpu={NVIDIA_SMI_QUERY}",
+            "--format=csv,noheader,nounits",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        print(f"nvidia-smi failed: {result.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+
+    gpus = []
+    for line in result.stdout.strip().split("\n"):
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) < 8:
+            continue
+
+        def safe_float(v):
+            try:
+                return float(v)
+            except (ValueError, TypeError):
+                return None
+
+        gpus.append({
+            "index": int(parts[0]),
+            "name": parts[1] if parts[1] != "[N/A]" else None,
+            "gpu_util": safe_float(parts[2]) or 0,
+            "mem_used_mb": safe_float(parts[3]) or 0,
+            "mem_total_mb": safe_float(parts[4]) or 0,
+            "temperature_c": safe_float(parts[5]),
+            "power_draw_w": safe_float(parts[6]),
+            "power_limit_w": safe_float(parts[7]),
+        })
+    return gpus
+
+
+def report(gpus):
+    payload = json.dumps({"hostname": HOSTNAME, "gpus": gpus}).encode()
+
+    headers = {"Content-Type": "application/json"}
+    if REPORT_SECRET:
+        headers["Authorization"] = f"Bearer {REPORT_SECRET}"
+
+    req = urllib.request.Request(REPORT_URL, data=payload, headers=headers, method="POST")
+
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        body = json.loads(resp.read())
+        print(f"OK: {body.get('gpus', 0)} GPUs reported for {HOSTNAME}")
+
+
+def main():
+    if not REPORT_URL:
+        print("GPU_REPORT_URL not set", file=sys.stderr)
+        sys.exit(1)
+
+    gpus = query_gpus()
+    if not gpus:
+        print("No GPUs found", file=sys.stderr)
+        sys.exit(1)
+
+    report(gpus)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gpu-reporter.service
+++ b/scripts/gpu-reporter.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Report GPU utilization to vLLM Dashboard
+
+[Service]
+Type=oneshot
+Environment=GPU_REPORT_URL=https://your-dashboard.vercel.app/api/gpu/report
+Environment=GPU_REPORT_SECRET=your-secret-here
+ExecStart=/usr/bin/python3 /opt/gpu-reporter/gpu-reporter.py
+TimeoutSec=30

--- a/scripts/gpu-reporter.timer
+++ b/scripts/gpu-reporter.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run GPU reporter every 30 seconds
+
+[Timer]
+OnBootSec=10
+OnUnitActiveSec=30
+
+[Install]
+WantedBy=timers.target

--- a/src/app/api/cron/poll-metrics/route.ts
+++ b/src/app/api/cron/poll-metrics/route.ts
@@ -122,6 +122,10 @@ export async function GET(request: NextRequest) {
       DELETE FROM queue_snapshots
       WHERE polled_at < NOW() - INTERVAL '30 days'
     `;
+    await db`
+      DELETE FROM gpu_snapshots
+      WHERE reported_at < NOW() - INTERVAL '30 days'
+    `;
 
     return NextResponse.json({
       ok: true,

--- a/src/app/api/gpu/report/route.ts
+++ b/src/app/api/gpu/report/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb, initSchema } from "@/lib/db";
+
+let schemaInitialized = false;
+
+interface GpuReport {
+  hostname: string;
+  gpus: Array<{
+    index: number;
+    name?: string;
+    gpu_util: number;
+    mem_used_mb: number;
+    mem_total_mb: number;
+    temperature_c?: number;
+    power_draw_w?: number;
+    power_limit_w?: number;
+  }>;
+}
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.GPU_REPORT_SECRET;
+  if (secret) {
+    const auth = request.headers.get("authorization");
+    if (auth !== `Bearer ${secret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  try {
+    const body: GpuReport = await request.json();
+
+    if (!body.hostname || !Array.isArray(body.gpus) || body.gpus.length === 0) {
+      return NextResponse.json(
+        { error: "Invalid payload: need hostname and gpus array" },
+        { status: 400 },
+      );
+    }
+
+    const db = getDb();
+
+    if (!schemaInitialized) {
+      await initSchema();
+      schemaInitialized = true;
+    }
+
+    const now = new Date();
+
+    for (const gpu of body.gpus) {
+      await db`
+        INSERT INTO gpu_snapshots (
+          reported_at, hostname, gpu_index, gpu_name,
+          gpu_util, mem_used_mb, mem_total_mb,
+          temperature_c, power_draw_w, power_limit_w
+        ) VALUES (
+          ${now}, ${body.hostname}, ${gpu.index}, ${gpu.name ?? null},
+          ${gpu.gpu_util}, ${gpu.mem_used_mb}, ${gpu.mem_total_mb},
+          ${gpu.temperature_c ?? null}, ${gpu.power_draw_w ?? null}, ${gpu.power_limit_w ?? null}
+        )
+      `;
+    }
+
+    return NextResponse.json({
+      ok: true,
+      hostname: body.hostname,
+      gpus: body.gpus.length,
+      reported_at: now.toISOString(),
+    });
+  } catch (error) {
+    console.error("GPU report failed:", error);
+    return NextResponse.json(
+      { error: "Failed to store GPU report" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/gpu/route.ts
+++ b/src/app/api/gpu/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb, initSchema } from "@/lib/db";
+
+let schemaInitialized = false;
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const hours = Math.min(parseInt(searchParams.get("hours") ?? "24", 10) || 24, 720);
+  const hostname = searchParams.get("hostname") ?? "";
+
+  try {
+    const db = getDb();
+
+    if (!schemaInitialized) {
+      await initSchema();
+      schemaInitialized = true;
+    }
+
+    const bucketMinutes = hours <= 1 ? 1 : hours <= 6 ? 2 : hours <= 24 ? 5 : hours <= 168 ? 30 : 60;
+
+    const snapshots = hostname
+      ? await db`
+          SELECT
+            date_trunc('hour', reported_at)
+              + INTERVAL '1 minute' * (FLOOR(EXTRACT(MINUTE FROM reported_at) / ${bucketMinutes}) * ${bucketMinutes})
+              AS time_bucket,
+            hostname,
+            gpu_index,
+            gpu_name,
+            ROUND(AVG(gpu_util)::numeric, 1) AS gpu_util,
+            ROUND(AVG(mem_used_mb)::numeric, 0) AS mem_used_mb,
+            MAX(mem_total_mb) AS mem_total_mb,
+            ROUND(AVG(temperature_c)::numeric, 0) AS temperature_c,
+            ROUND(AVG(power_draw_w)::numeric, 0) AS power_draw_w,
+            MAX(power_limit_w) AS power_limit_w
+          FROM gpu_snapshots
+          WHERE reported_at > NOW() - INTERVAL '1 hour' * ${hours}
+            AND hostname = ${hostname}
+          GROUP BY time_bucket, hostname, gpu_index, gpu_name
+          ORDER BY time_bucket ASC, gpu_index ASC
+        `
+      : await db`
+          SELECT
+            date_trunc('hour', reported_at)
+              + INTERVAL '1 minute' * (FLOOR(EXTRACT(MINUTE FROM reported_at) / ${bucketMinutes}) * ${bucketMinutes})
+              AS time_bucket,
+            hostname,
+            gpu_index,
+            gpu_name,
+            ROUND(AVG(gpu_util)::numeric, 1) AS gpu_util,
+            ROUND(AVG(mem_used_mb)::numeric, 0) AS mem_used_mb,
+            MAX(mem_total_mb) AS mem_total_mb,
+            ROUND(AVG(temperature_c)::numeric, 0) AS temperature_c,
+            ROUND(AVG(power_draw_w)::numeric, 0) AS power_draw_w,
+            MAX(power_limit_w) AS power_limit_w
+          FROM gpu_snapshots
+          WHERE reported_at > NOW() - INTERVAL '1 hour' * ${hours}
+          GROUP BY time_bucket, hostname, gpu_index, gpu_name
+          ORDER BY time_bucket ASC, gpu_index ASC
+        `;
+
+    const hostnamesResult = await db`
+      SELECT DISTINCT hostname FROM gpu_snapshots
+      WHERE reported_at > NOW() - INTERVAL '1 hour' * ${hours}
+      ORDER BY hostname
+    `;
+
+    const latestResult = await db`
+      SELECT DISTINCT ON (hostname, gpu_index)
+        hostname, gpu_index, gpu_name, gpu_util, mem_used_mb, mem_total_mb,
+        temperature_c, power_draw_w, power_limit_w, reported_at
+      FROM gpu_snapshots
+      WHERE reported_at > NOW() - INTERVAL '10 minutes'
+      ORDER BY hostname, gpu_index, reported_at DESC
+    `;
+
+    return NextResponse.json({
+      snapshots,
+      hostnames: hostnamesResult.map((r) => r.hostname),
+      latest: latestResult,
+    });
+  } catch (error) {
+    console.error("GPU metrics query failed:", error);
+    return NextResponse.json(
+      { error: "Failed to query GPU metrics" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/gpu/page.tsx
+++ b/src/app/gpu/page.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import useSWR from "swr";
+import { StatCard } from "@/components/stat-card";
+import { SearchableSelect } from "@/components/searchable-select";
+import { GpuUtilChart } from "@/components/gpu-util-chart";
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+interface GpuSnapshot {
+  time_bucket: string;
+  hostname: string;
+  gpu_index: number;
+  gpu_name: string | null;
+  gpu_util: number;
+  mem_used_mb: number;
+  mem_total_mb: number;
+  temperature_c: number | null;
+  power_draw_w: number | null;
+  power_limit_w: number | null;
+}
+
+interface GpuLatest {
+  hostname: string;
+  gpu_index: number;
+  gpu_name: string | null;
+  gpu_util: number;
+  mem_used_mb: number;
+  mem_total_mb: number;
+  temperature_c: number | null;
+  power_draw_w: number | null;
+  power_limit_w: number | null;
+  reported_at: string;
+}
+
+interface GpuResponse {
+  snapshots: GpuSnapshot[];
+  hostnames: string[];
+  latest: GpuLatest[];
+  error?: string;
+}
+
+const HOURS_OPTIONS = [
+  { label: "1h", value: 1 },
+  { label: "6h", value: 6 },
+  { label: "24h", value: 24 },
+  { label: "7d", value: 168 },
+];
+
+function formatMemory(mb: number): string {
+  if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
+  return `${Math.round(mb)} MB`;
+}
+
+export default function GpuPage() {
+  const [hostname, setHostname] = useState("");
+  const [hours, setHours] = useState(24);
+
+  const url = `/api/gpu?hours=${hours}${hostname ? `&hostname=${encodeURIComponent(hostname)}` : ""}`;
+  const { data, error, isLoading } = useSWR<GpuResponse>(url, fetcher, {
+    refreshInterval: 60_000,
+  });
+
+  const chartDataByGpu = useMemo(() => {
+    const snapshots = data?.snapshots ?? [];
+    if (snapshots.length === 0) return new Map<string, Array<{ time: number; gpu_util: number; mem_pct: number; temperature_c: number | null }>>();
+
+    const grouped = new Map<string, Array<{ time: number; gpu_util: number; mem_pct: number; temperature_c: number | null }>>();
+
+    for (const row of snapshots) {
+      const key = `${row.hostname}:gpu${row.gpu_index}`;
+      if (!grouped.has(key)) grouped.set(key, []);
+      grouped.get(key)!.push({
+        time: new Date(row.time_bucket).getTime(),
+        gpu_util: Number(row.gpu_util),
+        mem_pct: row.mem_total_mb > 0 ? Math.round((Number(row.mem_used_mb) / Number(row.mem_total_mb)) * 100) : 0,
+        temperature_c: row.temperature_c != null ? Number(row.temperature_c) : null,
+      });
+    }
+
+    for (const arr of grouped.values()) {
+      arr.sort((a, b) => a.time - b.time);
+    }
+
+    return grouped;
+  }, [data]);
+
+  const avgChartData = useMemo(() => {
+    const snapshots = data?.snapshots ?? [];
+    if (snapshots.length === 0) return [];
+
+    const targetHost = hostname || null;
+    const bucketMap = new Map<number, { utilSum: number; memPctSum: number; tempSum: number; tempCount: number; count: number }>();
+
+    for (const row of snapshots) {
+      if (targetHost && row.hostname !== targetHost) continue;
+      const t = new Date(row.time_bucket).getTime();
+      if (!bucketMap.has(t)) bucketMap.set(t, { utilSum: 0, memPctSum: 0, tempSum: 0, tempCount: 0, count: 0 });
+      const entry = bucketMap.get(t)!;
+      entry.utilSum += Number(row.gpu_util);
+      entry.memPctSum += row.mem_total_mb > 0 ? (Number(row.mem_used_mb) / Number(row.mem_total_mb)) * 100 : 0;
+      if (row.temperature_c != null) {
+        entry.tempSum += Number(row.temperature_c);
+        entry.tempCount++;
+      }
+      entry.count++;
+    }
+
+    return [...bucketMap.entries()]
+      .map(([time, v]) => ({
+        time,
+        gpu_util: Math.round((v.utilSum / v.count) * 10) / 10,
+        mem_pct: Math.round(v.memPctSum / v.count),
+        temperature_c: v.tempCount > 0 ? Math.round(v.tempSum / v.tempCount) : null,
+      }))
+      .sort((a, b) => a.time - b.time);
+  }, [data, hostname]);
+
+  const tickInterval = Math.max(1, Math.floor(avgChartData.length / 10));
+
+  function formatXTick(t: number): string {
+    const d = new Date(t);
+    if (hours <= 24) {
+      return d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true });
+    } else if (hours <= 168) {
+      return d.toLocaleString("en-US", { weekday: "short", hour: "numeric", hour12: true });
+    }
+    return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center text-zinc-400">
+        Loading GPU data...
+      </div>
+    );
+  }
+
+  if (error || data?.error) {
+    return (
+      <div className="flex h-64 items-center justify-center text-red-400">
+        Failed to load GPU data. Check DATABASE_URL configuration.
+      </div>
+    );
+  }
+
+  const latest = data?.latest ?? [];
+  const filtered = hostname ? latest.filter((g) => g.hostname === hostname) : latest;
+  const totalGpus = filtered.length;
+  const avgUtil = totalGpus > 0 ? Math.round(filtered.reduce((s, g) => s + g.gpu_util, 0) / totalGpus) : 0;
+  const avgMemPct = totalGpus > 0
+    ? Math.round(filtered.reduce((s, g) => s + (g.mem_total_mb > 0 ? (g.mem_used_mb / g.mem_total_mb) * 100 : 0), 0) / totalGpus)
+    : 0;
+  const uniqueHosts = new Set(filtered.map((g) => g.hostname)).size;
+  const maxTemp = filtered.reduce((m, g) => Math.max(m, g.temperature_c ?? 0), 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="text-2xl font-semibold">GPU Utilization</h1>
+        <div className="flex gap-3">
+          <SearchableSelect
+            label="Host"
+            value={hostname}
+            onChange={setHostname}
+            options={data?.hostnames ?? []}
+            allLabel="All Hosts"
+          />
+          <div className="flex gap-1 rounded-md border border-zinc-200 p-0.5 dark:border-zinc-700">
+            {HOURS_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => setHours(opt.value)}
+                className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+                  hours === opt.value
+                    ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                    : "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        <StatCard label="Nodes" value={uniqueHosts} detail={`${totalGpus} GPUs total`} />
+        <StatCard
+          label="Avg GPU Util"
+          value={`${avgUtil}%`}
+          color={avgUtil > 90 ? "green" : avgUtil < 30 ? "yellow" : "default"}
+        />
+        <StatCard
+          label="Avg Mem Used"
+          value={`${avgMemPct}%`}
+          color={avgMemPct > 90 ? "red" : "default"}
+        />
+        <StatCard
+          label="Max Temp"
+          value={maxTemp > 0 ? `${maxTemp}°C` : "—"}
+          color={maxTemp > 85 ? "red" : maxTemp > 75 ? "yellow" : "default"}
+        />
+        <StatCard
+          label="Total Power"
+          value={
+            filtered.some((g) => g.power_draw_w != null)
+              ? `${Math.round(filtered.reduce((s, g) => s + (g.power_draw_w ?? 0), 0))} W`
+              : "—"
+          }
+        />
+      </div>
+
+      {/* Average utilization chart */}
+      <div className="rounded-lg border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950">
+        <h3 className="mb-4 text-sm font-medium text-zinc-500 dark:text-zinc-400">
+          Average GPU Utilization{hostname ? ` — ${hostname}` : ""}
+        </h3>
+        <GpuUtilChart
+          data={avgChartData}
+          formatXTick={formatXTick}
+          tickInterval={tickInterval}
+        />
+      </div>
+
+      {/* Per-GPU charts when a host is selected */}
+      {hostname && chartDataByGpu.size > 1 && (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {[...chartDataByGpu.entries()].map(([key, gpuData]) => {
+            const gpuTickInterval = Math.max(1, Math.floor(gpuData.length / 8));
+            return (
+              <div
+                key={key}
+                className="rounded-lg border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950"
+              >
+                <h3 className="mb-4 text-sm font-medium text-zinc-500 dark:text-zinc-400">
+                  {key}
+                </h3>
+                <GpuUtilChart
+                  data={gpuData}
+                  formatXTick={formatXTick}
+                  tickInterval={gpuTickInterval}
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* GPU detail table */}
+      <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+        <div className="border-b border-zinc-200 px-5 py-3 dark:border-zinc-800">
+          <h3 className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
+            GPU Status
+          </h3>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-zinc-200 text-left text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+                <th className="px-5 py-2.5 font-medium">Host</th>
+                <th className="px-5 py-2.5 font-medium">GPU</th>
+                <th className="px-5 py-2.5 font-medium">Model</th>
+                <th className="px-5 py-2.5 font-medium">Util</th>
+                <th className="px-5 py-2.5 font-medium">Memory</th>
+                <th className="px-5 py-2.5 font-medium">Temp</th>
+                <th className="px-5 py-2.5 font-medium">Power</th>
+                <th className="px-5 py-2.5 font-medium">Last Seen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered
+                .sort((a, b) => a.hostname.localeCompare(b.hostname) || a.gpu_index - b.gpu_index)
+                .map((g) => {
+                  const memPct = g.mem_total_mb > 0 ? Math.round((g.mem_used_mb / g.mem_total_mb) * 100) : 0;
+                  const ago = Math.round((Date.now() - new Date(g.reported_at).getTime()) / 60_000);
+                  const stale = ago > 5;
+                  return (
+                    <tr
+                      key={`${g.hostname}-${g.gpu_index}`}
+                      className={`border-b border-zinc-100 last:border-0 dark:border-zinc-800/50 ${stale ? "opacity-50" : ""}`}
+                    >
+                      <td className="px-5 py-2.5 font-medium">{g.hostname}</td>
+                      <td className="px-5 py-2.5">{g.gpu_index}</td>
+                      <td className="px-5 py-2.5 text-zinc-500 dark:text-zinc-400">{g.gpu_name ?? "—"}</td>
+                      <td className={`px-5 py-2.5 font-medium ${
+                        g.gpu_util > 80 ? "text-emerald-600 dark:text-emerald-400"
+                          : g.gpu_util < 20 ? "text-yellow-600 dark:text-yellow-400"
+                          : ""
+                      }`}>
+                        {g.gpu_util}%
+                      </td>
+                      <td className="px-5 py-2.5">
+                        <span className={memPct > 90 ? "font-medium text-red-600 dark:text-red-400" : ""}>
+                          {formatMemory(g.mem_used_mb)}
+                        </span>
+                        <span className="text-zinc-400"> / {formatMemory(g.mem_total_mb)}</span>
+                        <span className="ml-1 text-xs text-zinc-400">({memPct}%)</span>
+                      </td>
+                      <td className={`px-5 py-2.5 ${
+                        (g.temperature_c ?? 0) > 85 ? "text-red-600 dark:text-red-400"
+                          : (g.temperature_c ?? 0) > 75 ? "text-yellow-600 dark:text-yellow-400"
+                          : ""
+                      }`}>
+                        {g.temperature_c != null ? `${g.temperature_c}°C` : "—"}
+                      </td>
+                      <td className="px-5 py-2.5">
+                        {g.power_draw_w != null
+                          ? `${g.power_draw_w}W${g.power_limit_w ? ` / ${g.power_limit_w}W` : ""}`
+                          : "—"
+                        }
+                      </td>
+                      <td className={`whitespace-nowrap px-5 py-2.5 text-zinc-500 dark:text-zinc-400 ${stale ? "text-yellow-600 dark:text-yellow-400" : ""}`}>
+                        {stale ? `${ago}m ago` : "just now"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan={8} className="px-5 py-8 text-center text-zinc-400">
+                    No GPU data found. Deploy the reporting script to start collecting metrics.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/gpu-util-chart.tsx
+++ b/src/components/gpu-util-chart.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import {
+  ComposedChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+
+interface GpuUtilChartProps {
+  data: Array<{ time: number; gpu_util: number; mem_pct: number; temperature_c: number | null }>;
+  formatXTick: (t: number) => string;
+  tickInterval: number;
+}
+
+function GpuTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{ value: number; name: string; color: string }>;
+  label?: number;
+}) {
+  if (!active || !payload?.length) return null;
+  const timeLabel = label
+    ? new Date(label).toLocaleString("en-US", {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      })
+    : "";
+  return (
+    <div className="rounded-md border border-zinc-200 bg-white px-3 py-2 text-xs shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+      <p className="mb-1 font-medium">{timeLabel}</p>
+      {payload.map((p) => (
+        <div key={p.name} className="flex items-center justify-between gap-4">
+          <span className="flex items-center gap-1.5">
+            <span
+              className="inline-block h-2 w-2 rounded-full"
+              style={{ backgroundColor: p.color }}
+            />
+            {p.name}
+          </span>
+          <span className="tabular-nums">
+            {p.name === "Temp" ? `${p.value}°C` : `${p.value}%`}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function GpuUtilChart({ data, formatXTick, tickInterval }: GpuUtilChartProps) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-[300px] items-center justify-center text-sm text-zinc-400">
+        No GPU data yet. Deploy the reporting script to start collecting metrics.
+      </div>
+    );
+  }
+
+  const hasTemp = data.some((d) => d.temperature_c != null);
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <ComposedChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#27272a" vertical={false} />
+        <XAxis
+          dataKey="time"
+          tick={{ fontSize: 10 }}
+          stroke="#71717a"
+          tickFormatter={formatXTick}
+          interval={tickInterval}
+        />
+        <YAxis
+          tick={{ fontSize: 11 }}
+          stroke="#71717a"
+          width={40}
+          domain={[0, 100]}
+          tickFormatter={(v: number) => `${v}%`}
+        />
+        <Tooltip
+          content={<GpuTooltip />}
+          cursor={{ fill: "rgba(113,113,122,0.08)" }}
+        />
+        <Legend wrapperStyle={{ fontSize: 11 }} />
+        <Area
+          type="monotone"
+          dataKey="gpu_util"
+          name="GPU Util"
+          stroke="#10b981"
+          fill="#10b981"
+          fillOpacity={0.15}
+          strokeWidth={2}
+          dot={false}
+          activeDot={{ r: 4 }}
+        />
+        <Area
+          type="monotone"
+          dataKey="mem_pct"
+          name="Mem Used"
+          stroke="#3b82f6"
+          fill="#3b82f6"
+          fillOpacity={0.1}
+          strokeWidth={2}
+          dot={false}
+          activeDot={{ r: 4 }}
+        />
+        {hasTemp && (
+          <Line
+            type="monotone"
+            dataKey="temperature_c"
+            name="Temp"
+            stroke="#f59e0b"
+            strokeWidth={1.5}
+            strokeDasharray="4 2"
+            dot={false}
+            activeDot={{ r: 3 }}
+          />
+        )}
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -8,6 +8,7 @@ const links = [
   { href: "/jobs", label: "Jobs" },
   { href: "/nightly", label: "Nightly" },
   { href: "/queue", label: "Queue" },
+  { href: "/gpu", label: "GPU" },
   { href: "/cost", label: "Cost" },
   { href: "/perf", label: "Performance" },
   { href: "/eval", label: "Evaluation" },

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -70,4 +70,28 @@ export async function initSchema() {
       updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `;
+
+  await db`
+    CREATE TABLE IF NOT EXISTS gpu_snapshots (
+      id             SERIAL PRIMARY KEY,
+      reported_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      hostname       TEXT NOT NULL,
+      gpu_index      INT NOT NULL,
+      gpu_name       TEXT,
+      gpu_util       REAL NOT NULL,
+      mem_used_mb    REAL NOT NULL,
+      mem_total_mb   REAL NOT NULL,
+      temperature_c  REAL,
+      power_draw_w   REAL,
+      power_limit_w  REAL
+    )
+  `;
+  await db`
+    CREATE INDEX IF NOT EXISTS idx_gpu_snapshots_reported
+    ON gpu_snapshots (reported_at DESC, hostname)
+  `;
+  await db`
+    CREATE INDEX IF NOT EXISTS idx_gpu_snapshots_host
+    ON gpu_snapshots (hostname, reported_at DESC)
+  `;
 }


### PR DESCRIPTION
## Summary
- Adds `/gpu` page with per-node GPU utilization charts, stat cards, and detail table
- New `POST /api/gpu/report` endpoint for nodes to push nvidia-smi metrics
- New `gpu_snapshots` Postgres table with 30-day retention
- Node-side Python reporter script in `scripts/` (also pushed to ci-infra)

## Test plan
- [ ] Deploy to Vercel preview, verify `/gpu` page loads with empty state
- [ ] Run `gpu-reporter.py` against the preview URL, confirm data appears
- [ ] Verify GPU_REPORT_SECRET auth rejects unauthorized requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)