### PR TITLE
Add Performance tab with Trends/Benchmarks sub-tabs

### DIFF
--- a/src/app/api/perf/filters/route.ts
+++ b/src/app/api/perf/filters/route.ts
@@ -26,34 +26,50 @@ export async function GET(request: Request) {
       conditions.push(`message:date::STRING <= '${end.slice(0, 10)}'`);
     }
 
-    const rows = await queryDatabricks<{
-      model: string;
-      device: string;
-      tp: string;
-      conc: string;
-      precision: string;
-      image: string;
-    }>(`
-      SELECT DISTINCT
-        message:model::STRING AS model,
-        message:device::STRING AS device,
-        message:tp::STRING AS tp,
-        message:conc::STRING AS conc,
-        message:precision::STRING AS precision,
-        message:image::STRING AS image
-      FROM vllm_data_warehouse.default.vllm_perf_data_ingest
-      WHERE ${conditions.join(" AND ")}
-      ORDER BY model, device
-    `);
+    const where = conditions.join(" AND ");
 
-    const models = [...new Set(rows.map((r) => r.model).filter(Boolean))].sort();
-    const devices = [...new Set(rows.map((r) => r.device).filter(Boolean))].sort();
-    const tps = [...new Set(rows.map((r) => r.tp).filter(Boolean))].sort((a, b) => +a - +b);
-    const concs = [...new Set(rows.map((r) => r.conc).filter(Boolean))].sort((a, b) => +a - +b);
-    const precisions = [...new Set(rows.map((r) => r.precision).filter(Boolean))].sort();
-    const images = [...new Set(rows.map((r) => r.image).filter(Boolean))].sort();
+    // Per-model datapoint counts, so the UI can sort models by how much data
+    // they have (and show the count). Other dims come from a DISTINCT scan.
+    const [modelRows, dimRows] = await Promise.all([
+      queryDatabricks<{ model: string; n: number }>(`
+        SELECT message:model::STRING AS model, COUNT(*) AS n
+        FROM vllm_data_warehouse.default.vllm_perf_data_ingest
+        WHERE ${where}
+        GROUP BY message:model::STRING
+      `),
+      queryDatabricks<{
+        device: string;
+        tp: string;
+        conc: string;
+        precision: string;
+        image: string;
+      }>(`
+        SELECT DISTINCT
+          message:device::STRING AS device,
+          message:tp::STRING AS tp,
+          message:conc::STRING AS conc,
+          message:precision::STRING AS precision,
+          message:image::STRING AS image
+        FROM vllm_data_warehouse.default.vllm_perf_data_ingest
+        WHERE ${where}
+      `),
+    ]);
 
-    const result = { models, devices, tps, concs, precisions, images };
+    const modelCounts: Record<string, number> = {};
+    for (const r of modelRows) {
+      if (r.model) modelCounts[r.model] = Number(r.n) || 0;
+    }
+    // Most data first; alphabetical as a tiebreak.
+    const models = Object.keys(modelCounts).sort(
+      (a, b) => modelCounts[b] - modelCounts[a] || a.localeCompare(b)
+    );
+    const devices = [...new Set(dimRows.map((r) => r.device).filter(Boolean))].sort();
+    const tps = [...new Set(dimRows.map((r) => r.tp).filter(Boolean))].sort((a, b) => +a - +b);
+    const concs = [...new Set(dimRows.map((r) => r.conc).filter(Boolean))].sort((a, b) => +a - +b);
+    const precisions = [...new Set(dimRows.map((r) => r.precision).filter(Boolean))].sort();
+    const images = [...new Set(dimRows.map((r) => r.image).filter(Boolean))].sort();
+
+    const result = { models, modelCounts, devices, tps, concs, precisions, images };
     setCache(cacheKey, result, TTL);
 
     return NextResponse.json(result);

--- a/src/app/api/perf/route.ts
+++ b/src/app/api/perf/route.ts
@@ -2,7 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
 
-const TTL = 60_000;
+// Perf data refreshes at most nightly, so a longer cache keeps repeat loads
+// instant without serving stale numbers.
+const TTL = 300_000;
 
 export async function GET(request: NextRequest) {
   try {

--- a/src/app/perf/benchmarks/page.tsx
+++ b/src/app/perf/benchmarks/page.tsx
@@ -1,0 +1,555 @@
+"use client";
+
+import { useState, useMemo, useEffect } from "react";
+import useSWR from "swr";
+import dynamic from "next/dynamic";
+import { SearchableSelect } from "@/components/searchable-select";
+
+const Plot = dynamic(() => import("@/components/plotly-chart"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-[420px] items-center justify-center">
+      <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600 dark:border-zinc-600 dark:border-t-zinc-300" />
+    </div>
+  ),
+});
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface PerfRow {
+  date: string;
+  model: string;
+  device: string;
+  tp: string;
+  conc: string;
+  isl: string;
+  osl: string;
+  precision: string;
+  image: string;
+  tput_per_gpu: string;
+  input_tput_per_gpu: string;
+  output_tput_per_gpu: string;
+  mean_ttft: string;
+  mean_tpot: string;
+  mean_itl: string;
+  mean_e2el: string;
+  p99_ttft: string;
+  p99_tpot: string;
+  p99_itl: string;
+  p99_e2el: string;
+  median_ttft: string;
+  median_tpot: string;
+  median_itl: string;
+  median_e2el: string;
+}
+
+interface FiltersResponse {
+  models: string[];
+  modelCounts: Record<string, number>;
+  devices: string[];
+  tps: string[];
+  concs: string[];
+  precisions: string[];
+}
+
+interface ChartRow {
+  device: string;
+  dateStr: string;
+  date: string;
+  conc: number;
+  tp: number;
+  image: string;
+  _idx: number;
+  [key: string]: number | string;
+}
+
+// ── Metric metadata ──────────────────────────────────────────────────────────
+
+interface MetricInfo {
+  name: string;
+  unit: string;
+  higherIsBetter: boolean;
+}
+
+const METRIC_INFO: Record<string, MetricInfo> = {
+  tput_per_gpu: { name: "Throughput / GPU", unit: "token/s/gpu", higherIsBetter: true },
+  input_tput_per_gpu: { name: "Input Throughput / GPU", unit: "token/s/gpu", higherIsBetter: true },
+  output_tput_per_gpu: { name: "Output Throughput / GPU", unit: "token/s/gpu", higherIsBetter: true },
+  mean_ttft: { name: "Mean TTFT", unit: "s", higherIsBetter: false },
+  mean_tpot: { name: "Mean TPOT", unit: "s", higherIsBetter: false },
+  mean_itl: { name: "Mean ITL", unit: "s", higherIsBetter: false },
+  mean_e2el: { name: "Mean E2E Latency", unit: "s", higherIsBetter: false },
+  p99_ttft: { name: "P99 TTFT", unit: "s", higherIsBetter: false },
+  p99_tpot: { name: "P99 TPOT", unit: "s", higherIsBetter: false },
+  p99_itl: { name: "P99 ITL", unit: "s", higherIsBetter: false },
+  p99_e2el: { name: "P99 E2E Latency", unit: "s", higherIsBetter: false },
+};
+
+function metricLabel(metric: string): string {
+  const info = METRIC_INFO[metric];
+  if (!info) return metric;
+  return info.unit ? `${info.name} (${info.unit})` : info.name;
+}
+
+// ── Chart configs ────────────────────────────────────────────────────────────
+
+interface ChartConfig {
+  x: string;
+  y: string;
+  title: string;
+}
+
+const CHART_CONFIGS: ChartConfig[] = [
+  { x: "p99_ttft", y: "input_tput_per_gpu", title: "Input Throughput vs P99 TTFT" },
+  { x: "p99_itl", y: "tput_per_gpu", title: "Throughput vs P99 ITL" },
+  { x: "p99_e2el", y: "tput_per_gpu", title: "Throughput vs P99 E2E Latency" },
+];
+
+const COLORS = [
+  "#818cf8", "#fb923c", "#34d399", "#f87171",
+  "#a78bfa", "#22d3ee", "#f472b6", "#fbbf24",
+];
+
+// ── Hooks ────────────────────────────────────────────────────────────────────
+
+function useDarkMode() {
+  const [dark, setDark] = useState(
+    () =>
+      typeof document !== "undefined" &&
+      document.documentElement.classList.contains("dark")
+  );
+  useEffect(() => {
+    const el = document.documentElement;
+    const obs = new MutationObserver(() =>
+      setDark(el.classList.contains("dark"))
+    );
+    obs.observe(el, { attributes: true, attributeFilter: ["class"] });
+    return () => obs.disconnect();
+  }, []);
+  return dark;
+}
+
+// ── Pareto frontier ──────────────────────────────────────────────────────────
+
+function computeOptimal(
+  rows: ChartRow[],
+  xMetric: string,
+  yMetric: string
+): Set<number> {
+  const xHb = METRIC_INFO[xMetric]?.higherIsBetter ?? false;
+  const yHb = METRIC_INFO[yMetric]?.higherIsBetter ?? false;
+  const optimalIndices = new Set<number>();
+
+  const groups = new Map<string, ChartRow[]>();
+  for (const row of rows) {
+    const key = `${row.device}|${row.dateStr}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(row);
+  }
+
+  for (const groupRows of groups.values()) {
+    const sorted = [...groupRows].sort((a, b) => {
+      const av = a[yMetric] as number;
+      const bv = b[yMetric] as number;
+      return yHb ? bv - av : av - bv;
+    });
+    let bestX: number | null = null;
+    for (const row of sorted) {
+      const xv = row[xMetric] as number;
+      if (isNaN(xv)) continue;
+      if (bestX === null) {
+        bestX = xv;
+        optimalIndices.add(row._idx);
+      } else if (xHb && xv >= bestX) {
+        bestX = xv;
+        optimalIndices.add(row._idx);
+      } else if (!xHb && xv <= bestX) {
+        bestX = xv;
+        optimalIndices.add(row._idx);
+      }
+    }
+  }
+  return optimalIndices;
+}
+
+// ── Chart component ──────────────────────────────────────────────────────────
+
+function PerfChart({
+  chartRows,
+  config,
+  colorMap,
+  hideNonOptimal,
+}: {
+  chartRows: ChartRow[];
+  config: ChartConfig;
+  colorMap: Record<string, string>;
+  hideNonOptimal: boolean;
+}) {
+  const dark = useDarkMode();
+  const { x: xMetric, y: yMetric, title } = config;
+
+  const { traces, hasData } = useMemo(() => {
+    const xLabel = metricLabel(xMetric);
+    const yLabel = metricLabel(yMetric);
+
+    const valid = chartRows.filter(
+      (r) => !isNaN(r[xMetric] as number) && !isNaN(r[yMetric] as number)
+    );
+    if (valid.length === 0) return { traces: [], hasData: false };
+
+    const optimalSet = computeOptimal(valid, xMetric, yMetric);
+    const showAll = !hideNonOptimal && valid.length !== optimalSet.size;
+    const displayRows = hideNonOptimal
+      ? valid.filter((r) => optimalSet.has(r._idx))
+      : valid;
+
+    const groups = new Map<string, ChartRow[]>();
+    for (const row of displayRows) {
+      const key = `${row.device}|${row.dateStr}`;
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)!.push(row);
+    }
+
+    const result: object[] = [];
+    const sortedKeys = [...groups.keys()].sort();
+
+    for (const key of sortedKeys) {
+      const groupRows = groups.get(key)!;
+      const [deviceName, dateStr] = key.split("|");
+      const color = colorMap[key];
+      const label = `${deviceName} / ${dateStr}`;
+
+      const cd = (rows: ChartRow[]) =>
+        rows.map((r) => [r.conc, r.date, r.tp, r.device, r.image]);
+
+      const hoverBase = (tag: string) =>
+        `<b>${label}${tag}</b><br>` +
+        `${xLabel}: <b>%{x:.2f}</b><br>${yLabel}: <b>%{y:.4f}</b><br>` +
+        `Concurrency: <b>%{customdata[0]:.0f}</b>  TP: <b>%{text}</b><br>` +
+        `<span style="color:${dark ? "#71717a" : "#a1a1aa"}">%{customdata[4]}</span>` +
+        `<extra></extra>`;
+
+      if (showAll) {
+        const nonOpt = groupRows.filter((r) => !optimalSet.has(r._idx));
+        if (nonOpt.length > 0) {
+          result.push({
+            x: nonOpt.map((r) => r[xMetric]),
+            y: nonOpt.map((r) => r[yMetric]),
+            mode: "markers",
+            name: label,
+            legendgroup: label,
+            showlegend: false,
+            marker: { color, size: 6, opacity: 0.2, line: { width: 0 } },
+            customdata: cd(nonOpt),
+            text: nonOpt.map((r) => String(r.tp)),
+            hovertemplate: hoverBase(""),
+          });
+        }
+        const opt = groupRows
+          .filter((r) => optimalSet.has(r._idx))
+          .sort((a, b) => (a[xMetric] as number) - (b[xMetric] as number));
+        result.push({
+          x: opt.map((r) => r[xMetric]),
+          y: opt.map((r) => r[yMetric]),
+          mode: "lines+markers",
+          name: label,
+          legendgroup: label,
+          showlegend: true,
+          line: { color, width: 2.5, shape: "spline" },
+          marker: { color, size: 8, line: { color: dark ? "#18181b" : "#ffffff", width: 1.5 } },
+          customdata: cd(opt),
+          text: opt.map((r) => String(r.tp)),
+          hovertemplate: hoverBase("  \u2726"),
+        });
+      } else {
+        const sorted = [...groupRows].sort(
+          (a, b) => (a[xMetric] as number) - (b[xMetric] as number)
+        );
+        result.push({
+          x: sorted.map((r) => r[xMetric]),
+          y: sorted.map((r) => r[yMetric]),
+          mode: "lines+markers",
+          name: label,
+          line: { color, width: 2, shape: "spline" },
+          marker: { color, size: 8, line: { color: dark ? "#18181b" : "#ffffff", width: 1.5 } },
+          customdata: cd(sorted),
+          text: sorted.map((r) => String(r.tp)),
+          hovertemplate: hoverBase(""),
+        });
+      }
+    }
+    return { traces: result, hasData: true };
+  }, [chartRows, xMetric, yMetric, colorMap, hideNonOptimal, dark]);
+
+  if (!hasData) return null;
+
+  const xLabel = metricLabel(xMetric);
+  const yLabel = metricLabel(yMetric);
+  const axisColor = dark ? "#52525b" : "#d4d4d8";
+  const gridColor = dark ? "rgba(63,63,70,0.4)" : "rgba(228,228,231,0.6)";
+  const textColor = dark ? "#a1a1aa" : "#71717a";
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-zinc-200/80 bg-white shadow-[0_1px_3px_rgba(0,0,0,0.04)] dark:border-zinc-800/80 dark:bg-zinc-950 dark:shadow-[0_1px_3px_rgba(0,0,0,0.3)]">
+      <div className="px-5 pt-4 pb-0">
+        <h3 className="text-[13px] font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
+          {title}
+        </h3>
+      </div>
+      <div className="-mx-px">
+        <Plot
+          data={traces}
+          layout={{
+            paper_bgcolor: "transparent",
+            plot_bgcolor: "transparent",
+            font: {
+              family: "system-ui, -apple-system, sans-serif",
+              color: textColor,
+              size: 11,
+            },
+            xaxis: {
+              title: { text: xLabel, font: { size: 11 }, standoff: 10 },
+              tickfont: { size: 10 },
+              gridcolor: gridColor,
+              linecolor: axisColor,
+              showline: true,
+              zeroline: false,
+              rangemode: "tozero" as const,
+              showgrid: true,
+              gridwidth: 1,
+              ticks: "outside" as const,
+              tickcolor: axisColor,
+              ticklen: 4,
+            },
+            yaxis: {
+              title: { text: yLabel, font: { size: 11 }, standoff: 8 },
+              tickfont: { size: 10 },
+              gridcolor: gridColor,
+              linecolor: axisColor,
+              showline: true,
+              zeroline: false,
+              rangemode: "tozero" as const,
+              showgrid: true,
+              gridwidth: 1,
+              ticks: "outside" as const,
+              tickcolor: axisColor,
+              ticklen: 4,
+            },
+            legend: {
+              font: { size: 10 },
+              bgcolor: "transparent",
+              borderwidth: 0,
+              orientation: "h" as const,
+              y: -0.22,
+              x: 0.5,
+              xanchor: "center" as const,
+              yanchor: "top" as const,
+              tracegroupgap: 4,
+              itemwidth: 30,
+            },
+            height: 420,
+            margin: { l: 56, r: 16, t: 12, b: 80 },
+            hovermode: "closest" as const,
+            hoverlabel: {
+              bgcolor: dark ? "#27272a" : "#ffffff",
+              bordercolor: dark ? "#3f3f46" : "#e4e4e7",
+              font: {
+                size: 11,
+                family: "system-ui, -apple-system, sans-serif",
+                color: dark ? "#e4e4e7" : "#27272a",
+              },
+              align: "left" as const,
+            },
+            dragmode: "zoom" as const,
+          }}
+          config={{
+            responsive: true,
+            displaylogo: false,
+            modeBarButtonsToRemove: [
+              "lasso2d", "select2d", "autoScale2d", "toImage",
+            ],
+          }}
+          useResizeHandler
+          style={{ width: "100%" }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export default function PerfPage() {
+  const [model, setModel] = useState("");
+  const [device, setDevice] = useState("");
+  const [tp, setTp] = useState("");
+  const [conc, setConc] = useState("");
+  const [hideNonOptimal, setHideNonOptimal] = useState(false);
+
+  const { data: filters } = useSWR<FiltersResponse>("/api/perf/filters", fetcher);
+
+  const params = new URLSearchParams();
+  if (model) params.set("model", model);
+  if (device) params.set("device", device);
+  if (tp) params.set("tp", tp);
+  if (conc) params.set("conc", conc);
+
+  const { data, isLoading } = useSWR<{ rows: PerfRow[] }>(
+    model ? `/api/perf?${params.toString()}` : null,
+    fetcher,
+    { refreshInterval: 10 * 60 * 1000 }
+  );
+
+  const rawRows = useMemo(() => data?.rows ?? [], [data]);
+
+  const chartRows: ChartRow[] = useMemo(() => {
+    return rawRows
+      .map((r, i) => ({
+        device: r.device,
+        dateStr: r.date,
+        date: r.date,
+        conc: parseFloat(r.conc),
+        tp: parseInt(r.tp, 10),
+        image: r.image,
+        _idx: i,
+        tput_per_gpu: parseFloat(r.tput_per_gpu),
+        input_tput_per_gpu: parseFloat(r.input_tput_per_gpu),
+        output_tput_per_gpu: parseFloat(r.output_tput_per_gpu),
+        mean_ttft: parseFloat(r.mean_ttft),
+        mean_tpot: parseFloat(r.mean_tpot),
+        mean_itl: parseFloat(r.mean_itl),
+        mean_e2el: parseFloat(r.mean_e2el),
+        p99_ttft: parseFloat(r.p99_ttft),
+        p99_tpot: parseFloat(r.p99_tpot),
+        p99_itl: parseFloat(r.p99_itl),
+        p99_e2el: parseFloat(r.p99_e2el),
+      }))
+      .filter((r) => !isNaN(r.tput_per_gpu));
+  }, [rawRows]);
+
+  const colorMap = useMemo(() => {
+    const keys = [
+      ...new Set(chartRows.map((r) => `${r.device}|${r.dateStr}`)),
+    ].sort();
+    const map: Record<string, string> = {};
+    keys.forEach((key, i) => {
+      map[key] = COLORS[i % COLORS.length];
+    });
+    return map;
+  }, [chartRows]);
+
+
+  return (
+    <div className="space-y-5">
+      <p className="text-sm text-zinc-500 dark:text-zinc-400">
+        Throughput-latency tradeoff curves across hardware configurations.
+        Points on the Pareto frontier represent optimal throughput/latency tradeoffs.
+      </p>
+
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-end gap-x-4 gap-y-3 rounded-xl border border-zinc-200/80 bg-white px-5 py-4 shadow-[0_1px_3px_rgba(0,0,0,0.04)] dark:border-zinc-800/80 dark:bg-zinc-950 dark:shadow-[0_1px_3px_rgba(0,0,0,0.3)]">
+        <SearchableSelect
+          label="Model"
+          value={model}
+          onChange={(v) => {
+            setModel(v);
+            setDevice("");
+            setTp("");
+          }}
+          options={filters?.models ?? []}
+          counts={filters?.modelCounts}
+          allLabel="Select Model"
+        />
+        <SearchableSelect
+          label="Device"
+          value={device}
+          onChange={setDevice}
+          options={filters?.devices ?? []}
+          allLabel="All Devices"
+        />
+        <SearchableSelect
+          label="TP"
+          value={tp}
+          onChange={setTp}
+          options={filters?.tps ?? []}
+          allLabel="All TP"
+        />
+        <SearchableSelect
+          label="Concurrency"
+          value={conc}
+          onChange={setConc}
+          options={filters?.concs ?? []}
+          allLabel="All Concurrency"
+        />
+        {model && chartRows.length > 0 && (
+          <div className="flex items-center gap-2.5 pb-0.5">
+            <button
+              type="button"
+              role="switch"
+              aria-checked={hideNonOptimal}
+              onClick={() => setHideNonOptimal(!hideNonOptimal)}
+              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200 ${
+                hideNonOptimal
+                  ? "bg-indigo-500"
+                  : "bg-zinc-200 dark:bg-zinc-700"
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform duration-200 ${
+                  hideNonOptimal ? "translate-x-[18px]" : "translate-x-[3px]"
+                }`}
+              />
+            </button>
+            <span className="text-xs font-medium text-zinc-600 dark:text-zinc-400">
+              Optimal only
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Empty states */}
+      {!model && (
+        <div className="flex h-64 flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700">
+          <svg className="h-8 w-8 text-zinc-300 dark:text-zinc-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+          </svg>
+          <span className="text-sm text-zinc-400 dark:text-zinc-500">
+            Select a model to view performance benchmarks
+          </span>
+        </div>
+      )}
+      {model && isLoading && (
+        <div className="flex h-64 items-center justify-center gap-3">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600 dark:border-zinc-600 dark:border-t-zinc-300" />
+          <span className="text-sm text-zinc-400">Loading benchmarks...</span>
+        </div>
+      )}
+      {model && !isLoading && rawRows.length === 0 && (
+        <div className="flex h-64 items-center justify-center rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700">
+          <span className="text-sm text-zinc-400 dark:text-zinc-500">
+            No data found for this configuration.
+          </span>
+        </div>
+      )}
+
+      {/* Charts grid */}
+      {model && !isLoading && chartRows.length > 0 && (
+        <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
+          {CHART_CONFIGS.map((cfg) => (
+            <PerfChart
+              key={`${cfg.x}-${cfg.y}`}
+              chartRows={chartRows}
+              config={cfg}
+              colorMap={colorMap}
+              hideNonOptimal={hideNonOptimal}
+            />
+          ))}
+        </div>
+      )}
+
+    </div>
+  );
+}
+

--- a/src/app/perf/layout.tsx
+++ b/src/app/perf/layout.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const tabs = [
+  { href: "/perf", label: "Trends" },
+  { href: "/perf/benchmarks", label: "Benchmarks" },
+];
+
+export default function PerfLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  return (
+    <div className="space-y-5">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Performance</h1>
+        <div className="mt-3 flex gap-1 border-b border-zinc-200 dark:border-zinc-800">
+          {tabs.map((t) => {
+            const active = pathname === t.href;
+            return (
+              <Link
+                key={t.href}
+                href={t.href}
+                className={`-mb-px border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
+                  active
+                    ? "border-indigo-500 text-zinc-900 dark:text-zinc-100"
+                    : "border-transparent text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                }`}
+              >
+                {t.label}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/app/perf/page.tsx
+++ b/src/app/perf/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect } from "react";
 import useSWR from "swr";
 import dynamic from "next/dynamic";
 import { SearchableSelect } from "@/components/searchable-select";
@@ -8,7 +8,7 @@ import { SearchableSelect } from "@/components/searchable-select";
 const Plot = dynamic(() => import("@/components/plotly-chart"), {
   ssr: false,
   loading: () => (
-    <div className="flex h-[420px] items-center justify-center">
+    <div className="flex h-[320px] items-center justify-center">
       <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600 dark:border-zinc-600 dark:border-t-zinc-300" />
     </div>
   ),
@@ -47,21 +47,17 @@ interface PerfRow {
 
 interface FiltersResponse {
   models: string[];
-  devices: string[];
-  tps: string[];
-  concs: string[];
-  precisions: string[];
+  modelCounts: Record<string, number>;
 }
 
-interface ChartRow {
-  device: string;
-  dateStr: string;
+interface TrendPoint {
   date: string;
-  conc: number;
-  tp: number;
   image: string;
-  _idx: number;
-  [key: string]: number | string;
+  device: string;
+  tp: number;
+  conc: number;
+  series: string;
+  [metric: string]: number | string;
 }
 
 // ── Metric metadata ──────────────────────────────────────────────────────────
@@ -74,17 +70,24 @@ interface MetricInfo {
 
 const METRIC_INFO: Record<string, MetricInfo> = {
   tput_per_gpu: { name: "Throughput / GPU", unit: "token/s/gpu", higherIsBetter: true },
-  input_tput_per_gpu: { name: "Input Throughput / GPU", unit: "token/s/gpu", higherIsBetter: true },
   output_tput_per_gpu: { name: "Output Throughput / GPU", unit: "token/s/gpu", higherIsBetter: true },
-  mean_ttft: { name: "Mean TTFT", unit: "s", higherIsBetter: false },
-  mean_tpot: { name: "Mean TPOT", unit: "s", higherIsBetter: false },
-  mean_itl: { name: "Mean ITL", unit: "s", higherIsBetter: false },
-  mean_e2el: { name: "Mean E2E Latency", unit: "s", higherIsBetter: false },
-  p99_ttft: { name: "P99 TTFT", unit: "s", higherIsBetter: false },
-  p99_tpot: { name: "P99 TPOT", unit: "s", higherIsBetter: false },
-  p99_itl: { name: "P99 ITL", unit: "s", higherIsBetter: false },
-  p99_e2el: { name: "P99 E2E Latency", unit: "s", higherIsBetter: false },
+  ttft: { name: "TTFT", unit: "s", higherIsBetter: false },
+  tpot: { name: "TPOT", unit: "s", higherIsBetter: false },
+  itl: { name: "ITL", unit: "s", higherIsBetter: false },
+  e2el: { name: "E2E Latency", unit: "s", higherIsBetter: false },
 };
+
+// Latency families switch with the selected statistic; throughput is always raw.
+const THROUGHPUT_METRICS = ["tput_per_gpu", "output_tput_per_gpu"] as const;
+const LATENCY_METRICS = ["ttft", "tpot", "itl", "e2el"] as const;
+const STATS = ["p99", "mean", "median"] as const;
+type Stat = (typeof STATS)[number];
+
+function metricColumn(metric: string, stat: Stat): string {
+  return THROUGHPUT_METRICS.includes(metric as (typeof THROUGHPUT_METRICS)[number])
+    ? metric
+    : `${stat}_${metric}`;
+}
 
 function metricLabel(metric: string): string {
   const info = METRIC_INFO[metric];
@@ -92,24 +95,10 @@ function metricLabel(metric: string): string {
   return info.unit ? `${info.name} (${info.unit})` : info.name;
 }
 
-// ── Chart configs ────────────────────────────────────────────────────────────
-
-interface ChartConfig {
-  x: string;
-  y: string;
-  title: string;
-  desc: string;
-}
-
-const CHART_CONFIGS: ChartConfig[] = [
-  { x: "p99_ttft", y: "input_tput_per_gpu", title: "Input Throughput vs P99 TTFT", desc: "" },
-  { x: "p99_itl", y: "tput_per_gpu", title: "Throughput vs P99 ITL", desc: "" },
-  { x: "p99_e2el", y: "tput_per_gpu", title: "Throughput vs P99 E2E Latency", desc: "" },
-];
-
 const COLORS = [
   "#818cf8", "#fb923c", "#34d399", "#f87171",
   "#a78bfa", "#22d3ee", "#f472b6", "#fbbf24",
+  "#60a5fa", "#4ade80", "#e879f9", "#facc15",
 ];
 
 // ── Hooks ────────────────────────────────────────────────────────────────────
@@ -131,181 +120,77 @@ function useDarkMode() {
   return dark;
 }
 
-// ── Pareto frontier ──────────────────────────────────────────────────────────
+// ── Trend chart ──────────────────────────────────────────────────────────────
 
-function computeOptimal(
-  rows: ChartRow[],
-  xMetric: string,
-  yMetric: string
-): Set<number> {
-  const xHb = METRIC_INFO[xMetric]?.higherIsBetter ?? false;
-  const yHb = METRIC_INFO[yMetric]?.higherIsBetter ?? false;
-  const optimalIndices = new Set<number>();
-
-  const groups = new Map<string, ChartRow[]>();
-  for (const row of rows) {
-    const key = `${row.device}|${row.dateStr}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key)!.push(row);
-  }
-
-  for (const groupRows of groups.values()) {
-    const sorted = [...groupRows].sort((a, b) => {
-      const av = a[yMetric] as number;
-      const bv = b[yMetric] as number;
-      return yHb ? bv - av : av - bv;
-    });
-    let bestX: number | null = null;
-    for (const row of sorted) {
-      const xv = row[xMetric] as number;
-      if (isNaN(xv)) continue;
-      if (bestX === null) {
-        bestX = xv;
-        optimalIndices.add(row._idx);
-      } else if (xHb && xv >= bestX) {
-        bestX = xv;
-        optimalIndices.add(row._idx);
-      } else if (!xHb && xv <= bestX) {
-        bestX = xv;
-        optimalIndices.add(row._idx);
-      }
-    }
-  }
-  return optimalIndices;
-}
-
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-function extractVersion(image: string): string {
-  if (!image) return "unknown";
-  const tag = image.split(":").pop() ?? image;
-  if (tag.startsWith("nightly-")) return tag.slice(0, 16);
-  return tag;
-}
-
-// ── Chart component ──────────────────────────────────────────────────────────
-
-function PerfChart({
-  chartRows,
-  config,
+function TrendChart({
+  points,
+  metric,
+  stat,
   colorMap,
-  hideNonOptimal,
 }: {
-  chartRows: ChartRow[];
-  config: ChartConfig;
+  points: TrendPoint[];
+  metric: string;
+  stat: Stat;
   colorMap: Record<string, string>;
-  hideNonOptimal: boolean;
 }) {
   const dark = useDarkMode();
-  const { x: xMetric, y: yMetric, title, desc } = config;
+  const col = metricColumn(metric, stat);
+  const info = METRIC_INFO[metric];
 
   const { traces, hasData } = useMemo(() => {
-    const xLabel = metricLabel(xMetric);
-    const yLabel = metricLabel(yMetric);
-
-    const valid = chartRows.filter(
-      (r) => !isNaN(r[xMetric] as number) && !isNaN(r[yMetric] as number)
-    );
+    const valid = points.filter((p) => !isNaN(p[col] as number));
     if (valid.length === 0) return { traces: [], hasData: false };
 
-    const optimalSet = computeOptimal(valid, xMetric, yMetric);
-    const showAll = !hideNonOptimal && valid.length !== optimalSet.size;
-    const displayRows = hideNonOptimal
-      ? valid.filter((r) => optimalSet.has(r._idx))
-      : valid;
-
-    const groups = new Map<string, ChartRow[]>();
-    for (const row of displayRows) {
-      const key = `${row.device}|${row.dateStr}`;
-      if (!groups.has(key)) groups.set(key, []);
-      groups.get(key)!.push(row);
+    const groups = new Map<string, TrendPoint[]>();
+    for (const p of valid) {
+      if (!groups.has(p.series)) groups.set(p.series, []);
+      groups.get(p.series)!.push(p);
     }
 
     const result: object[] = [];
-    const sortedKeys = [...groups.keys()].sort();
-
-    for (const key of sortedKeys) {
-      const groupRows = groups.get(key)!;
-      const [deviceName, dateStr] = key.split("|");
-      const color = colorMap[key];
-      const label = `${deviceName} / ${dateStr}`;
-
-      const cd = (rows: ChartRow[]) =>
-        rows.map((r) => [r.conc, r.date, r.tp, r.device, r.image]);
-
-      const hoverBase = (tag: string) =>
-        `<b>${label}${tag}</b><br>` +
-        `${xLabel}: <b>%{x:.2f}</b><br>${yLabel}: <b>%{y:.4f}</b><br>` +
-        `Concurrency: <b>%{customdata[0]:.0f}</b>  TP: <b>%{text}</b><br>` +
-        `<span style="color:${dark ? "#71717a" : "#a1a1aa"}">%{customdata[4]}</span>` +
-        `<extra></extra>`;
-
-      if (showAll) {
-        const nonOpt = groupRows.filter((r) => !optimalSet.has(r._idx));
-        if (nonOpt.length > 0) {
-          result.push({
-            x: nonOpt.map((r) => r[xMetric]),
-            y: nonOpt.map((r) => r[yMetric]),
-            mode: "markers",
-            name: label,
-            legendgroup: label,
-            showlegend: false,
-            marker: { color, size: 6, opacity: 0.2, line: { width: 0 } },
-            customdata: cd(nonOpt),
-            text: nonOpt.map((r) => String(r.tp)),
-            hovertemplate: hoverBase(""),
-          });
-        }
-        const opt = groupRows
-          .filter((r) => optimalSet.has(r._idx))
-          .sort((a, b) => (a[xMetric] as number) - (b[xMetric] as number));
-        result.push({
-          x: opt.map((r) => r[xMetric]),
-          y: opt.map((r) => r[yMetric]),
-          mode: "lines+markers",
-          name: label,
-          legendgroup: label,
-          showlegend: true,
-          line: { color, width: 2.5, shape: "spline" },
-          marker: { color, size: 8, line: { color: dark ? "#18181b" : "#ffffff", width: 1.5 } },
-          customdata: cd(opt),
-          text: opt.map((r) => String(r.tp)),
-          hovertemplate: hoverBase("  \u2726"),
-        });
-      } else {
-        const sorted = [...groupRows].sort(
-          (a, b) => (a[xMetric] as number) - (b[xMetric] as number)
-        );
-        result.push({
-          x: sorted.map((r) => r[xMetric]),
-          y: sorted.map((r) => r[yMetric]),
-          mode: "lines+markers",
-          name: label,
-          line: { color, width: 2, shape: "spline" },
-          marker: { color, size: 8, line: { color: dark ? "#18181b" : "#ffffff", width: 1.5 } },
-          customdata: cd(sorted),
-          text: sorted.map((r) => String(r.tp)),
-          hovertemplate: hoverBase(""),
-        });
-      }
+    for (const series of [...groups.keys()].sort()) {
+      const rows = [...groups.get(series)!].sort((a, b) =>
+        a.date < b.date ? -1 : a.date > b.date ? 1 : a.image < b.image ? -1 : 1
+      );
+      const color = colorMap[series];
+      result.push({
+        x: rows.map((r) => r.date),
+        y: rows.map((r) => r[col]),
+        mode: "lines+markers",
+        name: series,
+        line: { color, width: 2, shape: "linear" },
+        marker: {
+          color,
+          size: 7,
+          line: { color: dark ? "#18181b" : "#ffffff", width: 1.5 },
+        },
+        customdata: rows.map((r) => [r.image, r.tp, r.conc, r.device]),
+        hovertemplate:
+          `<b>${series}</b><br>` +
+          `%{x}<br>${metricLabel(metric)}: <b>%{y:.4f}</b><br>` +
+          `Concurrency: <b>%{customdata[2]}</b>  TP: <b>%{customdata[1]}</b><br>` +
+          `<span style="color:${dark ? "#71717a" : "#a1a1aa"}">%{customdata[0]}</span>` +
+          `<extra></extra>`,
+      });
     }
     return { traces: result, hasData: true };
-  }, [chartRows, xMetric, yMetric, colorMap, hideNonOptimal, dark]);
+  }, [points, col, metric, colorMap, dark]);
 
   if (!hasData) return null;
 
-  const xLabel = metricLabel(xMetric);
-  const yLabel = metricLabel(yMetric);
   const axisColor = dark ? "#52525b" : "#d4d4d8";
   const gridColor = dark ? "rgba(63,63,70,0.4)" : "rgba(228,228,231,0.6)";
   const textColor = dark ? "#a1a1aa" : "#71717a";
 
   return (
     <div className="overflow-hidden rounded-xl border border-zinc-200/80 bg-white shadow-[0_1px_3px_rgba(0,0,0,0.04)] dark:border-zinc-800/80 dark:bg-zinc-950 dark:shadow-[0_1px_3px_rgba(0,0,0,0.3)]">
-      <div className="px-5 pt-4 pb-0">
+      <div className="flex items-baseline justify-between px-5 pt-4 pb-0">
         <h3 className="text-[13px] font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
-          {title}
+          {metricLabel(metric)}
         </h3>
+        <span className="text-[10px] font-medium uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
+          {info?.higherIsBetter ? "higher is better" : "lower is better"}
+        </span>
       </div>
       <div className="-mx-px">
         <Plot
@@ -319,13 +204,12 @@ function PerfChart({
               size: 11,
             },
             xaxis: {
-              title: { text: xLabel, font: { size: 11 }, standoff: 10 },
+              type: "date" as const,
               tickfont: { size: 10 },
               gridcolor: gridColor,
               linecolor: axisColor,
               showline: true,
               zeroline: false,
-              rangemode: "tozero" as const,
               showgrid: true,
               gridwidth: 1,
               ticks: "outside" as const,
@@ -333,7 +217,7 @@ function PerfChart({
               ticklen: 4,
             },
             yaxis: {
-              title: { text: yLabel, font: { size: 11 }, standoff: 8 },
+              title: { text: metricLabel(metric), font: { size: 11 }, standoff: 8 },
               tickfont: { size: 10 },
               gridcolor: gridColor,
               linecolor: axisColor,
@@ -351,15 +235,15 @@ function PerfChart({
               bgcolor: "transparent",
               borderwidth: 0,
               orientation: "h" as const,
-              y: -0.22,
+              y: -0.2,
               x: 0.5,
               xanchor: "center" as const,
               yanchor: "top" as const,
               tracegroupgap: 4,
               itemwidth: 30,
             },
-            height: 420,
-            margin: { l: 56, r: 16, t: 12, b: 80 },
+            height: 340,
+            margin: { l: 56, r: 16, t: 12, b: 70 },
             hovermode: "closest" as const,
             hoverlabel: {
               bgcolor: dark ? "#27272a" : "#ffffff",
@@ -390,79 +274,102 @@ function PerfChart({
 
 // ── Page ─────────────────────────────────────────────────────────────────────
 
-export default function PerfPage() {
+export default function PerfTrendsPage() {
   const [model, setModel] = useState("");
   const [device, setDevice] = useState("");
   const [tp, setTp] = useState("");
   const [conc, setConc] = useState("");
-  const [hideNonOptimal, setHideNonOptimal] = useState(false);
+  const [stat, setStat] = useState<Stat>("p99");
 
   const { data: filters } = useSWR<FiltersResponse>("/api/perf/filters", fetcher);
 
-  const params = new URLSearchParams();
-  if (model) params.set("model", model);
-  if (device) params.set("device", device);
-  if (tp) params.set("tp", tp);
-  if (conc) params.set("conc", conc);
-
+  // Fetch every row for the model once, then filter device/TP/concurrency
+  // client-side so those switches are instant (no refetch).
   const { data, isLoading } = useSWR<{ rows: PerfRow[] }>(
-    model ? `/api/perf?${params.toString()}` : null,
+    model ? `/api/perf?model=${encodeURIComponent(model)}` : null,
     fetcher,
-    { refreshInterval: 10 * 60 * 1000 }
+    { refreshInterval: 10 * 60 * 1000, keepPreviousData: true }
   );
 
-  const rawRows = data?.rows ?? [];
-
-  const chartRows: ChartRow[] = useMemo(() => {
+  const allPoints: TrendPoint[] = useMemo(() => {
+    const rawRows = data?.rows ?? [];
     return rawRows
-      .map((r, i) => ({
-        device: r.device,
-        dateStr: r.date,
-        date: r.date,
-        conc: parseFloat(r.conc),
-        tp: parseInt(r.tp, 10),
-        image: r.image,
-        _idx: i,
-        tput_per_gpu: parseFloat(r.tput_per_gpu),
-        input_tput_per_gpu: parseFloat(r.input_tput_per_gpu),
-        output_tput_per_gpu: parseFloat(r.output_tput_per_gpu),
-        mean_ttft: parseFloat(r.mean_ttft),
-        mean_tpot: parseFloat(r.mean_tpot),
-        mean_itl: parseFloat(r.mean_itl),
-        mean_e2el: parseFloat(r.mean_e2el),
-        p99_ttft: parseFloat(r.p99_ttft),
-        p99_tpot: parseFloat(r.p99_tpot),
-        p99_itl: parseFloat(r.p99_itl),
-        p99_e2el: parseFloat(r.p99_e2el),
-      }))
-      .filter((r) => !isNaN(r.tput_per_gpu));
-  }, [rawRows]);
+      .map(
+        (r) =>
+          ({
+            date: r.date,
+            image: r.image,
+            device: r.device,
+            tp: parseInt(r.tp, 10),
+            conc: parseInt(r.conc, 10),
+            series: `${r.device} · TP${r.tp} · c${r.conc}`,
+            tput_per_gpu: parseFloat(r.tput_per_gpu),
+            output_tput_per_gpu: parseFloat(r.output_tput_per_gpu),
+            mean_ttft: parseFloat(r.mean_ttft),
+            mean_tpot: parseFloat(r.mean_tpot),
+            mean_itl: parseFloat(r.mean_itl),
+            mean_e2el: parseFloat(r.mean_e2el),
+            p99_ttft: parseFloat(r.p99_ttft),
+            p99_tpot: parseFloat(r.p99_tpot),
+            p99_itl: parseFloat(r.p99_itl),
+            p99_e2el: parseFloat(r.p99_e2el),
+            median_ttft: parseFloat(r.median_ttft),
+            median_tpot: parseFloat(r.median_tpot),
+            median_itl: parseFloat(r.median_itl),
+            median_e2el: parseFloat(r.median_e2el),
+          }) as TrendPoint
+      )
+      .filter((p) => !isNaN(p.tput_per_gpu as number));
+  }, [data]);
+
+  // Dropdown options reflect only what this model actually has data for.
+  const deviceOpts = useMemo(
+    () => [...new Set(allPoints.map((p) => p.device))].filter(Boolean).sort(),
+    [allPoints]
+  );
+  const tpOpts = useMemo(
+    () =>
+      [...new Set(allPoints.map((p) => p.tp))]
+        .sort((a, b) => a - b)
+        .map(String),
+    [allPoints]
+  );
+  const concOpts = useMemo(
+    () =>
+      [...new Set(allPoints.map((p) => p.conc))]
+        .sort((a, b) => a - b)
+        .map(String),
+    [allPoints]
+  );
+
+  const points = useMemo(
+    () =>
+      allPoints.filter(
+        (p) =>
+          (!device || p.device === device) &&
+          (!tp || p.tp === Number(tp)) &&
+          (!conc || p.conc === Number(conc))
+      ),
+    [allPoints, device, tp, conc]
+  );
+
+  const seriesKeys = useMemo(
+    () => [...new Set(points.map((p) => p.series))].sort(),
+    [points]
+  );
 
   const colorMap = useMemo(() => {
-    const keys = [
-      ...new Set(chartRows.map((r) => `${r.device}|${r.dateStr}`)),
-    ].sort();
     const map: Record<string, string> = {};
-    keys.forEach((key, i) => {
+    seriesKeys.forEach((key, i) => {
       map[key] = COLORS[i % COLORS.length];
     });
     return map;
-  }, [chartRows]);
+  }, [seriesKeys]);
 
+  const allMetrics = [...THROUGHPUT_METRICS, ...LATENCY_METRICS];
 
   return (
     <div className="space-y-5">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">
-          Performance Benchmarks
-        </h1>
-        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-          Throughput-latency tradeoff curves across hardware configurations.
-          Points on the Pareto frontier represent optimal throughput/latency tradeoffs.
-        </p>
-      </div>
-
       {/* Filter bar */}
       <div className="flex flex-wrap items-end gap-x-4 gap-y-3 rounded-xl border border-zinc-200/80 bg-white px-5 py-4 shadow-[0_1px_3px_rgba(0,0,0,0.04)] dark:border-zinc-800/80 dark:bg-zinc-950 dark:shadow-[0_1px_3px_rgba(0,0,0,0.3)]">
         <SearchableSelect
@@ -472,65 +379,67 @@ export default function PerfPage() {
             setModel(v);
             setDevice("");
             setTp("");
+            setConc("");
           }}
           options={filters?.models ?? []}
+          counts={filters?.modelCounts}
           allLabel="Select Model"
         />
         <SearchableSelect
           label="Device"
           value={device}
           onChange={setDevice}
-          options={filters?.devices ?? []}
+          options={deviceOpts}
           allLabel="All Devices"
         />
         <SearchableSelect
           label="TP"
           value={tp}
           onChange={setTp}
-          options={filters?.tps ?? []}
+          options={tpOpts}
           allLabel="All TP"
         />
         <SearchableSelect
           label="Concurrency"
           value={conc}
           onChange={setConc}
-          options={filters?.concs ?? []}
+          options={concOpts}
           allLabel="All Concurrency"
         />
-        {model && chartRows.length > 0 && (
-          <div className="flex items-center gap-2.5 pb-0.5">
-            <button
-              type="button"
-              role="switch"
-              aria-checked={hideNonOptimal}
-              onClick={() => setHideNonOptimal(!hideNonOptimal)}
-              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200 ${
-                hideNonOptimal
-                  ? "bg-indigo-500"
-                  : "bg-zinc-200 dark:bg-zinc-700"
-              }`}
-            >
-              <span
-                className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform duration-200 ${
-                  hideNonOptimal ? "translate-x-[18px]" : "translate-x-[3px]"
+        {/* Statistic toggle */}
+        <div>
+          <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
+            Latency stat
+          </label>
+          <div className="inline-flex rounded-md border border-zinc-200 bg-white p-0.5 dark:border-zinc-700 dark:bg-zinc-900">
+            {STATS.map((s) => (
+              <button
+                key={s}
+                type="button"
+                onClick={() => setStat(s)}
+                className={`rounded px-2.5 py-1 text-xs font-medium uppercase tracking-wide transition-colors ${
+                  stat === s
+                    ? "bg-indigo-500 text-white"
+                    : "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
                 }`}
-              />
-            </button>
-            <span className="text-xs font-medium text-zinc-600 dark:text-zinc-400">
-              Optimal only
-            </span>
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        </div>
+        {model && seriesKeys.length > 0 && (
+          <div className="pb-1.5 text-xs text-zinc-400 dark:text-zinc-500">
+            {seriesKeys.length} series
           </div>
         )}
       </div>
 
       {/* Empty states */}
       {!model && (
-        <div className="flex h-64 flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700">
-          <svg className="h-8 w-8 text-zinc-300 dark:text-zinc-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
-          </svg>
+        <div className="flex h-64 items-center justify-center rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700">
           <span className="text-sm text-zinc-400 dark:text-zinc-500">
-            Select a model to view performance benchmarks
+            Select a model to view performance trends
           </span>
         </div>
       )}
@@ -540,7 +449,7 @@ export default function PerfPage() {
           <span className="text-sm text-zinc-400">Loading benchmarks...</span>
         </div>
       )}
-      {model && !isLoading && rawRows.length === 0 && (
+      {model && !isLoading && points.length === 0 && (
         <div className="flex h-64 items-center justify-center rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700">
           <span className="text-sm text-zinc-400 dark:text-zinc-500">
             No data found for this configuration.
@@ -549,21 +458,19 @@ export default function PerfPage() {
       )}
 
       {/* Charts grid */}
-      {model && !isLoading && chartRows.length > 0 && (
+      {model && !isLoading && points.length > 0 && (
         <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
-          {CHART_CONFIGS.map((cfg) => (
-            <PerfChart
-              key={`${cfg.x}-${cfg.y}`}
-              chartRows={chartRows}
-              config={cfg}
+          {allMetrics.map((m) => (
+            <TrendChart
+              key={m}
+              points={points}
+              metric={m}
+              stat={stat}
               colorMap={colorMap}
-              hideNonOptimal={hideNonOptimal}
             />
           ))}
         </div>
       )}
-
     </div>
   );
 }
-

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -27,7 +27,10 @@ export function Nav() {
         </Link>
         <div className="flex gap-1">
           {links.map((link) => {
-            const active = pathname === link.href;
+            const active =
+              link.href === "/"
+                ? pathname === "/"
+                : pathname === link.href || pathname.startsWith(`${link.href}/`);
             return (
               <Link
                 key={link.href}

--- a/src/components/searchable-select.tsx
+++ b/src/components/searchable-select.tsx
@@ -8,6 +8,8 @@ interface SearchableSelectProps {
   onChange: (value: string) => void;
   options: string[];
   allLabel?: string;
+  /** Optional per-option count, shown muted on the right (e.g. datapoints). */
+  counts?: Record<string, number>;
 }
 
 export function SearchableSelect({
@@ -16,6 +18,7 @@ export function SearchableSelect({
   onChange,
   options,
   allLabel,
+  counts,
 }: SearchableSelectProps) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -122,13 +125,18 @@ export function SearchableSelect({
                     setOpen(false);
                     setSearch("");
                   }}
-                  className={`w-full px-3 py-1.5 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 ${
+                  className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 ${
                     value === option
                       ? "font-medium text-blue-600 dark:text-blue-400"
                       : ""
                   }`}
                 >
-                  {option}
+                  <span className="min-w-0 flex-1 truncate">{option}</span>
+                  {counts?.[option] !== undefined && (
+                    <span className="shrink-0 tabular-nums text-xs text-zinc-400 dark:text-zinc-500">
+                      {counts[option]}
+                    </span>
+                  )}
                 </button>
               </li>
             ))}


### PR DESCRIPTION
Adds a **Performance** section with two sub-tabs sharing one layout:

- **Trends** (default, `/perf`) — benchmark metrics over time, one line per config (`device · TP · concurrency`), with a `p99 / mean / median` toggle. Built to spot regressions across nightly builds.
- **Benchmarks** (`/perf/benchmarks`) — the existing throughput-vs-latency Pareto curves.

Both reuse the existing `/api/perf` and `/api/perf/filters` endpoints, so there are **no schema or ingestion changes** — it consumes exactly what the perf-dashboard automation already writes.

<img width="1644" height="1037" alt="Screenshot 2026-06-30 at 1 44 23 PM" src="https://github.com/user-attachments/assets/795b2a14-0937-4701-bd2d-9bc78650f180" />


## Usability & performance
- **Model dropdown sorted by datapoint count** (most data first), with the count shown per option — so models with rich history surface above near-empty ones (e.g. a model with 2 datapoints no longer sorts near the top).
- **Instant filtering**: Trends fetches all rows for a model once, then filters device/TP/concurrency **client-side** (no refetch). Dropdown options are derived from the loaded data, so only configs that actually have data are offered.
- Perf data cache bumped 60s → 5 min (data refreshes at most nightly).

## Changes
- `src/app/perf/layout.tsx` — sub-tab bar
- `src/app/perf/page.tsx` — Trends (default)
- `src/app/perf/benchmarks/page.tsx` — Pareto benchmarks (moved from `/perf`)
- `src/app/api/perf/filters/route.ts` — per-model counts + count-sort
- `src/app/api/perf/route.ts` — cache TTL
- `src/components/searchable-select.tsx` — optional per-option count
- `src/components/nav.tsx` — single Performance entry, active across `/perf/*`

## Testing
- `bunx tsc --noEmit` — clean
- `eslint` — clean (no warnings in the perf area)
- `bun run build` — `/perf` and `/perf/benchmarks` build
- Verified locally against live Databricks data (sub-tab nav, model sorting + counts, client-side filtering).

AI assistance (Claude) was used.