### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/src/app/eval/page.tsx
+++ b/src/app/eval/page.tsx
@@ -86,16 +86,20 @@ const COLORS = [
 ];
 
 function subscribeToColorScheme(onStoreChange: () => void) {
-  if (typeof window === "undefined") return () => {};
-  const mq = window.matchMedia("(prefers-color-scheme: dark)");
-  mq.addEventListener("change", onStoreChange);
-  return () => mq.removeEventListener("change", onStoreChange);
+  if (typeof document === "undefined") return () => {};
+  const obs = new MutationObserver(onStoreChange);
+  obs.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+  return () => obs.disconnect();
 }
 
 function getColorSchemeSnapshot() {
-  return typeof window !== "undefined"
-    ? window.matchMedia("(prefers-color-scheme: dark)").matches
-    : false;
+  return (
+    typeof document !== "undefined" &&
+    document.documentElement.classList.contains("dark")
+  );
 }
 
 function useDarkMode() {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+/* Drive `dark:` utilities off a `.dark` class on <html> instead of the
+   prefers-color-scheme media query, so the theme toggle can override it. */
+@custom-variant dark (&:is(.dark *));
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
@@ -12,11 +16,10 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  color-scheme: dark;
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,16 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Apply the saved theme (or system default) before paint to avoid a
+            flash of the wrong theme. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem('theme');var d=t?t==='dark':window.matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.classList.toggle('dark',d);}catch(e){}})();`,
+          }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/src/app/perf/page.tsx
+++ b/src/app/perf/page.tsx
@@ -115,13 +115,18 @@ const COLORS = [
 // ── Hooks ────────────────────────────────────────────────────────────────────
 
 function useDarkMode() {
-  const [dark, setDark] = useState(false);
+  const [dark, setDark] = useState(
+    () =>
+      typeof document !== "undefined" &&
+      document.documentElement.classList.contains("dark")
+  );
   useEffect(() => {
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    setDark(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setDark(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
+    const el = document.documentElement;
+    const obs = new MutationObserver(() =>
+      setDark(el.classList.contains("dark"))
+    );
+    obs.observe(el, { attributes: true, attributeFilter: ["class"] });
+    return () => obs.disconnect();
   }, []);
   return dark;
 }

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 const links = [
   { href: "/", label: "Builds" },
@@ -41,6 +42,9 @@ export function Nav() {
               </Link>
             );
           })}
+        </div>
+        <div className="ml-auto">
+          <ThemeToggle />
         </div>
       </div>
     </nav>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+// Stateless: the inline <head> script sets the initial `.dark` class on
+// <html>, and the icons below show/hide purely via the `dark:` CSS variant,
+// so there is nothing to hydrate. The button just flips the class + storage.
+export function ThemeToggle() {
+  const toggle = () => {
+    const next = document.documentElement.classList.contains("dark")
+      ? "light"
+      : "dark";
+    document.documentElement.classList.toggle("dark", next === "dark");
+    try {
+      localStorage.setItem("theme", next);
+    } catch {}
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label="Toggle light/dark theme"
+      className="rounded-md p-2 text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+    >
+      {/* Sun — shown in dark mode */}
+      <svg className="hidden h-4 w-4 dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+        <circle cx="12" cy="12" r="4" />
+        <path strokeLinecap="round" d="M12 2v2m0 16v2M2 12h2m16 0h2M4.93 4.93l1.41 1.41m11.32 11.32 1.41 1.41M19.07 4.93l-1.41 1.41M6.34 17.66l-1.41 1.41" />
+      </svg>
+      {/* Moon — shown in light mode */}
+      <svg className="h-4 w-4 dark:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z" />
+      </svg>
+    </button>
+  );
+}


### PR DESCRIPTION
The dashboard previously followed `prefers-color-scheme` only, so anyone whose system defaults to dark mode couldn't view light mode at all. This adds a sun/moon toggle in the nav bar.

## How it works
- Tailwind's `dark:` variant is switched to **class-based** (`@custom-variant dark`) and driven by a `.dark` class on `<html>`.
- The toggle persists the choice to `localStorage`, **defaulting to the system preference** when unset.
- An inline `<head>` script applies the theme before first paint, so there's no flash of the wrong theme on load.
- The Performance/Evaluation Plotly charts read the `.dark` class (via a `MutationObserver`) instead of the media query, so they follow the toggle too.

Pattern mirrors the toggle in `vllm-project/recipes`; uses inline SVG icons so no new dependency is added.

## Changes
- `src/components/theme-toggle.tsx` — new, stateless toggle (icons show/hide via CSS)
- `src/components/nav.tsx` — render it (right-aligned)
- `src/app/layout.tsx` — pre-paint theme script
- `src/app/globals.css` — class-based `dark:`, `.dark` body vars
- `src/app/perf/page.tsx`, `src/app/eval/page.tsx` — charts follow the class

## Testing
- `bunx tsc --noEmit` — clean
- `eslint` (new/changed files) — no new errors
- `bun run build` — succeeds

AI assistance (Claude) was used.