### PR TITLE
style: swap queue chart colors — Scheduled yellow, Waiting grey

### DIFF
--- a/src/components/queue-overview-chart.tsx
+++ b/src/components/queue-overview-chart.tsx
@@ -99,7 +99,7 @@ export function QueueOverviewChart({ data, formatXTick, tickInterval }: QueueOve
           dataKey="scheduled"
           name="Scheduled"
           stackId="jobs"
-          fill="#a1a1aa"
+          fill="#eab308"
           radius={[0, 0, 0, 0]}
         />
         <Bar
@@ -107,7 +107,7 @@ export function QueueOverviewChart({ data, formatXTick, tickInterval }: QueueOve
           dataKey="waiting"
           name="Waiting"
           stackId="jobs"
-          fill="#eab308"
+          fill="#a1a1aa"
           radius={[2, 2, 0, 0]}
         />
         <Line


### PR DESCRIPTION
## What

Swaps the two non-green bar colors in the Queue tab overview chart:

| Series | Before (#14) | After |
|---|---|---|
| Scheduled | grey `#a1a1aa` | 🟡 yellow `#eab308` |
| Waiting | yellow `#eab308` | ⬜ grey `#a1a1aa` |

Running (green `#10b981`) and the Connected Agents line (blue `#3b82f6`) are unchanged.

## Why

Follow-up to #14. Per request, Scheduled should be the yellow (attention) series and Waiting the neutral grey.

## Scope

Single-line-pair change in `src/components/queue-overview-chart.tsx`. No data, API, or DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)