### PR TITLE
feat: keep non-reporting GPU nodes visible, badge them as Offline

### DIFF
--- a/src/app/api/gpu/route.ts
+++ b/src/app/api/gpu/route.ts
@@ -70,7 +70,7 @@ export async function GET(request: NextRequest) {
         hostname, gpu_index, gpu_name, gpu_util, mem_used_mb, mem_total_mb,
         temperature_c, power_draw_w, power_limit_w, reported_at
       FROM gpu_snapshots
-      WHERE reported_at > NOW() - INTERVAL '10 minutes'
+      WHERE reported_at > NOW() - INTERVAL '1 hour' * ${hours}
       ORDER BY hostname, gpu_index, reported_at DESC
     `;
 

--- a/src/app/gpu/page.tsx
+++ b/src/app/gpu/page.tsx
@@ -44,6 +44,12 @@ function formatMemory(mb: number): string {
   return `${Math.round(mb)} MB`;
 }
 
+function formatAgo(minutes: number): string {
+  if (minutes < 60) return `${minutes}m ago`;
+  if (minutes < 1440) return `${Math.round(minutes / 60)}h ago`;
+  return `${Math.round(minutes / 1440)}d ago`;
+}
+
 function gpuType(name: string | null): string {
   if (!name) return "Unknown";
   const match = name.match(/\b(A100|H100|H200|B200|B100|L40S?|A10G?|T4|V100|GB200|GB300)\b/i);
@@ -254,13 +260,21 @@ export default function GpuPage() {
               {hostRows.map((h) => {
                 const memPct = h.memTotalMb > 0 ? Math.round((h.memUsedMb / h.memTotalMb) * 100) : 0;
                 const ago = Math.round((Date.now() - new Date(h.lastSeen).getTime()) / 60_000);
+                const offline = ago > 10;
                 const stale = ago > 5;
                 return (
                   <tr
                     key={h.hostname}
                     className={`border-b border-zinc-100 last:border-0 dark:border-zinc-800/50 ${stale ? "opacity-50" : ""}`}
                   >
-                    <td className="px-5 py-2.5 font-medium">{h.hostname}</td>
+                    <td className="px-5 py-2.5 font-medium">
+                      {h.hostname}
+                      {offline && (
+                        <span className="ml-2 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/40 dark:text-red-400">
+                          Offline
+                        </span>
+                      )}
+                    </td>
                     <td className="px-5 py-2.5">{h.gpuType}</td>
                     <td className="px-5 py-2.5">
                       <span className={memPct > 90 ? "font-medium text-red-600 dark:text-red-400" : ""}>
@@ -303,8 +317,16 @@ export default function GpuPage() {
                         })}
                       </div>
                     </td>
-                    <td className={`whitespace-nowrap px-5 py-2.5 text-zinc-500 dark:text-zinc-400 ${stale ? "text-yellow-600 dark:text-yellow-400" : ""}`}>
-                      {stale ? `${ago}m ago` : "just now"}
+                    <td
+                      className={`whitespace-nowrap px-5 py-2.5 ${
+                        offline
+                          ? "text-red-600 dark:text-red-400"
+                          : stale
+                          ? "text-yellow-600 dark:text-yellow-400"
+                          : "text-zinc-500 dark:text-zinc-400"
+                      }`}
+                    >
+                      {stale ? formatAgo(ago) : "just now"}
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
## What changed

- **API** (`src/app/api/gpu/route.ts`): the `latest` query previously only returned snapshots from the past 10 minutes, so any node that stopped reporting silently disappeared from the GPU tab. It now returns each node's most recent snapshot within the selected time window (1h/6h/24h/7d), so dead nodes stay visible with their last-known stats.
- **GPU tab** (`src/app/gpu/page.tsx`):
  - Nodes silent for **>10 minutes** get a red **Offline** pill next to the hostname and a red Last Seen timestamp.
  - The existing >5-minute stale treatment (dimmed row, yellow Last Seen) is unchanged.
  - Last Seen now formats as `45m ago` / `3h ago` / `2d ago` instead of raw minutes, since offline nodes can be stale by days.
  - Fixed the Last Seen cell stacking two conflicting Tailwind text colors (`text-zinc-500` + `text-yellow-600`), which made the stale highlight unreliable.

## Why

A node that crashes or loses its reporter is exactly the one you want to see on the dashboard — previously it just vanished from the Host Summary after 10 minutes.

## Notes for reviewers

- The latest-node list is bounded by the selected time window, so in the 1h view a node offline for >1h still won't appear; switch to 24h/7d for longer-dead nodes. Easy to change to a fixed lookback if preferred.
- Typecheck clean; lint shows the same 7 pre-existing errors before and after (none in touched code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)