### PR TITLE
fix: stop /api/gpu hanging on 30-day roster query

### DIFF
--- a/src/app/api/gpu/route.ts
+++ b/src/app/api/gpu/route.ts
@@ -72,13 +72,30 @@ export async function GET(request: NextRequest) {
       ORDER BY hostname
     `;
 
+    // Latest snapshot per (hostname, gpu_index) over the 30-day roster window.
+    // A plain DISTINCT ON here forces Postgres to read+dedup every row in the
+    // window (millions, at a 30s report cadence) before keeping one per GPU.
+    // Instead, enumerate the distinct GPU keys (index-only scan over
+    // idx_gpu_snapshots_host_gpu_reported), then fetch just the single newest
+    // row per key via a lateral lookup — bounding heap fetches to ~one per GPU.
     const latestResult = await db`
-      SELECT DISTINCT ON (hostname, gpu_index)
-        hostname, gpu_index, gpu_name, gpu_util, mem_used_mb, mem_total_mb,
-        temperature_c, power_draw_w, power_limit_w, reported_at
-      FROM gpu_snapshots
-      WHERE reported_at > NOW() - INTERVAL '1 hour' * ${LATEST_LOOKBACK_HOURS}
-      ORDER BY hostname, gpu_index, reported_at DESC
+      SELECT l.hostname, l.gpu_index, l.gpu_name, l.gpu_util, l.mem_used_mb,
+             l.mem_total_mb, l.temperature_c, l.power_draw_w, l.power_limit_w,
+             l.reported_at
+      FROM (
+        SELECT DISTINCT hostname, gpu_index
+        FROM gpu_snapshots
+        WHERE reported_at > NOW() - INTERVAL '1 hour' * ${LATEST_LOOKBACK_HOURS}
+      ) k
+      CROSS JOIN LATERAL (
+        SELECT hostname, gpu_index, gpu_name, gpu_util, mem_used_mb, mem_total_mb,
+               temperature_c, power_draw_w, power_limit_w, reported_at
+        FROM gpu_snapshots s
+        WHERE s.hostname = k.hostname AND s.gpu_index = k.gpu_index
+        ORDER BY s.reported_at DESC
+        LIMIT 1
+      ) l
+      ORDER BY l.hostname, l.gpu_index
     `;
 
     return NextResponse.json({

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -94,4 +94,13 @@ export async function initSchema() {
     CREATE INDEX IF NOT EXISTS idx_gpu_snapshots_host
     ON gpu_snapshots (hostname, reported_at DESC)
   `;
+  // Supports the "latest snapshot per (hostname, gpu_index)" roster query in
+  // /api/gpu over a 30-day lookback: an index-only scan to enumerate distinct
+  // GPU keys, plus a per-key newest-row lookup. Without gpu_index in the index,
+  // that query degrades to a full scan + sort over millions of rows and times
+  // out (the cause of the /gpu page hanging).
+  await db`
+    CREATE INDEX IF NOT EXISTS idx_gpu_snapshots_host_gpu_reported
+    ON gpu_snapshots (hostname, gpu_index, reported_at DESC)
+  `;
 }


### PR DESCRIPTION
## Problem

The `/gpu` page is stuck on "Loading GPU data…" because `/api/gpu` **never responds** — it times out on every request. Confirmed against production:

| Endpoint | Result |
|---|---|
| `/api/gpu?hours=24` | **HTTP 000 / timed out at 60s** |
| `/api/gpu?hours=1` | **timed out** (even the smallest window) |
| `/api/gpu?hours=24&hostname=<nonexistent>` | **timed out** |
| `/api/queue`, `/api/metrics` (same Postgres) | 200 OK in ~7s |

So the DB is healthy — this is specific to one query in the GPU route. The page shows "Loading…" rather than "Failed to load" precisely because the request never resolves.

## Root cause

Regression from #19 (`448e66c`). The "latest snapshot per (hostname, gpu_index)" roster query was changed to always scan a 30-day lookback (`LATEST_LOOKBACK_HOURS = 720`) regardless of the selected window, so offline nodes stay visible.

That query — `DISTINCT ON (hostname, gpu_index) ... ORDER BY hostname, gpu_index, reported_at DESC` — has **no supporting index**. The existing `idx_gpu_snapshots_host` is `(hostname, reported_at DESC)`, missing `gpu_index`. With agents reporting every **30 seconds**, 30 days is millions of rows, so it degrades to a full-table scan + external sort on *every* request. That's why even `hours=1` hangs — this query ignores the window.

## Fix

- **`src/lib/db.ts`** — add a composite index `idx_gpu_snapshots_host_gpu_reported (hostname, gpu_index, reported_at DESC)`.
- **`src/app/api/gpu/route.ts`** — rewrite the roster query as a lateral "latest row per group": enumerate distinct `(hostname, gpu_index)` pairs (index-only scan), then fetch only the single newest row per pair. Caps heap fetches at ~one per GPU instead of millions, even over the 30-day lookback. Same output shape/columns — the page is unchanged.

## ⚠️ Deploy ordering

`initSchema()` runs `CREATE INDEX IF NOT EXISTS` (non-concurrent), which takes a write lock and builds on the huge existing table — on a cold start it could exceed the function timeout, roll back, and never complete.

**Run this against the production DB *before* deploying** (non-blocking, no write lock):

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_gpu_snapshots_host_gpu_reported
ON gpu_snapshots (hostname, gpu_index, reported_at DESC);
```

After the index exists, `initSchema()`'s `IF NOT EXISTS` is a harmless no-op and the new lateral query returns near-instantly.

## Verification

- `tsc --noEmit` ✅
- `eslint` on changed files ✅
- Query/index logic validated by analysis; could not run against prod (no local `DATABASE_URL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)