### PR TITLE
Add stacked GPU memory chart

### DIFF
--- a/src/app/gpu/gpu-dashboard.tsx
+++ b/src/app/gpu/gpu-dashboard.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import { SearchableSelect } from "@/components/searchable-select";
+import type { GpuChartMode } from "@/components/gpu-util-chart";
 import type {
   GpuHistoryResponse,
   GpuLatest,
@@ -82,6 +83,7 @@ export function GpuDashboard({
   const [gpuTypeFilter, setGpuTypeFilter] = useState("");
   const [hostFilter, setHostFilter] = useState("");
   const [hours, setHours] = useState(24);
+  const [chartMode, setChartMode] = useState<GpuChartMode>("lines");
   const [now, setNow] = useState(initialNow);
 
   useEffect(() => {
@@ -151,6 +153,22 @@ export function GpuDashboard({
     return [...new Set(filtered.map((g) => g.hostname))].sort();
   }, [filtered]);
 
+  const hostCapacityGb = useMemo(() => {
+    const capacities = new Map<string, number>();
+    for (const gpu of filtered) {
+      capacities.set(
+        gpu.hostname,
+        (capacities.get(gpu.hostname) ?? 0) + gpu.mem_total_mb / 1024,
+      );
+    }
+    return capacities;
+  }, [filtered]);
+
+  const totalCapacityGb = useMemo(
+    () => [...hostCapacityGb.values()].reduce((sum, capacity) => sum + capacity, 0),
+    [hostCapacityGb],
+  );
+
   const chartData = useMemo(() => {
     if (snapshots.length === 0) return { data: [] as Array<Record<string, number>>, hosts: [] as string[] };
 
@@ -182,14 +200,19 @@ export function GpuDashboard({
         const row: Record<string, number> = { time };
         for (const host of hosts) {
           const entry = hostMap.get(host);
-          if (entry) row[host] = Math.round(entry.memPctSum / entry.count);
+          if (entry) {
+            const averagePercent = entry.memPctSum / entry.count;
+            row[host] = chartMode === "stacked"
+              ? Math.round((averagePercent / 100) * (hostCapacityGb.get(host) ?? 0) * 10) / 10
+              : Math.round(averagePercent);
+          }
         }
         return row;
       })
       .sort((a, b) => a.time - b.time);
 
     return { data: rows, hosts };
-  }, [snapshots, filteredHosts, gpuTypeFilter]);
+  }, [snapshots, filteredHosts, gpuTypeFilter, chartMode, hostCapacityGb]);
 
   const tickInterval = Math.max(1, Math.floor(chartData.data.length / 10));
 
@@ -352,21 +375,59 @@ export function GpuDashboard({
       </div>
 
       {/* Per-host memory chart */}
-      <div className="relative rounded-lg border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950">
-        <h3 className="mb-4 text-sm font-medium text-zinc-500 dark:text-zinc-400">
-          Memory Utilization by Host
-        </h3>
-        {historyPending && (
-          <span className="absolute right-5 top-4 inline-flex items-center gap-1.5 text-xs text-zinc-400" role="status">
-            <span className="h-3 w-3 animate-spin rounded-full border border-zinc-300 border-t-zinc-600 motion-reduce:animate-none dark:border-zinc-700 dark:border-t-zinc-300" aria-hidden="true" />
-            Updating {HOURS_OPTIONS.find((option) => option.value === hours)?.label ?? `${hours}h`} chart…
-          </span>
-        )}
+      <div className="rounded-lg border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950">
+        <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
+              {chartMode === "stacked" ? "Stacked Memory by Host" : "Memory Utilization by Host"}
+            </h3>
+            {chartMode === "stacked" && (
+              <p className="mt-1 text-xs text-zinc-400">
+                Aggregate usage across {filtered.length} GPUs, stacked by host.
+              </p>
+            )}
+          </div>
+          <div className="flex items-center gap-3">
+            {historyPending && (
+              <span className="inline-flex items-center gap-1.5 text-xs text-zinc-400" role="status">
+                <span className="h-3 w-3 animate-spin rounded-full border border-zinc-300 border-t-zinc-600 motion-reduce:animate-none dark:border-zinc-700 dark:border-t-zinc-300" aria-hidden="true" />
+                Updating {HOURS_OPTIONS.find((option) => option.value === hours)?.label ?? `${hours}h`} chart…
+              </span>
+            )}
+            <div
+              className="flex gap-1 rounded-md border border-zinc-200 p-0.5 dark:border-zinc-700"
+              role="group"
+              aria-label="GPU chart mode"
+            >
+              {([
+                { label: "Lines", value: "lines" },
+                { label: "Stacked", value: "stacked" },
+              ] as const).map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setChartMode(option.value)}
+                  aria-pressed={chartMode === option.value}
+                  className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+                    chartMode === option.value
+                      ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                      : "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
         <GpuMemChart
           data={chartData.data}
           hosts={chartData.hosts}
           formatXTick={formatXTick}
           tickInterval={tickInterval}
+          mode={chartMode}
+          totalCapacityGb={totalCapacityGb}
+          totalGpuCount={filtered.length}
         />
       </div>
 

--- a/src/components/gpu-util-chart.tsx
+++ b/src/components/gpu-util-chart.tsx
@@ -1,21 +1,29 @@
 "use client";
 
 import {
+  Area,
+  AreaChart,
   LineChart,
   Line,
   XAxis,
   YAxis,
   Tooltip,
   Legend,
+  ReferenceLine,
   ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
+
+export type GpuChartMode = "lines" | "stacked";
 
 interface GpuMemChartProps {
   data: Array<Record<string, number>>;
   hosts: string[];
   formatXTick: (t: number) => string;
   tickInterval: number;
+  mode: GpuChartMode;
+  totalCapacityGb: number;
+  totalGpuCount: number;
 }
 
 const HOST_COLORS = [
@@ -27,10 +35,12 @@ function MemTooltip({
   active,
   payload,
   label,
+  mode,
 }: {
   active?: boolean;
   payload?: Array<{ value: number; name: string; color: string }>;
   label?: number;
+  mode: GpuChartMode;
 }) {
   if (!active || !payload?.length) return null;
   const timeLabel = label
@@ -42,13 +52,20 @@ function MemTooltip({
         hour12: true,
       })
     : "";
+  const entries = payload
+    .filter((entry) => entry.value != null)
+    .sort((a, b) => b.value - a.value);
+  const total = entries.reduce((sum, entry) => sum + Number(entry.value), 0);
+
   return (
     <div className="rounded-md border border-zinc-200 bg-white px-3 py-2 text-xs shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
-      <p className="mb-1 font-medium">{timeLabel}</p>
-      {payload
-        .filter((p) => p.value != null)
-        .sort((a, b) => b.value - a.value)
-        .map((p) => (
+      <div className="mb-1 flex items-center justify-between gap-5">
+        <p className="font-medium">{timeLabel}</p>
+        {mode === "stacked" && (
+          <span className="font-medium tabular-nums">{formatGigabytes(total)}</span>
+        )}
+      </div>
+      {entries.map((p) => (
           <div key={p.name} className="flex items-center justify-between gap-4">
             <span className="flex items-center gap-1.5">
               <span
@@ -57,14 +74,30 @@ function MemTooltip({
               />
               {p.name}
             </span>
-            <span className="tabular-nums">{p.value}%</span>
+            <span className="tabular-nums">
+              {mode === "stacked" ? formatGigabytes(p.value) : `${p.value}%`}
+            </span>
           </div>
         ))}
     </div>
   );
 }
 
-export function GpuMemChart({ data, hosts, formatXTick, tickInterval }: GpuMemChartProps) {
+function formatGigabytes(value: number): string {
+  if (value >= 1024) return `${(value / 1024).toFixed(1)} TB`;
+  if (value >= 10) return `${Math.round(value)} GB`;
+  return `${value.toFixed(1)} GB`;
+}
+
+export function GpuMemChart({
+  data,
+  hosts,
+  formatXTick,
+  tickInterval,
+  mode,
+  totalCapacityGb,
+  totalGpuCount,
+}: GpuMemChartProps) {
   if (data.length === 0) {
     return (
       <div className="flex h-[300px] items-center justify-center text-sm text-zinc-400">
@@ -73,17 +106,76 @@ export function GpuMemChart({ data, hosts, formatXTick, tickInterval }: GpuMemCh
     );
   }
 
+  const xAxis = (
+    <XAxis
+      dataKey="time"
+      tick={{ fontSize: 10 }}
+      stroke="#71717a"
+      tickFormatter={formatXTick}
+      interval={tickInterval}
+    />
+  );
+  const grid = <CartesianGrid strokeDasharray="3 3" stroke="#27272a" vertical={false} />;
+
+  if (mode === "stacked") {
+    return (
+      <ResponsiveContainer width="100%" height={300}>
+        <AreaChart data={data}>
+          {grid}
+          {xAxis}
+          <YAxis
+            tick={{ fontSize: 11 }}
+            stroke="#71717a"
+            width={58}
+            domain={[0, totalCapacityGb]}
+            tickFormatter={formatGigabytes}
+            allowDataOverflow
+          />
+          <Tooltip
+            content={<MemTooltip mode="stacked" />}
+            cursor={{ fill: "rgba(113,113,122,0.08)" }}
+          />
+          <Legend wrapperStyle={{ fontSize: 11 }} />
+          <ReferenceLine
+            y={totalCapacityGb}
+            stroke="#71717a"
+            strokeDasharray="4 4"
+            strokeWidth={1.5}
+            ifOverflow="extendDomain"
+            label={{
+              value: `${totalGpuCount} GPUs · ${formatGigabytes(totalCapacityGb)} capacity`,
+              position: "insideTopRight",
+              fill: "#71717a",
+              fontSize: 11,
+            }}
+          />
+          {hosts.map((host, i) => (
+            <Area
+              key={host}
+              type="monotone"
+              dataKey={host}
+              name={host}
+              stackId="gpu-memory"
+              stroke={HOST_COLORS[i % HOST_COLORS.length]}
+              fill={HOST_COLORS[i % HOST_COLORS.length]}
+              fillOpacity={0.72}
+              strokeWidth={1.5}
+              dot={false}
+              activeDot={{ r: 4 }}
+              connectNulls
+              isAnimationActive={false}
+            />
+          ))}
+        </AreaChart>
+      </ResponsiveContainer>
+    );
+  }
+
   return (
     <ResponsiveContainer width="100%" height={300}>
       <LineChart data={data}>
-        <CartesianGrid strokeDasharray="3 3" stroke="#27272a" vertical={false} />
-        <XAxis
-          dataKey="time"
-          tick={{ fontSize: 10 }}
-          stroke="#71717a"
-          tickFormatter={formatXTick}
-          interval={tickInterval}
-        />
+        {grid}
+        {xAxis}
         <YAxis
           tick={{ fontSize: 11 }}
           stroke="#71717a"
@@ -92,7 +184,7 @@ export function GpuMemChart({ data, hosts, formatXTick, tickInterval }: GpuMemCh
           tickFormatter={(v: number) => `${v}%`}
         />
         <Tooltip
-          content={<MemTooltip />}
+          content={<MemTooltip mode="lines" />}
           cursor={{ fill: "rgba(113,113,122,0.08)" }}
         />
         <Legend wrapperStyle={{ fontSize: 11 }} />


### PR DESCRIPTION
## What changed

- adds a Lines / Stacked mode control to the GPU memory chart
- renders stacked per-host memory usage in GB/TB
- caps the stacked Y-axis at the aggregate capacity of the currently filtered GPUs
- adds a dotted capacity reference line labeled with GPU count and total capacity
- recalculates capacity for Host and GPU Type filters and shows aggregate/per-host tooltip values

## Why

The existing percentage lines make it difficult to see fleet-wide GPU memory consumption. The stacked view shows aggregate usage while preserving the existing line chart as the default.

## Validation

- `npx eslint src/app/gpu/gpu-dashboard.tsx src/components/gpu-util-chart.tsx`
- `npm run build`
- browser-tested both chart modes at 1440×1100
- verified the Stacked toggle's pressed state and capacity label against live GPU data