### PR TITLE
Clean up AMD perf trends: dedup, per-model filters, and ROCm commit-sha keying

### DIFF
--- a/src/app/perf/benchmarks/page.tsx
+++ b/src/app/perf/benchmarks/page.tsx
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import dynamic from "next/dynamic";
 import { SearchableSelect } from "@/components/searchable-select";
 import { usePerfSettings } from "@/app/perf/perf-settings";
+import { dedupePerfRows } from "@/lib/perf-data";
 
 const Plot = dynamic(() => import("@/components/plotly-chart"), {
   ssr: false,
@@ -395,12 +396,12 @@ export default function PerfPage() {
     fetcher
   );
 
+  // Fetch every row for the model (device/TP/concurrency are applied
+  // client-side), so the filter options below reflect only what this model
+  // actually ran — not a global list that includes other models' hardware.
   const params = new URLSearchParams();
   params.set("start", startDate);
   if (model) params.set("model", model);
-  if (device) params.set("device", device);
-  if (tp) params.set("tp", tp);
-  if (conc) params.set("conc", conc);
 
   const { data, isLoading } = useSWR<{ rows: PerfRow[] }>(
     model ? `/api/perf?${params.toString()}` : null,
@@ -408,7 +409,26 @@ export default function PerfPage() {
     { refreshInterval: 10 * 60 * 1000 }
   );
 
-  const rawRows = useMemo(() => data?.rows ?? [], [data]);
+  // Collapse duplicate/re-ingested rows to one point per config+build.
+  const rawRows = useMemo(() => dedupePerfRows(data?.rows ?? []), [data]);
+
+  // Model-scoped dropdown options.
+  const deviceOpts = useMemo(
+    () => [...new Set(rawRows.map((r) => r.device).filter(Boolean))].sort(),
+    [rawRows]
+  );
+  const tpOpts = useMemo(
+    () =>
+      [...new Set(rawRows.map((r) => r.tp).filter(Boolean))]
+        .sort((a, b) => +a - +b),
+    [rawRows]
+  );
+  const concOpts = useMemo(
+    () =>
+      [...new Set(rawRows.map((r) => r.conc).filter(Boolean))]
+        .sort((a, b) => +a - +b),
+    [rawRows]
+  );
 
   const chartRows: ChartRow[] = useMemo(() => {
     return rawRows
@@ -432,8 +452,14 @@ export default function PerfPage() {
         p99_itl: parseFloat(r.p99_itl),
         p99_e2el: parseFloat(r.p99_e2el),
       }))
-      .filter((r) => !isNaN(r.tput_per_gpu));
-  }, [rawRows]);
+      .filter(
+        (r) =>
+          !isNaN(r.tput_per_gpu) &&
+          (!device || r.device === device) &&
+          (!tp || r.tp === Number(tp)) &&
+          (!conc || r.conc === Number(conc))
+      );
+  }, [rawRows, device, tp, conc]);
 
   const colorMap = useMemo(() => {
     const keys = [
@@ -463,6 +489,7 @@ export default function PerfPage() {
             setModel(v);
             setDevice("");
             setTp("");
+            setConc("");
           }}
           options={filters?.models ?? []}
           counts={filters?.modelCounts}
@@ -472,21 +499,21 @@ export default function PerfPage() {
           label="Device"
           value={device}
           onChange={setDevice}
-          options={filters?.devices ?? []}
+          options={deviceOpts}
           allLabel="All Devices"
         />
         <SearchableSelect
           label="TP"
           value={tp}
           onChange={setTp}
-          options={filters?.tps ?? []}
+          options={tpOpts}
           allLabel="All TP"
         />
         <SearchableSelect
           label="Concurrency"
           value={conc}
           onChange={setConc}
-          options={filters?.concs ?? []}
+          options={concOpts}
           allLabel="All Concurrency"
         />
         {model && chartRows.length > 0 && (

--- a/src/app/perf/page.tsx
+++ b/src/app/perf/page.tsx
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import dynamic from "next/dynamic";
 import { SearchableSelect } from "@/components/searchable-select";
 import { usePerfSettings } from "@/app/perf/perf-settings";
+import { dedupePerfRows } from "@/lib/perf-data";
 
 const Plot = dynamic(() => import("@/components/plotly-chart"), {
   ssr: false,
@@ -299,7 +300,10 @@ export default function PerfTrendsPage() {
   );
 
   const allPoints: TrendPoint[] = useMemo(() => {
-    const rawRows = data?.rows ?? [];
+    // Collapse duplicate/re-ingested rows so each build contributes one point
+    // per config; otherwise the same nightly can appear several times and the
+    // line zig-zags.
+    const rawRows = dedupePerfRows(data?.rows ?? []);
     return rawRows
       .map(
         (r) =>
@@ -309,7 +313,12 @@ export default function PerfTrendsPage() {
             device: r.device,
             tp: parseInt(r.tp, 10),
             conc: parseInt(r.conc, 10),
-            series: `${r.device} · TP${r.tp} · c${r.conc}`,
+            // Include ISL/OSL and precision in the series identity: rows that
+            // differ in these are distinct benchmarks and must not share a
+            // line, or a second config/producer makes the trend look erratic.
+            series: `${r.device} · TP${r.tp} · c${r.conc} · ${r.isl}/${r.osl}${
+              r.precision ? ` · ${r.precision}` : ""
+            }`,
             tput_per_gpu: parseFloat(r.tput_per_gpu),
             output_tput_per_gpu: parseFloat(r.output_tput_per_gpu),
             mean_ttft: parseFloat(r.mean_ttft),

--- a/src/lib/perf-data.ts
+++ b/src/lib/perf-data.ts
@@ -18,3 +18,44 @@ export function perfDataStartCondition(value?: string | null): string {
 }
 
 export const PERF_DATA_START_CONDITION = perfDataStartCondition();
+
+// ── Row identity / de-duplication ────────────────────────────────────────────
+
+// The minimal set of fields (all strings, as returned by the perf API) that
+// identify a single benchmark data point.
+export interface PerfRowIdentity {
+  device: string;
+  tp: string;
+  conc: string;
+  isl: string;
+  osl: string;
+  precision: string;
+  image: string;
+  date: string;
+}
+
+// A single benchmark point is fully identified by its config
+// (device/tp/conc/isl/osl/precision) on a specific build `image`. The warehouse
+// can legitimately hold several rows for one such point — a run re-ingested or
+// retried, or more than one producer posting the same nightly into the shared
+// `vllm_perf_data_ingest` table. Those extra rows are what make a trend line
+// zig-zag. Keying on the full config + image lets us collapse them to one point
+// per build, matching the commit-keyed de-dup the standalone AMD dashboard uses.
+export function perfPointKey(r: PerfRowIdentity): string {
+  return [r.device, r.tp, r.conc, r.isl, r.osl, r.precision, r.image]
+    .map((v) => (v ?? "").toString())
+    .join("|");
+}
+
+// Collapse duplicate rows to the latest (by `date`) per config+image.
+export function dedupePerfRows<T extends PerfRowIdentity>(rows: T[]): T[] {
+  const byKey = new Map<string, T>();
+  for (const row of rows) {
+    const key = perfPointKey(row);
+    const prev = byKey.get(key);
+    if (!prev || (row.date ?? "") > (prev.date ?? "")) {
+      byKey.set(key, row);
+    }
+  }
+  return [...byKey.values()];
+}

--- a/src/lib/perf-data.ts
+++ b/src/lib/perf-data.ts
@@ -41,8 +41,25 @@ export interface PerfRowIdentity {
 // `vllm_perf_data_ingest` table. Those extra rows are what make a trend line
 // zig-zag. Keying on the full config + image lets us collapse them to one point
 // per build, matching the commit-keyed de-dup the standalone AMD dashboard uses.
+//
+// ROCm nightlies are published under both a floating `…-rocm:nightly` tag and a
+// commit-pinned `…-rocm:nightly-<sha>` tag, so the same build can be ingested
+// under two different `image` strings. Keying ROCm rows on the embedded commit
+// sha (when present) makes those collapse to one point per commit instead of
+// being double-counted. Non-ROCm images are left untouched.
+const ROCM_NIGHTLY_SHA = /nightly-([0-9a-f]{7,40})\b/i;
+
+export function imageIdentity(image?: string): string {
+  const img = image ?? "";
+  if (/rocm/i.test(img)) {
+    const m = img.match(ROCM_NIGHTLY_SHA);
+    if (m) return `rocm@${m[1].toLowerCase()}`;
+  }
+  return img;
+}
+
 export function perfPointKey(r: PerfRowIdentity): string {
-  return [r.device, r.tp, r.conc, r.isl, r.osl, r.precision, r.image]
+  return [r.device, r.tp, r.conc, r.isl, r.osl, r.precision, imageIdentity(r.image)]
     .map((v) => (v ?? "").toString())
     .join("|");
 }


### PR DESCRIPTION
## Problem

The Performance pages read every row from the shared
`vllm_data_warehouse.default.vllm_perf_data_ingest` table with minimal
processing, which makes AMD workloads (e.g. `openai/gpt-oss-120b` on `mi355x`)
look erratic and surface configs the selected model never ran:

- **No de-duplication** — every warehouse row becomes a point, so
  re-ingested/retried runs show up as extra points and lines zig-zag.
- **Coarse trend series key** — keyed only on `device · TP · conc`, so distinct
  benchmarks (different ISL/OSL or precision) collapse onto one line.
- **Global filter dropdowns** — Benchmarks tab options came from a `DISTINCT`
  across all models, offering combos a given model never ran.
- **ROCm image tag split** — ROCm nightlies are published under both a floating
  `…-rocm:nightly` tag and a commit-pinned `…-rocm:nightly-<sha>` tag, so the
  same build can be counted twice under two different `image` strings.

## Changes (dashboard-side only)

- `src/lib/perf-data.ts`: add `perfPointKey()` / `dedupePerfRows()` to collapse
  duplicate rows to the latest per config+build.
- `src/lib/perf-data.ts`: add `imageIdentity()` — for **ROCm** images, key on
  the embedded commit sha (`rocm@<sha>`) so a build tagged both `:nightly` and
  `:nightly-<sha>` collapses to one point per commit. Non-ROCm images and ROCm
  rows without a sha (bare `:nightly`) are left unchanged.
- `src/app/perf/page.tsx` (Trends): dedup rows and include ISL/OSL + precision
  in the series identity.
- `src/app/perf/benchmarks/page.tsx` (Benchmarks): fetch all rows for the model
  and derive Device/TP/Concurrency options from that model's data.

## Notes / follow-up

Bare `:nightly` rows carry no sha, so they can't be pinned to a commit; this
unifies the commit-pinned duplicates but doesn't drop the non-pinned rows
(likely a different producer). Filtering those out is a follow-up pending a look
at the warehouse's distinct image formats.

## Testing

Verified the transforms on real gpt-oss-120b/mi355x data and representative
image strings. `node_modules` wasn't available locally to run `next build`, so
please confirm CI/preview is green.