### PR TITLE
fix: show all GPU hosts even when reporting has lapsed

### DIFF
--- a/src/app/api/gpu/route.ts
+++ b/src/app/api/gpu/route.ts
@@ -3,6 +3,13 @@ import { getDb, initSchema } from "@/lib/db";
 
 let schemaInitialized = false;
 
+// The host roster (latest snapshot per host) is decoupled from the chart's
+// selected time window: a node that stopped reporting should still appear in
+// the Host Summary table (badged Offline) instead of silently vanishing once
+// its last report ages past the chart window. Anything seen within this
+// lookback is shown; longer-dead/decommissioned nodes eventually drop off.
+const LATEST_LOOKBACK_HOURS = 720; // 30 days
+
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const hours = Math.min(parseInt(searchParams.get("hours") ?? "24", 10) || 24, 720);
@@ -70,7 +77,7 @@ export async function GET(request: NextRequest) {
         hostname, gpu_index, gpu_name, gpu_util, mem_used_mb, mem_total_mb,
         temperature_c, power_draw_w, power_limit_w, reported_at
       FROM gpu_snapshots
-      WHERE reported_at > NOW() - INTERVAL '1 hour' * ${hours}
+      WHERE reported_at > NOW() - INTERVAL '1 hour' * ${LATEST_LOOKBACK_HOURS}
       ORDER BY hostname, gpu_index, reported_at DESC
     `;
 

--- a/src/app/gpu/page.tsx
+++ b/src/app/gpu/page.tsx
@@ -92,6 +92,10 @@ export default function GpuPage() {
     if (snapshots.length === 0) return { data: [] as Array<Record<string, number>>, hosts: [] as string[] };
 
     const relevantHosts = new Set(filteredHosts);
+    // Only chart hosts that actually have data points in the selected window —
+    // offline hosts still belong in the roster/table but would otherwise add
+    // empty legend lines here.
+    const hostsWithData = new Set<string>();
 
     const bucketMap = new Map<number, Map<string, { memPctSum: number; count: number }>>();
 
@@ -99,6 +103,7 @@ export default function GpuPage() {
       if (!relevantHosts.has(row.hostname)) continue;
       if (gpuTypeFilter && gpuType(row.gpu_name) !== gpuTypeFilter) continue;
 
+      hostsWithData.add(row.hostname);
       const t = new Date(row.time_bucket).getTime();
       if (!bucketMap.has(t)) bucketMap.set(t, new Map());
       const hostMap = bucketMap.get(t)!;
@@ -108,7 +113,7 @@ export default function GpuPage() {
       entry.count++;
     }
 
-    const hosts = [...relevantHosts].sort();
+    const hosts = [...hostsWithData].sort();
     const rows = [...bucketMap.entries()]
       .map(([time, hostMap]) => {
         const row: Record<string, number> = { time };


### PR DESCRIPTION
## Problem

Only 2 of 6 B200 nodes were showing on the GPU tab. Two separate issues:

1. **Node health (not fixed here):** 4 nodes (dgxb200-11/13/15/16) have a hung `nvidia-smi` from an NVLink fabric fault, so the reporter agent collects nothing and they stop pushing data. dgxb200-12/14 are healthy — those are the 2 visible.
2. **Dashboard (this PR):** even setting node health aside, the Host Summary table derived its host roster from the *same time window* as the chart. So once a non-reporting node's last snapshot aged past the selected window (24h default), it dropped out of the table entirely — it couldn't even be badged **Offline** because the API returned no row for it. The #18 "keep non-reporting nodes visible" change only worked *within* that window.

## Fix

Decouple the host roster from the chart's time window:

- `src/app/api/gpu/route.ts` — the `latest` query (drives the Host Summary table + host dropdown) now looks back a fixed **30 days** instead of the selected `hours`. Any node seen recently always appears with its true last-seen timestamp; the existing `>10min` rule badges it **Offline**. Genuinely decommissioned nodes still drop off after 30 days of silence.
- `src/app/gpu/page.tsx` — the chart only plots hosts that have data points in the selected window, so offline nodes appear in the table without adding empty legend lines.

Result: all 6 nodes show again — 12/14 live, 11/13/15/16 as Offline (they reported before they hung, well within the 30-day lookback).

## Verification

- `tsc --noEmit` clean
- `next build` clean

The pre-existing eslint `Date.now()` warning in `page.tsx` is from commit #18 and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)