### PR TITLE
feat: show Running / Scheduled / Waiting as separate series in queue chart

### DIFF
--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -91,19 +91,20 @@ export default function QueuePage() {
 
   const metricsQueuesForFilter = metricsData?.queues ?? [];
 
-  // Aggregate snapshots into chart data: sum running/waiting/agents per time bucket
+  // Aggregate snapshots into chart data: sum running/scheduled/waiting/agents per time bucket
   const overviewChartData = useMemo(() => {
     const snapshots = metricsData?.snapshots ?? [];
     if (snapshots.length === 0) return [];
 
-    const bucketMap = new Map<number, { running: number; waiting: number; agents: number }>();
+    const bucketMap = new Map<number, { running: number; scheduled: number; waiting: number; agents: number }>();
     for (const row of snapshots) {
       if (queue && row.queue !== queue) continue;
       const t = new Date(row.time_bucket).getTime();
-      if (!bucketMap.has(t)) bucketMap.set(t, { running: 0, waiting: 0, agents: 0 });
+      if (!bucketMap.has(t)) bucketMap.set(t, { running: 0, scheduled: 0, waiting: 0, agents: 0 });
       const entry = bucketMap.get(t)!;
       entry.running += row.jobs_running;
-      entry.waiting += effectiveWaiting(row.queue, row.jobs_scheduled, row.jobs_waiting);
+      entry.scheduled += row.jobs_scheduled;
+      entry.waiting += row.jobs_waiting;
       entry.agents += row.agents_total;
     }
 

--- a/src/components/queue-overview-chart.tsx
+++ b/src/components/queue-overview-chart.tsx
@@ -13,7 +13,7 @@ import {
 } from "recharts";
 
 interface QueueOverviewChartProps {
-  data: Array<{ time: number; running: number; waiting: number; agents: number }>;
+  data: Array<{ time: number; running: number; scheduled: number; waiting: number; agents: number }>;
   formatXTick: (t: number) => string;
   tickInterval: number;
 }
@@ -96,10 +96,18 @@ export function QueueOverviewChart({ data, formatXTick, tickInterval }: QueueOve
         />
         <Bar
 
+          dataKey="scheduled"
+          name="Scheduled"
+          stackId="jobs"
+          fill="#a1a1aa"
+          radius={[0, 0, 0, 0]}
+        />
+        <Bar
+
           dataKey="waiting"
           name="Waiting"
           stackId="jobs"
-          fill="#a1a1aa"
+          fill="#eab308"
           radius={[2, 2, 0, 0]}
         />
         <Line


### PR DESCRIPTION
## What

The Queue tab overview chart now plots **all three job states as separate stacked bars** instead of collapsing them into one bar:

| Series | Source field | Color |
|---|---|---|
| Running | `jobs_running` | 🟢 green `#10b981` |
| Scheduled | `jobs_scheduled` | ⬜ grey `#a1a1aa` |
| Waiting | `jobs_waiting` | 🟡 yellow `#eab308` |

The blue "Connected Agents" line is unchanged. Stacked, the three bars sum to `jobs_total`.

## Why

Previously the chart had only **Running** (green) + a single **Waiting** (grey) bar, where "Waiting" came from `effectiveWaiting()`. That helper **collapses `jobs_scheduled` + `jobs_waiting` into one number and discards `jobs_waiting` entirely for Docker/k8s queues** (it's considered noisy for those). The result: for queues like `b200-k8s`, real `jobs_waiting` backlog (observed up to ~38) was completely invisible on the chart. This change surfaces the full breakdown for every queue.

## Database changes?

**None.** This is frontend-only. The `queue_snapshots` table already stores `jobs_running`, `jobs_scheduled`, and `jobs_waiting` as separate columns, and `/api/metrics` already returns all three — the page was just folding two of them together before rendering.

## Changes

- `src/app/queue/page.tsx` — `overviewChartData` now emits `running` / `scheduled` / `waiting` separately (raw `jobs_scheduled` and `jobs_waiting`) instead of `effectiveWaiting()`.
- `src/components/queue-overview-chart.tsx` — added a third stacked `<Bar>`; Running green, Scheduled grey, Waiting recolored to yellow.

## Notes / follow-up

- The **stat cards** ("Waiting Jobs") still use `effectiveWaiting()`, so the card and the chart now define "waiting" differently for Docker/k8s queues. Left as-is since the request was about the chart — happy to align the cards in a follow-up if desired.

## Verification

- `tsc --noEmit` ✅ and `eslint` ✅ on both changed files.
- Rendered preview from live `b200-k8s` data confirming the yellow Waiting series now appears (was previously hidden for this k8s queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)