### PR TITLE
Filter out perf data before June 14th by default

### DIFF
--- a/src/app/api/perf/filters/route.ts
+++ b/src/app/api/perf/filters/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
+import {
+  perfDataStartCondition,
+  resolvePerfDataStartDate,
+} from "@/lib/perf-data";
 
 const TTL = 300_000;
 
@@ -11,17 +15,17 @@ function isIsoDate(s: string): boolean {
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    const start = searchParams.get("start");
+    const startDate = resolvePerfDataStartDate(searchParams.get("start"));
     const end = searchParams.get("end");
 
-    const cacheKey = `perf:filters:${start}:${end}`;
+    const cacheKey = `perf:filters:${startDate}:${end}`;
     const cached = getCached(cacheKey);
     if (cached) return NextResponse.json(cached);
 
-    const conditions = ["message:model IS NOT NULL"];
-    if (start && isIsoDate(start)) {
-      conditions.push(`message:date::STRING >= '${start.slice(0, 10)}'`);
-    }
+    const conditions = [
+      "message:model IS NOT NULL",
+      perfDataStartCondition(startDate),
+    ];
     if (end && isIsoDate(end)) {
       conditions.push(`message:date::STRING <= '${end.slice(0, 10)}'`);
     }

--- a/src/app/api/perf/route.ts
+++ b/src/app/api/perf/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
+import {
+  perfDataStartCondition,
+  resolvePerfDataStartDate,
+} from "@/lib/perf-data";
 
 // Perf data refreshes at most nightly, so a longer cache keeps repeat loads
 // instant without serving stale numbers.
@@ -13,12 +17,16 @@ export async function GET(request: NextRequest) {
     const device = sp.get("device");
     const tp = sp.get("tp");
     const conc = sp.get("conc");
+    const startDate = resolvePerfDataStartDate(sp.get("start"));
 
-    const cacheKey = `perf:${model}:${device}:${tp}:${conc}`;
+    const cacheKey = `perf:${startDate}:${model}:${device}:${tp}:${conc}`;
     const cached = getCached(cacheKey);
     if (cached) return NextResponse.json(cached);
 
-    const conditions = ["message:model IS NOT NULL"];
+    const conditions = [
+      "message:model IS NOT NULL",
+      perfDataStartCondition(startDate),
+    ];
     if (model) conditions.push(`message:model::STRING = '${model.replace(/'/g, "''")}'`);
     if (device) conditions.push(`message:device::STRING = '${device.replace(/'/g, "''")}'`);
     if (tp) conditions.push(`message:tp::INT = ${parseInt(tp, 10)}`);

--- a/src/app/perf/benchmarks/page.tsx
+++ b/src/app/perf/benchmarks/page.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useEffect } from "react";
 import useSWR from "swr";
 import dynamic from "next/dynamic";
 import { SearchableSelect } from "@/components/searchable-select";
+import { usePerfSettings } from "@/app/perf/perf-settings";
 
 const Plot = dynamic(() => import("@/components/plotly-chart"), {
   ssr: false,
@@ -382,15 +383,20 @@ function PerfChart({
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export default function PerfPage() {
+  const { startDate } = usePerfSettings();
   const [model, setModel] = useState("");
   const [device, setDevice] = useState("");
   const [tp, setTp] = useState("");
   const [conc, setConc] = useState("");
   const [hideNonOptimal, setHideNonOptimal] = useState(false);
 
-  const { data: filters } = useSWR<FiltersResponse>("/api/perf/filters", fetcher);
+  const { data: filters } = useSWR<FiltersResponse>(
+    `/api/perf/filters?start=${encodeURIComponent(startDate)}`,
+    fetcher
+  );
 
   const params = new URLSearchParams();
+  params.set("start", startDate);
   if (model) params.set("model", model);
   if (device) params.set("device", device);
   if (tp) params.set("tp", tp);
@@ -552,4 +558,3 @@ export default function PerfPage() {
     </div>
   );
 }
-

--- a/src/app/perf/layout.tsx
+++ b/src/app/perf/layout.tsx
@@ -2,6 +2,10 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import {
+  PerfSettingsMenu,
+  PerfSettingsProvider,
+} from "@/app/perf/perf-settings";
 
 const tabs = [
   { href: "/perf", label: "Trends" },
@@ -13,7 +17,16 @@ export default function PerfLayout({
 }: {
   children: React.ReactNode;
 }) {
+  return (
+    <PerfSettingsProvider>
+      <PerfLayoutContent>{children}</PerfLayoutContent>
+    </PerfSettingsProvider>
+  );
+}
+
+function PerfLayoutContent({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+
   return (
     <div className="space-y-5">
       <div>
@@ -35,6 +48,7 @@ export default function PerfLayout({
               </Link>
             );
           })}
+          <PerfSettingsMenu />
         </div>
       </div>
       {children}

--- a/src/app/perf/page.tsx
+++ b/src/app/perf/page.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useEffect } from "react";
 import useSWR from "swr";
 import dynamic from "next/dynamic";
 import { SearchableSelect } from "@/components/searchable-select";
+import { usePerfSettings } from "@/app/perf/perf-settings";
 
 const Plot = dynamic(() => import("@/components/plotly-chart"), {
   ssr: false,
@@ -275,18 +276,24 @@ function TrendChart({
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export default function PerfTrendsPage() {
+  const { startDate } = usePerfSettings();
   const [model, setModel] = useState("");
   const [device, setDevice] = useState("");
   const [tp, setTp] = useState("");
   const [conc, setConc] = useState("");
   const [stat, setStat] = useState<Stat>("p99");
 
-  const { data: filters } = useSWR<FiltersResponse>("/api/perf/filters", fetcher);
+  const { data: filters } = useSWR<FiltersResponse>(
+    `/api/perf/filters?start=${encodeURIComponent(startDate)}`,
+    fetcher
+  );
 
   // Fetch every row for the model once, then filter device/TP/concurrency
   // client-side so those switches are instant (no refetch).
   const { data, isLoading } = useSWR<{ rows: PerfRow[] }>(
-    model ? `/api/perf?model=${encodeURIComponent(model)}` : null,
+    model
+      ? `/api/perf?model=${encodeURIComponent(model)}&start=${encodeURIComponent(startDate)}`
+      : null,
     fetcher,
     { refreshInterval: 10 * 60 * 1000, keepPreviousData: true }
   );

--- a/src/app/perf/perf-settings.tsx
+++ b/src/app/perf/perf-settings.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { PERF_DATA_START_DATE } from "@/lib/perf-data";
+
+interface PerfSettingsValue {
+  startDate: string;
+  setStartDate: (date: string) => void;
+}
+
+const PerfSettingsContext = createContext<PerfSettingsValue | null>(null);
+
+export function PerfSettingsProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [startDate, setStartDate] = useState(PERF_DATA_START_DATE);
+
+  return (
+    <PerfSettingsContext.Provider value={{ startDate, setStartDate }}>
+      {children}
+    </PerfSettingsContext.Provider>
+  );
+}
+
+export function usePerfSettings(): PerfSettingsValue {
+  const value = useContext(PerfSettingsContext);
+  if (!value) {
+    throw new Error("usePerfSettings must be used within PerfSettingsProvider");
+  }
+  return value;
+}
+
+export function PerfSettingsMenu() {
+  const { startDate, setStartDate } = usePerfSettings();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const overridden = startDate !== PERF_DATA_START_DATE;
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div ref={ref} className="relative ml-auto self-center">
+      <button
+        type="button"
+        aria-label="Performance settings"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        className="relative rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+        title="Performance settings"
+      >
+        <svg
+          aria-hidden="true"
+          className="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={1.75}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.592c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.245a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.7 7.7 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.956.259 1.431l-1.296 2.245a1.125 1.125 0 0 1-1.37.49l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.6 6.6 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.542-.56.94-1.11.94h-2.592c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.063-.374-.313-.686-.645-.87a6.5 6.5 0 0 1-.22-.127c-.325-.196-.72-.257-1.075-.124l-1.217.456a1.125 1.125 0 0 1-1.37-.49l-1.296-2.245a1.125 1.125 0 0 1 .26-1.431l1.003-.827c.293-.241.438-.613.43-.992a6.8 6.8 0 0 1 0-.255c.008-.378-.137-.75-.43-.991l-1.004-.827a1.125 1.125 0 0 1-.259-1.431l1.296-2.245a1.125 1.125 0 0 1 1.37-.49l1.217.456c.355.133.75.072 1.076-.124.072-.044.146-.086.22-.128.331-.183.581-.495.644-.869l.213-1.281Z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+          />
+        </svg>
+        {overridden && (
+          <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-indigo-500 ring-2 ring-white dark:ring-zinc-950" />
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-2 w-72 rounded-lg border border-zinc-200 bg-white p-4 shadow-xl dark:border-zinc-700 dark:bg-zinc-900">
+          <div className="mb-3">
+            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+              Performance data
+            </p>
+            <p className="mt-1 text-xs leading-5 text-zinc-500 dark:text-zinc-400">
+              Choose the earliest benchmark date to include on this tab.
+            </p>
+          </div>
+          <label
+            htmlFor="perf-start-date"
+            className="mb-1 block text-xs font-medium text-zinc-600 dark:text-zinc-300"
+          >
+            Show data from
+          </label>
+          <input
+            id="perf-start-date"
+            type="date"
+            value={startDate}
+            onInput={(event) =>
+              setStartDate(event.currentTarget.value || PERF_DATA_START_DATE)
+            }
+            className="w-full rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-100"
+          />
+          <div className="mt-3 flex items-center justify-between border-t border-zinc-100 pt-3 dark:border-zinc-800">
+            <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
+              Default: Jun 14, 2026
+            </span>
+            <button
+              type="button"
+              onClick={() => setStartDate(PERF_DATA_START_DATE)}
+              disabled={!overridden}
+              className="text-xs font-medium text-indigo-600 transition-colors hover:text-indigo-500 disabled:cursor-default disabled:text-zinc-300 dark:text-indigo-400 dark:hover:text-indigo-300 dark:disabled:text-zinc-600"
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/compare.ts
+++ b/src/lib/compare.ts
@@ -1,5 +1,6 @@
 import { queryDatabricks } from "@/lib/databricks";
 import type { EvalMetric, EvalRow } from "@/lib/eval-data";
+import { PERF_DATA_START_CONDITION } from "@/lib/perf-data";
 
 export type Area = "perf" | "eval";
 export type DeltaStatus = "regression" | "improvement" | "unchanged" | "noisy";
@@ -252,6 +253,7 @@ export async function loadPerfRowsByImages(
   const escapedImages = images.map((i) => `'${escapeSqlString(i)}'`).join(", ");
   const conditions = [
     "message:model IS NOT NULL",
+    PERF_DATA_START_CONDITION,
     `message:image::STRING IN (${escapedImages})`,
   ];
   if (opts.model) {

--- a/src/lib/perf-data.ts
+++ b/src/lib/perf-data.ts
@@ -1,0 +1,20 @@
+export const PERF_DATA_START_DATE = "2026-06-14";
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function resolvePerfDataStartDate(value?: string | null): string {
+  if (!value || !ISO_DATE_PATTERN.test(value)) return PERF_DATA_START_DATE;
+
+  const date = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) {
+    return PERF_DATA_START_DATE;
+  }
+
+  return value;
+}
+
+export function perfDataStartCondition(value?: string | null): string {
+  return `message:date::STRING >= '${resolvePerfDataStartDate(value)}'`;
+}
+
+export const PERF_DATA_START_CONDITION = perfDataStartCondition();


### PR DESCRIPTION
## Summary

* Default performance data to June 14, 2026 onward
* Add a hidden date override in Performance settings
* Apply the override across Trends and Benchmarks

### Before:

<img width="1770" height="1009" alt="Screenshot 2026-07-21 at 1 56 00 PM" src="https://github.com/user-attachments/assets/5f494345-ae93-4cb6-8a0f-1ff180cdd42b" />

### After:

<img width="1322" height="843" alt="Screenshot 2026-07-16 at 2 33 39 PM" src="https://github.com/user-attachments/assets/078d9c91-a452-4afb-a84d-a908d062b4e8" />
