### PR TITLE
chore: stop nightly perf/eval Slack summary cron

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,10 +11,6 @@
     {
       "path": "/api/cron/poll-agents",
       "schedule": "* * * * *"
-    },
-    {
-      "path": "/api/cron/nightly-summary",
-      "schedule": "0 16 * * *"
     }
   ]
 }


### PR DESCRIPTION
Removes the `/api/cron/nightly-summary` entry from `vercel.json` so the daily nightly perf/eval comparison stops posting to Slack.

The route (`src/app/api/cron/nightly-summary/route.ts`) and its comparison/template code are left in place, so the automation can be re-enabled later by restoring the cron entry.

Once merged, Vercel redeploys `main` and the cron stops firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)