### PR TITLE
Polish dashboard design and responsiveness

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,8 +5,10 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: #ffffff;
+  --background: #fafafa;
   --foreground: #171717;
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
 }
 
 @theme inline {
@@ -17,13 +19,113 @@
 }
 
 .dark {
-  --background: #0a0a0a;
+  --background: #09090b;
   --foreground: #ededed;
   color-scheme: dark;
+}
+
+html {
+  min-width: 320px;
+  font-optical-sizing: auto;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  overflow-x: clip;
+}
+
+h1,
+h2 {
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+
+::selection {
+  background: rgb(59 130 246 / 22%);
+}
+
+:where(a, button, input, select, textarea):focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+.dashboard-nav {
+  background: rgb(255 255 255 / 82%);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+}
+
+.dark .dashboard-nav {
+  background: rgb(9 9 11 / 82%);
+}
+
+.dashboard-popover {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transform-origin: top;
+  transition:
+    opacity 160ms var(--ease-out),
+    transform 160ms var(--ease-out);
+
+  @starting-style {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
+  }
+}
+
+.dashboard-control {
+  transition:
+    color 140ms var(--ease-out),
+    background-color 140ms var(--ease-out),
+    border-color 140ms var(--ease-out),
+    box-shadow 140ms var(--ease-out),
+    transform 140ms var(--ease-out);
+}
+
+.scrollbar-hidden {
+  scrollbar-width: none;
+}
+
+.scrollbar-hidden::-webkit-scrollbar {
+  display: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .dashboard-control:not(:disabled):active:not(:focus-visible) {
+    transform: scale(0.98);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dashboard-popover {
+    transform: none;
+    transition: opacity 120ms ease-out;
+
+    @starting-style {
+      opacity: 0;
+      transform: none;
+    }
+  }
+
+  .dashboard-control {
+    transition-property: color, background-color, border-color, box-shadow;
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .dashboard-nav {
+    background: var(--background);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .dashboard-nav {
+    background: var(--background);
+    border-color: currentColor;
+  }
 }

--- a/src/app/gpu/gpu-dashboard.tsx
+++ b/src/app/gpu/gpu-dashboard.tsx
@@ -323,7 +323,7 @@ export function GpuDashboard({
               type="button"
               onClick={() => void refreshLatest()}
               disabled={latestIsValidating}
-              className="inline-flex items-center gap-1 rounded px-1.5 py-1 font-medium text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zinc-500 disabled:cursor-wait disabled:opacity-50 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+              className="dashboard-control inline-flex items-center gap-1 rounded px-1.5 py-1 font-medium text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 disabled:cursor-wait disabled:opacity-50 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
               aria-label={latestError ? "Retry GPU data refresh" : "Refresh GPU data now"}
             >
               <svg
@@ -361,7 +361,7 @@ export function GpuDashboard({
               <button
                 key={opt.value}
                 onClick={() => setHours(opt.value)}
-                className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+                className={`dashboard-control rounded px-2.5 py-1 text-xs font-medium ${
                   hours === opt.value
                     ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                     : "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
@@ -375,7 +375,7 @@ export function GpuDashboard({
       </div>
 
       {/* Per-host memory chart */}
-      <div className="rounded-lg border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="min-w-0 overflow-hidden rounded-lg border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none sm:p-5">
         <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
           <div>
             <h3 className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
@@ -408,7 +408,7 @@ export function GpuDashboard({
                   type="button"
                   onClick={() => setChartMode(option.value)}
                   aria-pressed={chartMode === option.value}
-                  className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+                  className={`dashboard-control rounded px-2.5 py-1 text-xs font-medium ${
                     chartMode === option.value
                       ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                       : "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
@@ -432,14 +432,14 @@ export function GpuDashboard({
       </div>
 
       {/* Host summary table */}
-      <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="min-w-0 overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
         <div className="border-b border-zinc-200 px-5 py-3 dark:border-zinc-800">
           <h3 className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
             Host Summary
           </h3>
         </div>
         <div className="overflow-x-auto">
-          <table className="w-full text-sm">
+          <table className="w-full min-w-[760px] text-sm">
             <thead>
               <tr className="border-b border-zinc-200 text-left text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
                 <th className="px-5 py-2.5 font-medium">Host</th>
@@ -497,7 +497,7 @@ export function GpuDashboard({
                                 style={{ height: 36 }}
                               >
                                 <div
-                                  className={`absolute bottom-0 w-full rounded-sm transition-all ${barColor}`}
+                                  className={`absolute bottom-0 w-full rounded-sm ${barColor}`}
                                   style={{ height: `${Math.max(pct, 2)}%` }}
                                 />
                               </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,7 +39,9 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Nav />
-        <main className="mx-auto max-w-7xl px-6 py-8">{children}</main>
+        <main className="mx-auto min-w-0 max-w-7xl px-4 py-6 sm:px-6 sm:py-8">
+          {children}
+        </main>
         <Analytics />
       </body>
     </html>

--- a/src/components/date-range-picker.tsx
+++ b/src/components/date-range-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useId } from "react";
 
 interface DateRangePickerProps {
   startDate: string;
@@ -69,14 +69,8 @@ export function DateRangePicker({
   const [draftStart, setDraftStart] = useState(startDate);
   const [draftEnd, setDraftEnd] = useState(endDate);
   const ref = useRef<HTMLDivElement>(null);
-
-  // Sync draft with props when dropdown opens
-  useEffect(() => {
-    if (open) {
-      setDraftStart(startDate);
-      setDraftEnd(endDate);
-    }
-  }, [open, startDate, endDate]);
+  const triggerId = useId();
+  const panelId = useId();
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
@@ -98,21 +92,45 @@ export function DateRangePicker({
     setOpen(false);
   }
 
+  function toggleOpen() {
+    if (!open) {
+      setDraftStart(startDate);
+      setDraftEnd(endDate);
+    }
+    setOpen(!open);
+  }
+
   return (
-    <div ref={ref} className="relative">
-      <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
+    <div
+      ref={ref}
+      className="relative w-full min-w-0 sm:w-auto"
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && open) {
+          event.stopPropagation();
+          setOpen(false);
+        }
+      }}
+    >
+      <label
+        htmlFor={triggerId}
+        className="mb-1 block text-xs font-medium tracking-[0.01em] text-zinc-500 dark:text-zinc-400"
+      >
         Time Range
       </label>
       <button
+        id={triggerId}
         type="button"
-        onClick={() => setOpen(!open)}
-        className="flex w-64 items-center justify-between rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-left text-sm dark:border-zinc-700 dark:bg-zinc-900"
+        onClick={toggleOpen}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        className="dashboard-control flex w-full items-center justify-between rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-left text-sm shadow-sm hover:border-zinc-300 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-600 sm:w-64"
       >
-        <span className={startDate ? "" : "text-zinc-400"}>
+        <span className={`min-w-0 truncate ${startDate ? "" : "text-zinc-400"}`}>
           {displayLabel}
         </span>
         <svg
-          className={`ml-2 h-4 w-4 text-zinc-400 transition-transform ${open ? "rotate-180" : ""}`}
+          className={`ml-2 h-4 w-4 shrink-0 text-zinc-400 transition-transform duration-150 ease-[var(--ease-out)] motion-reduce:transition-none ${open ? "rotate-180" : ""}`}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -122,7 +140,12 @@ export function DateRangePicker({
         </svg>
       </button>
       {open && (
-        <div className="absolute z-50 mt-1 w-72 rounded-md border border-zinc-200 bg-white p-4 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+        <div
+          id={panelId}
+          role="dialog"
+          aria-label="Choose time range"
+          className="dashboard-popover absolute left-0 z-50 mt-1 w-full min-w-72 rounded-lg border border-black/10 bg-white p-4 shadow-[0_16px_40px_rgba(0,0,0,0.14)] dark:border-white/10 dark:bg-zinc-900 dark:shadow-[0_20px_50px_rgba(0,0,0,0.45)] sm:w-72"
+        >
           <div className="mb-3 flex flex-wrap gap-2">
             {PRESETS.map((preset) => {
               // Check if this preset matches the current draft
@@ -151,7 +174,7 @@ export function DateRangePicker({
                       setDraftEnd(formatDate(new Date()));
                     }
                   }}
-                  className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                  className={`dashboard-control rounded-md px-2.5 py-1 text-xs font-medium ${
                     isActive
                       ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                       : "border border-zinc-200 hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
@@ -162,7 +185,7 @@ export function DateRangePicker({
               );
             })}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
             <div className="flex-1">
               <label className="mb-1 block text-xs text-zinc-500 dark:text-zinc-400">
                 From
@@ -200,7 +223,7 @@ export function DateRangePicker({
             <button
               type="button"
               onClick={() => applyAndClose(draftStart, draftEnd)}
-              className="rounded-md bg-zinc-900 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
+              className="dashboard-control rounded-md bg-zinc-900 px-3 py-1 text-xs font-medium text-white hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
             >
               Apply
             </button>

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useId } from "react";
 
 interface MultiSelectProps {
   label: string;
@@ -21,6 +21,8 @@ export function MultiSelect({
   const [search, setSearch] = useState("");
   const ref = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const triggerId = useId();
+  const listboxId = useId();
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
@@ -71,20 +73,37 @@ export function MultiSelect({
         : `${selected.size} groups`;
 
   return (
-    <div ref={ref} className="relative">
-      <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
+    <div
+      ref={ref}
+      className="relative w-full min-w-0 sm:w-auto"
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && open) {
+          event.stopPropagation();
+          setOpen(false);
+          setSearch("");
+        }
+      }}
+    >
+      <label
+        htmlFor={triggerId}
+        className="mb-1 block text-xs font-medium tracking-[0.01em] text-zinc-500 dark:text-zinc-400"
+      >
         {label}
       </label>
       <button
+        id={triggerId}
         type="button"
         onClick={() => setOpen(!open)}
-        className="flex w-48 items-center justify-between rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-left text-sm dark:border-zinc-700 dark:bg-zinc-900"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        className="dashboard-control flex w-full items-center justify-between rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-left text-sm shadow-sm hover:border-zinc-300 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-600 sm:w-48"
       >
-        <span className={selected.size === 0 ? "text-zinc-400" : "truncate"}>
+        <span className={`min-w-0 truncate ${selected.size === 0 ? "text-zinc-400" : ""}`}>
           {buttonLabel}
         </span>
         <svg
-          className={`ml-2 h-4 w-4 flex-shrink-0 text-zinc-400 transition-transform ${open ? "rotate-180" : ""}`}
+          className={`ml-2 h-4 w-4 shrink-0 text-zinc-400 transition-transform duration-150 ease-[var(--ease-out)] motion-reduce:transition-none ${open ? "rotate-180" : ""}`}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -94,7 +113,7 @@ export function MultiSelect({
         </svg>
       </button>
       {open && (
-        <div className="absolute z-50 mt-1 w-72 rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+        <div className="dashboard-popover absolute left-0 z-50 mt-1 w-full min-w-64 rounded-lg border border-black/10 bg-white shadow-[0_16px_40px_rgba(0,0,0,0.14)] dark:border-white/10 dark:bg-zinc-900 dark:shadow-[0_20px_50px_rgba(0,0,0,0.45)] sm:w-72">
           <div className="border-b border-zinc-200 p-2 dark:border-zinc-700">
             <input
               ref={inputRef}
@@ -102,7 +121,8 @@ export function MultiSelect({
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search groups..."
-              className="w-full rounded border border-zinc-200 bg-zinc-50 px-2.5 py-1.5 text-sm outline-none focus:border-blue-400 dark:border-zinc-700 dark:bg-zinc-800"
+              aria-label={`Search ${label.toLowerCase()}`}
+              className="w-full rounded-md border border-zinc-200 bg-zinc-50 px-2.5 py-1.5 text-sm outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-500/15 dark:border-zinc-700 dark:bg-zinc-800"
             />
           </div>
           <div className="border-b border-zinc-200 px-3 py-1.5 dark:border-zinc-700">
@@ -124,11 +144,19 @@ export function MultiSelect({
               </button>
             </div>
           </div>
-          <ul className="max-h-60 overflow-y-auto py-1">
+          <ul
+            id={listboxId}
+            role="listbox"
+            aria-label={label}
+            aria-multiselectable="true"
+            className="max-h-60 overflow-y-auto py-1"
+          >
             {filtered.map((option) => (
               <li key={option}>
                 <button
                   type="button"
+                  role="option"
+                  aria-selected={selected.has(option)}
                   onClick={() => toggle(option)}
                   className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800"
                 >

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -18,36 +19,85 @@ const links = [
 
 export function Nav() {
   const pathname = usePathname();
+  const mobileNavRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = mobileNavRef.current;
+    const activeLink = mobileNavRef.current?.querySelector<HTMLElement>(
+      '[aria-current="page"]',
+    );
+    if (!container || !activeLink) return;
+
+    const leftEdge = activeLink.offsetLeft;
+    const rightEdge = leftEdge + activeLink.offsetWidth;
+    if (leftEdge < container.scrollLeft) {
+      container.scrollLeft = Math.max(0, leftEdge - 16);
+    } else if (rightEdge > container.scrollLeft + container.clientWidth) {
+      container.scrollLeft = rightEdge - container.clientWidth + 16;
+    }
+  }, [pathname]);
+
+  function isActive(href: string): boolean {
+    return href === "/"
+      ? pathname === "/"
+      : pathname === href || pathname.startsWith(`${href}/`);
+  }
 
   return (
-    <nav className="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
-      <div className="mx-auto flex h-14 max-w-7xl items-center gap-8 px-6">
-        <Link href="/" className="text-lg font-semibold tracking-tight">
-          vLLM Dashboard
-        </Link>
-        <div className="flex gap-1">
+    <nav className="dashboard-nav sticky top-0 z-50 border-b border-black/5 shadow-[0_1px_0_rgba(0,0,0,0.02)] dark:border-white/10">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6">
+        <div className="flex h-14 items-center gap-6">
+          <Link
+            href="/"
+            className="shrink-0 whitespace-nowrap text-base font-semibold tracking-[-0.02em] sm:text-lg"
+          >
+            vLLM Dashboard
+          </Link>
+          <div className="hidden min-w-0 flex-1 items-center gap-1 lg:flex">
+            {links.map((link) => {
+              const active = isActive(link.href);
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  aria-current={active ? "page" : undefined}
+                  className={`whitespace-nowrap rounded-md px-2.5 py-1.5 text-sm font-medium ${
+                    active
+                      ? "bg-zinc-950/[0.06] text-zinc-950 shadow-sm ring-1 ring-black/[0.04] dark:bg-white/10 dark:text-zinc-50 dark:ring-white/10"
+                      : "text-zinc-500 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-zinc-50"
+                  }`}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </div>
+          <div className="ml-auto shrink-0">
+            <ThemeToggle />
+          </div>
+        </div>
+        <div
+          ref={mobileNavRef}
+          className="scrollbar-hidden -mx-4 flex gap-1 overflow-x-auto px-4 pb-2 lg:hidden"
+          aria-label="Dashboard sections"
+        >
           {links.map((link) => {
-            const active =
-              link.href === "/"
-                ? pathname === "/"
-                : pathname === link.href || pathname.startsWith(`${link.href}/`);
+            const active = isActive(link.href);
             return (
               <Link
                 key={link.href}
                 href={link.href}
-                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                aria-current={active ? "page" : undefined}
+                className={`shrink-0 rounded-md px-2.5 py-1.5 text-sm font-medium ${
                   active
-                    ? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100"
-                    : "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                    ? "bg-zinc-950/[0.07] text-zinc-950 shadow-sm ring-1 ring-black/[0.04] dark:bg-white/10 dark:text-zinc-50 dark:ring-white/10"
+                    : "text-zinc-500 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-zinc-50"
                 }`}
               >
                 {link.label}
               </Link>
             );
           })}
-        </div>
-        <div className="ml-auto">
-          <ThemeToggle />
         </div>
       </div>
     </nav>

--- a/src/components/searchable-select.tsx
+++ b/src/components/searchable-select.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useId } from "react";
 
 interface SearchableSelectProps {
   label: string;
@@ -24,6 +24,8 @@ export function SearchableSelect({
   const [search, setSearch] = useState("");
   const ref = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const triggerId = useId();
+  const listboxId = useId();
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
@@ -63,21 +65,38 @@ export function SearchableSelect({
         });
 
   return (
-    <div ref={ref} className="relative">
-      <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
+    <div
+      ref={ref}
+      className="relative w-full min-w-0 sm:w-auto"
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && open) {
+          event.stopPropagation();
+          setOpen(false);
+          setSearch("");
+        }
+      }}
+    >
+      <label
+        htmlFor={triggerId}
+        className="mb-1 block text-xs font-medium tracking-[0.01em] text-zinc-500 dark:text-zinc-400"
+      >
         {label}
       </label>
       <button
+        id={triggerId}
         type="button"
         onClick={() => setOpen(!open)}
         title={value || allLabel}
-        className="flex w-48 items-center justify-between rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-left text-sm dark:border-zinc-700 dark:bg-zinc-900"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        className="dashboard-control flex w-full items-center justify-between rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-left text-sm shadow-sm hover:border-zinc-300 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-600 sm:w-48"
       >
         <span className={`min-w-0 truncate ${value ? "" : "text-zinc-400"}`}>
           {value || allLabel}
         </span>
         <svg
-          className={`ml-2 h-4 w-4 text-zinc-400 transition-transform ${open ? "rotate-180" : ""}`}
+          className={`ml-2 h-4 w-4 shrink-0 text-zinc-400 transition-transform duration-150 ease-[var(--ease-out)] motion-reduce:transition-none ${open ? "rotate-180" : ""}`}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -87,7 +106,7 @@ export function SearchableSelect({
         </svg>
       </button>
       {open && (
-        <div className="absolute z-50 mt-1 w-64 rounded-md border border-zinc-200 bg-white shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+        <div className="dashboard-popover absolute left-0 z-50 mt-1 w-full min-w-64 rounded-lg border border-black/10 bg-white shadow-[0_16px_40px_rgba(0,0,0,0.14)] dark:border-white/10 dark:bg-zinc-900 dark:shadow-[0_20px_50px_rgba(0,0,0,0.45)] sm:w-64">
           <div className="border-b border-zinc-200 p-2 dark:border-zinc-700">
             <input
               ref={inputRef}
@@ -95,14 +114,22 @@ export function SearchableSelect({
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder={`Search ${label.toLowerCase()}...`}
-              className="w-full rounded border border-zinc-200 bg-zinc-50 px-2.5 py-1.5 text-sm outline-none focus:border-blue-400 dark:border-zinc-700 dark:bg-zinc-800"
+              aria-label={`Search ${label.toLowerCase()}`}
+              className="w-full rounded-md border border-zinc-200 bg-zinc-50 px-2.5 py-1.5 text-sm outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-500/15 dark:border-zinc-700 dark:bg-zinc-800"
             />
           </div>
-          <ul className="max-h-60 overflow-y-auto py-1">
+          <ul
+            id={listboxId}
+            role="listbox"
+            aria-label={label}
+            className="max-h-60 overflow-y-auto py-1"
+          >
             {allLabel && (
               <li>
                 <button
                   type="button"
+                  role="option"
+                  aria-selected={!value}
                   onClick={() => {
                     onChange("");
                     setOpen(false);
@@ -120,6 +147,8 @@ export function SearchableSelect({
               <li key={option}>
                 <button
                   type="button"
+                  role="option"
+                  aria-selected={value === option}
                   onClick={() => {
                     onChange(option);
                     setOpen(false);


### PR DESCRIPTION
## What changed
- Added a sticky translucent navigation bar with a compact, horizontally scrollable mobile layout.
- Refined typography, surfaces, focus treatment, and control feedback with system-native styling.
- Made filters, date controls, GPU cards, and tables responsive at narrow viewport widths.
- Improved select, listbox, dialog, and active-route accessibility semantics.
- Added restrained popover and press motion with reduced-motion, reduced-transparency, and increased-contrast fallbacks.

## Why
The dashboard had desktop-first navigation and controls that became cramped or overflowed on mobile. Interactive states and motion were inconsistent, and several controls lacked complete accessibility semantics.

## Impact
The dashboard now has a calmer, more polished visual system, clearer interaction feedback, and a usable 390px mobile layout without page-level horizontal overflow.

## Validation
- `npx eslint src/app/gpu/gpu-dashboard.tsx src/app/layout.tsx src/components/date-range-picker.tsx src/components/multi-select.tsx src/components/nav.tsx src/components/searchable-select.tsx`
- `npm run build`
- `git diff --check`
- Browser verification at 1440×1100 and 390px
- Popover ARIA state, bounds, and transition timing inspection