### PR TITLE
feat: show raw jobs_waiting (grey bar) only for mithril-h100-pool

### DIFF
--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -63,6 +63,10 @@ const METRICS_HOURS_OPTIONS = [
   { label: "7d", value: 168 },
 ];
 
+// Queues whose raw jobs_waiting count is meaningful and should be charted as
+// a separate grey bar (in addition to the yellow scheduled "Waiting" bar).
+const RAW_WAITING_QUEUES = new Set(["mithril-h100-pool"]);
+
 export default function QueuePage() {
   const [queue, setQueue] = useState("gpu_1_queue");
   const [metricsHours, setMetricsHours] = useState(24);
@@ -92,19 +96,21 @@ export default function QueuePage() {
   const metricsQueuesForFilter = metricsData?.queues ?? [];
 
   // Aggregate snapshots into chart data: sum running/scheduled/agents per time bucket.
-  // jobs_scheduled is surfaced as the "Waiting" series; raw jobs_waiting is not charted.
+  // jobs_scheduled is surfaced as the "Waiting" series. Raw jobs_waiting is
+  // also tracked but only charted (as a grey bar) for RAW_WAITING_QUEUES.
   const overviewChartData = useMemo(() => {
     const snapshots = metricsData?.snapshots ?? [];
     if (snapshots.length === 0) return [];
 
-    const bucketMap = new Map<number, { running: number; scheduled: number; agents: number }>();
+    const bucketMap = new Map<number, { running: number; scheduled: number; waiting: number; agents: number }>();
     for (const row of snapshots) {
       if (queue && row.queue !== queue) continue;
       const t = new Date(row.time_bucket).getTime();
-      if (!bucketMap.has(t)) bucketMap.set(t, { running: 0, scheduled: 0, agents: 0 });
+      if (!bucketMap.has(t)) bucketMap.set(t, { running: 0, scheduled: 0, waiting: 0, agents: 0 });
       const entry = bucketMap.get(t)!;
       entry.running += row.jobs_running;
       entry.scheduled += row.jobs_scheduled;
+      entry.waiting += row.jobs_waiting;
       entry.agents += row.agents_total;
     }
 
@@ -219,6 +225,7 @@ export default function QueuePage() {
           data={overviewChartData}
           formatXTick={formatMetricsXTick}
           tickInterval={chartTickInterval}
+          showWaiting={queue ? RAW_WAITING_QUEUES.has(queue) : false}
         />
       </div>
 

--- a/src/components/queue-overview-chart.tsx
+++ b/src/components/queue-overview-chart.tsx
@@ -13,9 +13,11 @@ import {
 } from "recharts";
 
 interface QueueOverviewChartProps {
-  data: Array<{ time: number; running: number; scheduled: number; agents: number }>;
+  data: Array<{ time: number; running: number; scheduled: number; waiting: number; agents: number }>;
   formatXTick: (t: number) => string;
   tickInterval: number;
+  /** When true, also plot raw jobs_waiting as a grey bar (e.g. mithril-h100-pool). */
+  showWaiting?: boolean;
 }
 
 function OverviewTooltip({
@@ -56,7 +58,7 @@ function OverviewTooltip({
   );
 }
 
-export function QueueOverviewChart({ data, formatXTick, tickInterval }: QueueOverviewChartProps) {
+export function QueueOverviewChart({ data, formatXTick, tickInterval, showWaiting = false }: QueueOverviewChartProps) {
   if (data.length === 0) {
     return (
       <div className="flex h-[300px] items-center justify-center text-sm text-zinc-400">
@@ -100,8 +102,17 @@ export function QueueOverviewChart({ data, formatXTick, tickInterval }: QueueOve
           name="Waiting"
           stackId="jobs"
           fill="#eab308"
-          radius={[2, 2, 0, 0]}
+          radius={showWaiting ? [0, 0, 0, 0] : [2, 2, 0, 0]}
         />
+        {showWaiting && (
+          <Bar
+            dataKey="waiting"
+            name="Waiting (raw)"
+            stackId="jobs"
+            fill="#a1a1aa"
+            radius={[2, 2, 0, 0]}
+          />
+        )}
         <Line
 
           type="monotone"


### PR DESCRIPTION
## What

Re-introduces the grey raw-`jobs_waiting` bar in the Queue tab overview chart, but **only for `mithril-h100-pool`**. For that queue the chart now shows:

- **Running** — green `#10b981` (`jobs_running`)
- **Waiting** — yellow `#eab308` (`jobs_scheduled`)
- **Waiting (raw)** — grey `#a1a1aa` (`jobs_waiting`)  ← new, mithril only
- **Connected Agents** — blue line

All other queues are unchanged (green Running + yellow Waiting only).

## Why

Follow-up to #16, which removed the grey `jobs_waiting` bar everywhere. For `mithril-h100-pool` the raw `jobs_waiting` count is meaningful and worth surfacing, so it's shown there as an extra grey bar stacked on top.

## How

- `src/app/queue/page.tsx`
  - New `RAW_WAITING_QUEUES = new Set(["mithril-h100-pool"])`.
  - `overviewChartData` accumulates `jobs_waiting` again.
  - Passes `showWaiting={RAW_WAITING_QUEUES.has(queue)}` to the chart.
- `src/components/queue-overview-chart.tsx`
  - New optional `showWaiting` prop; when true, renders the grey `waiting` `<Bar>` (label "Waiting (raw)") and moves the top corner radius to it.

To add more queues later, just extend `RAW_WAITING_QUEUES`.

## Notes

- The grey bar is labeled **"Waiting (raw)"** to distinguish it from the yellow **"Waiting"** (scheduled) bar — happy to rename if you'd prefer something else.
- Frontend-only; no API or DB changes. `tsc` ✅ / `eslint` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)