### PR TITLE
refactor: hide raw waiting bar, relabel Scheduled as "Waiting" in queue chart

### DIFF
--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -91,20 +91,20 @@ export default function QueuePage() {
 
   const metricsQueuesForFilter = metricsData?.queues ?? [];
 
-  // Aggregate snapshots into chart data: sum running/scheduled/waiting/agents per time bucket
+  // Aggregate snapshots into chart data: sum running/scheduled/agents per time bucket.
+  // jobs_scheduled is surfaced as the "Waiting" series; raw jobs_waiting is not charted.
   const overviewChartData = useMemo(() => {
     const snapshots = metricsData?.snapshots ?? [];
     if (snapshots.length === 0) return [];
 
-    const bucketMap = new Map<number, { running: number; scheduled: number; waiting: number; agents: number }>();
+    const bucketMap = new Map<number, { running: number; scheduled: number; agents: number }>();
     for (const row of snapshots) {
       if (queue && row.queue !== queue) continue;
       const t = new Date(row.time_bucket).getTime();
-      if (!bucketMap.has(t)) bucketMap.set(t, { running: 0, scheduled: 0, waiting: 0, agents: 0 });
+      if (!bucketMap.has(t)) bucketMap.set(t, { running: 0, scheduled: 0, agents: 0 });
       const entry = bucketMap.get(t)!;
       entry.running += row.jobs_running;
       entry.scheduled += row.jobs_scheduled;
-      entry.waiting += row.jobs_waiting;
       entry.agents += row.agents_total;
     }
 

--- a/src/components/queue-overview-chart.tsx
+++ b/src/components/queue-overview-chart.tsx
@@ -13,7 +13,7 @@ import {
 } from "recharts";
 
 interface QueueOverviewChartProps {
-  data: Array<{ time: number; running: number; scheduled: number; waiting: number; agents: number }>;
+  data: Array<{ time: number; running: number; scheduled: number; agents: number }>;
   formatXTick: (t: number) => string;
   tickInterval: number;
 }
@@ -97,17 +97,9 @@ export function QueueOverviewChart({ data, formatXTick, tickInterval }: QueueOve
         <Bar
 
           dataKey="scheduled"
-          name="Scheduled"
-          stackId="jobs"
-          fill="#eab308"
-          radius={[0, 0, 0, 0]}
-        />
-        <Bar
-
-          dataKey="waiting"
           name="Waiting"
           stackId="jobs"
-          fill="#a1a1aa"
+          fill="#eab308"
           radius={[2, 2, 0, 0]}
         />
         <Line


### PR DESCRIPTION
## What

Two changes to the Queue tab overview chart:

1. **Remove the grey bar** — the raw `jobs_waiting` series is no longer plotted.
2. **Rename "Scheduled" → "Waiting"** — the `jobs_scheduled` series (yellow) now carries the "Waiting" label.

Result: the chart shows **Running** (green) + **Waiting** (yellow, sourced from `jobs_scheduled`) stacked bars, plus the **Connected Agents** line (blue).

## Why

Follow-up to #14/#15. `jobs_scheduled` is the meaningful waiting signal for our queues; the raw `jobs_waiting` count is noisy for Docker/k8s queues (it counts jobs queued against not-yet-booted agents), so it's dropped rather than shown.

## Changes

- `src/components/queue-overview-chart.tsx` — removed the `waiting` `<Bar>`; relabeled the `scheduled` bar to `name="Waiting"` and gave it the top corner radius. Dropped `waiting` from the data prop type.
- `src/app/queue/page.tsx` — stopped accumulating `jobs_waiting` into the chart data (now unused).

No API or DB changes.

## Verification

`tsc --noEmit` ✅ and `eslint` ✅ on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)