### PR TITLE
Make dashboard data feel instant

### DIFF
--- a/src/app/api/builds/filters/route.ts
+++ b/src/app/api/builds/filters/route.ts
@@ -1,14 +1,16 @@
 import { NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 
 const TTL = 300_000;
+const CDN_CACHE = { maxAge: 300, staleWhileRevalidate: 86_400 };
 
 export async function GET() {
   try {
     const cacheKey = "builds:filters";
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     const [pipelines, branches] = await Promise.all([
       queryDatabricks(`
@@ -32,7 +34,7 @@ export async function GET() {
     };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to fetch filters:", error);
     return NextResponse.json(

--- a/src/app/api/builds/route.ts
+++ b/src/app/api/builds/route.ts
@@ -2,9 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { aggregateJobsByGroup, resolveGroupsToJobConditions } from "@/lib/test-groups";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 
 const PAGE_SIZE = 50;
 const TTL = 30_000;
+const CDN_CACHE = { maxAge: 60, staleWhileRevalidate: 3_600 };
 
 function buildJobFilterSubquery(jobGroups: string[], jobNames: string[]): string {
   const nameConditions: string[] = [];
@@ -51,7 +53,7 @@ export async function GET(request: NextRequest) {
 
     const cacheKey = `builds:${pipeline}:${branch}:${startDate}:${endDate}:${page}:${jobGroups.join(",")}:${jobNames.join(",")}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     // Build WHERE clauses
     const conditions = ["b._fivetran_deleted = false"];
@@ -126,7 +128,7 @@ export async function GET(request: NextRequest) {
 
     // Second: fetch jobs only for the builds on this page
     const buildIds = builds.map((b) => (b as Record<string, unknown>).id as string);
-    let jobsByBuild = new Map<string, { name: string; state: string; web_url?: string }[]>();
+    const jobsByBuild = new Map<string, { name: string; state: string; web_url?: string }[]>();
 
     if (buildIds.length > 0) {
       const idList = buildIds.map((id) => `'${id}'`).join(",");
@@ -181,7 +183,7 @@ export async function GET(request: NextRequest) {
     };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to fetch builds:", error);
     return NextResponse.json(

--- a/src/app/api/compare/route.ts
+++ b/src/app/api/compare/route.ts
@@ -9,6 +9,9 @@ import {
   sortDeltas,
 } from "@/lib/compare";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
+
+const CDN_CACHE = { maxAge: 300, staleWhileRevalidate: 3_600 };
 
 export async function GET(request: NextRequest) {
   try {
@@ -30,7 +33,7 @@ export async function GET(request: NextRequest) {
 
     const cacheKey = `compare:${baseline}:${candidate}:${model}:${device}:${task}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     const [perfRows, evalRows] = await Promise.all([
       loadPerfRows({ baseline, candidate, model, device }),
@@ -67,7 +70,7 @@ export async function GET(request: NextRequest) {
     };
     setCache(cacheKey, result, 60_000);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to compare images:", error);
     return NextResponse.json(

--- a/src/app/api/cost/route.ts
+++ b/src/app/api/cost/route.ts
@@ -2,9 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getQueueCost } from "@/lib/queue-costs";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 
 export const maxDuration = 55;
 const TTL = 60_000;
+const CDN_CACHE = { maxAge: 120, staleWhileRevalidate: 3_600 };
 
 export async function GET(request: NextRequest) {
   try {
@@ -16,7 +18,7 @@ export async function GET(request: NextRequest) {
 
     const cacheKey = `cost:${pipeline}:${branch}:${startDate}:${endDate}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     const conditions = [
       "j._fivetran_deleted = false",
@@ -191,7 +193,7 @@ export async function GET(request: NextRequest) {
     };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to fetch cost data:", error);
     return NextResponse.json(

--- a/src/app/api/eval/filters/route.ts
+++ b/src/app/api/eval/filters/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { resolveEvalImage } from "@/lib/eval-images";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 
 interface RawRow {
   m: string;
@@ -30,6 +31,7 @@ function parseDateParam(s: string | null): number | null {
 }
 
 const TTL = 300_000;
+const CDN_CACHE = { maxAge: 600, staleWhileRevalidate: 86_400 };
 
 export async function GET(request: Request) {
   try {
@@ -44,7 +46,7 @@ export async function GET(request: Request) {
 
     const cacheKey = `eval:filters:${searchParams.get("start")}:${searchParams.get("end")}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     const conditions = [
       "(message:results IS NOT NULL OR message:data:results IS NOT NULL)",
@@ -113,7 +115,7 @@ export async function GET(request: Request) {
     };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to fetch eval filters:", error);
     return NextResponse.json(

--- a/src/app/api/eval/route.ts
+++ b/src/app/api/eval/route.ts
@@ -1,15 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { loadEvalRows } from "@/lib/eval-data";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 
 const TTL = 60_000;
+const CDN_CACHE = { maxAge: 300, staleWhileRevalidate: 3_600 };
 
 export async function GET(request: NextRequest) {
   try {
     const sp = request.nextUrl.searchParams;
     const cacheKey = `eval:${sp.get("model")}:${sp.get("task")}:${sp.get("image")}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     const rows = await loadEvalRows({
       model: sp.get("model"),
@@ -20,7 +22,7 @@ export async function GET(request: NextRequest) {
     const result = { rows };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to fetch eval data:", error);
     return NextResponse.json(

--- a/src/app/api/eval/samples/route.ts
+++ b/src/app/api/eval/samples/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 
 export interface EvalSample {
   doc_id: number;
@@ -84,7 +85,12 @@ export async function GET(request: NextRequest) {
 
     const cacheKey = `eval:samples:${buildId}:${taskParam}:${workloadParam}:${correct}:${limit}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) {
+      return cachedJson(cached, {
+        maxAge: 300,
+        staleWhileRevalidate: 3_600,
+      });
+    }
 
     const escBuild = buildId.replace(/'/g, "''");
     const escTask = taskParam ? taskParam.replace(/'/g, "''") : null;
@@ -169,7 +175,10 @@ export async function GET(request: NextRequest) {
     };
     setCache(cacheKey, result, 60_000);
 
-    return NextResponse.json(result);
+    return cachedJson(result, {
+      maxAge: 300,
+      staleWhileRevalidate: 3_600,
+    });
   } catch (error) {
     console.error("Failed to fetch eval samples:", error);
     return NextResponse.json(

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 
 const TTL = 60_000;
+const CDN_CACHE = { maxAge: 60, staleWhileRevalidate: 3_600 };
 
 export async function GET(request: NextRequest) {
   try {
@@ -14,7 +16,7 @@ export async function GET(request: NextRequest) {
 
     const cacheKey = `jobs:${pipeline}:${branch}:${startDate}:${endDate}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     const conditions = [
       "j._fivetran_deleted = false",
@@ -86,7 +88,7 @@ export async function GET(request: NextRequest) {
     const result = { failureRanking, durationStats };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to fetch job stats:", error);
     return NextResponse.json(

--- a/src/app/api/jobs/runs/route.ts
+++ b/src/app/api/jobs/runs/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 
 const TTL = 60_000;
+const CDN_CACHE = { maxAge: 60, staleWhileRevalidate: 3_600 };
 
 export async function GET(request: NextRequest) {
   try {
@@ -19,7 +21,7 @@ export async function GET(request: NextRequest) {
 
     const cacheKey = `jobs:runs:${jobName}:${pipeline}:${branch}:${startDate}:${endDate}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     const conditions = [
       "j._fivetran_deleted = false",
@@ -61,7 +63,7 @@ export async function GET(request: NextRequest) {
     const result = { runs };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to fetch job runs:", error);
     return NextResponse.json(

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 
 const TTL = 15_000;
+const CDN_CACHE = { maxAge: 15, staleWhileRevalidate: 3_600 };
 
 export async function GET(request: NextRequest) {
   try {
@@ -15,7 +17,7 @@ export async function GET(request: NextRequest) {
     const queue = searchParams.get("queue") || null;
     const cacheKey = `metrics:${hours}:${queue ?? "all"}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     const cutoff = new Date(Date.now() - hours * 3600 * 1000);
     const latestCutoff = new Date(Date.now() - 2 * 3600 * 1000);
@@ -121,7 +123,7 @@ export async function GET(request: NextRequest) {
     };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to fetch metrics:", error);
     return NextResponse.json(

--- a/src/app/api/metrics/waiting-builds/route.ts
+++ b/src/app/api/metrics/waiting-builds/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 
 const TTL = 60_000;
+const CDN_CACHE = { maxAge: 30, staleWhileRevalidate: 3_600 };
 
 export async function GET(request: NextRequest) {
   const queue = request.nextUrl.searchParams.get("queue");
@@ -12,15 +14,11 @@ export async function GET(request: NextRequest) {
 
   const cacheKey = `waiting-builds:${queue}`;
   const cached = getCached(cacheKey);
-  if (cached) return NextResponse.json(cached);
+  if (cached) return cachedJson(cached, CDN_CACHE);
 
   try {
     const rows = await queryDatabricks(`
-      SELECT
-        w.build_number, w.build_url, w.message, w.author,
-        w.waiting_jobs, w.max_wait_min,
-        t.total_jobs
-      FROM (
+      WITH waiting AS (
         SELECT
           b.number AS build_number,
           b.web_url AS build_url,
@@ -43,20 +41,34 @@ export async function GET(request: NextRequest) {
         GROUP BY b.number, b.web_url, b.message, b.github_author_name, b.id
         ORDER BY waiting_jobs DESC
         LIMIT 5
-      ) w
-      INNER JOIN (
-        SELECT build_id, COUNT(*) AS total_jobs
-        FROM vllm_data_warehouse.buildkite.build_job
-        WHERE _fivetran_deleted = false AND type = 'script'
-        GROUP BY build_id
-      ) t ON w.build_id = t.build_id
+      )
+      SELECT
+        w.build_number,
+        w.build_url,
+        w.message,
+        w.author,
+        w.waiting_jobs,
+        w.max_wait_min,
+        COUNT(t.id) AS total_jobs
+      FROM waiting AS w
+      INNER JOIN vllm_data_warehouse.buildkite.build_job AS t
+        ON w.build_id = t.build_id
+       AND t._fivetran_deleted = false
+       AND t.type = 'script'
+      GROUP BY
+        w.build_number,
+        w.build_url,
+        w.message,
+        w.author,
+        w.waiting_jobs,
+        w.max_wait_min
       ORDER BY w.waiting_jobs DESC
     `);
 
     const result = { builds: rows };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to fetch waiting builds:", error);
     return NextResponse.json(

--- a/src/app/api/nightly/route.ts
+++ b/src/app/api/nightly/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { loadEvalRows, type EvalRow } from "@/lib/eval-data";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 import {
   buildSummary,
   compareEvalRows,
@@ -360,6 +361,7 @@ function groupEvalByImage(rows: EvalRow[]): Map<string, EvalRow[]> {
 }
 
 const TTL = 60_000;
+const CDN_CACHE = { maxAge: 300, staleWhileRevalidate: 3_600 };
 
 export async function GET(request: NextRequest) {
   try {
@@ -373,11 +375,14 @@ export async function GET(request: NextRequest) {
 
     const cacheKey = `nightly:${limit}:${perfThreshold}:${evalSigma}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     const nightlies = await loadNightlies(limit + 1);
     if (nightlies.length === 0) {
-      return NextResponse.json({ nightlies: [], generatedAt: new Date().toISOString() });
+      return cachedJson(
+        { nightlies: [], generatedAt: new Date().toISOString() },
+        CDN_CACHE,
+      );
     }
 
     const allSourceImages = [...new Set(nightlies.map((n) => n.sourceImage))];
@@ -494,7 +499,7 @@ export async function GET(request: NextRequest) {
     };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to load nightly summary:", error);
     return NextResponse.json(

--- a/src/app/api/perf/filters/route.ts
+++ b/src/app/api/perf/filters/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 import {
   perfDataStartCondition,
   resolvePerfDataStartDate,
 } from "@/lib/perf-data";
 
 const TTL = 300_000;
+const CDN_CACHE = { maxAge: 600, staleWhileRevalidate: 86_400 };
 
 function isIsoDate(s: string): boolean {
   return /^\d{4}-\d{2}-\d{2}/.test(s);
@@ -20,7 +22,7 @@ export async function GET(request: Request) {
 
     const cacheKey = `perf:filters:${startDate}:${end}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     const conditions = [
       "message:model IS NOT NULL",
@@ -76,7 +78,7 @@ export async function GET(request: Request) {
     const result = { models, modelCounts, devices, tps, concs, precisions, images };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to fetch perf filters:", error);
     return NextResponse.json({ error: "Failed to fetch filters" }, { status: 500 });

--- a/src/app/api/perf/route.ts
+++ b/src/app/api/perf/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 import {
   perfDataStartCondition,
   resolvePerfDataStartDate,
@@ -9,6 +10,7 @@ import {
 // Perf data refreshes at most nightly, so a longer cache keeps repeat loads
 // instant without serving stale numbers.
 const TTL = 300_000;
+const CDN_CACHE = { maxAge: 300, staleWhileRevalidate: 3_600 };
 
 export async function GET(request: NextRequest) {
   try {
@@ -21,7 +23,7 @@ export async function GET(request: NextRequest) {
 
     const cacheKey = `perf:${startDate}:${model}:${device}:${tp}:${conc}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     const conditions = [
       "message:model IS NOT NULL",
@@ -68,7 +70,7 @@ export async function GET(request: NextRequest) {
     const result = { rows };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to fetch perf data:", error);
     return NextResponse.json({ error: "Failed to fetch performance data" }, { status: 500 });

--- a/src/app/api/queue/route.ts
+++ b/src/app/api/queue/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
 
 const TTL = 60_000;
+const CDN_CACHE = { maxAge: 60, staleWhileRevalidate: 3_600 };
 
 export async function GET(request: NextRequest) {
   try {
@@ -14,7 +16,7 @@ export async function GET(request: NextRequest) {
 
     const cacheKey = `queue:${pipeline}:${queue}:${startDate}:${endDate}`;
     const cached = getCached(cacheKey);
-    if (cached) return NextResponse.json(cached);
+    if (cached) return cachedJson(cached, CDN_CACHE);
 
     const conditions = [
       "j._fivetran_deleted = false",
@@ -125,7 +127,7 @@ export async function GET(request: NextRequest) {
     };
     setCache(cacheKey, result, TTL);
 
-    return NextResponse.json(result);
+    return cachedJson(result, CDN_CACHE);
   } catch (error) {
     console.error("Failed to fetch queue data:", error);
     return NextResponse.json(

--- a/src/app/compare/compare-content.tsx
+++ b/src/app/compare/compare-content.tsx
@@ -1358,7 +1358,7 @@ export default function ComparePage() {
   const { data, error, isLoading } = useSWR<CompareResponse>(
     compareUrl,
     fetcher,
-    { refreshInterval: 10 * 60 * 1000 }
+    { refreshInterval: 10 * 60 * 1000, keepPreviousData: true }
   );
 
   const classifiedPerf = useMemo(
@@ -1572,7 +1572,7 @@ export default function ComparePage() {
         </div>
       )}
 
-      {compareUrl && isLoading && (
+      {compareUrl && isLoading && !data && (
         <div className="flex h-64 items-center justify-center gap-3">
           <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600 dark:border-zinc-600 dark:border-t-zinc-300" />
           <span className="text-sm text-zinc-400">Comparing images...</span>
@@ -1585,7 +1585,7 @@ export default function ComparePage() {
         </div>
       )}
 
-      {data && !isLoading && (
+      {data && (
         <>
           <VerdictHero
             summary={derivedSummary}

--- a/src/app/cost/page.tsx
+++ b/src/app/cost/page.tsx
@@ -188,6 +188,7 @@ export default function CostPage() {
   const { data: filters } = useSWR<FiltersResponse>("/api/builds/filters", fetcher);
   const { data, error, isLoading } = useSWR<CostResponse>(apiUrl, fetcher, {
     refreshInterval: 5 * 60 * 1000,
+    keepPreviousData: true,
   });
 
   // Build stacked chart data
@@ -232,7 +233,7 @@ export default function CostPage() {
     return { stackedData: chartData, queues: allQueues, queueColors: colors, dayCount: chartData.length };
   }, [data, seriesMode]);
 
-  if (isLoading) {
+  if (isLoading && !data) {
     return (
       <div className="flex h-64 items-center justify-center text-zinc-400">
         Loading cost data...

--- a/src/app/eval/page.tsx
+++ b/src/app/eval/page.tsx
@@ -961,10 +961,11 @@ export default function EvalPage() {
   const { data, isLoading } = useSWR<{ rows: EvalRow[] }>(
     `/api/eval?${params.toString()}`,
     fetcher,
-    { refreshInterval: 10 * 60 * 1000 }
+    { refreshInterval: 10 * 60 * 1000, keepPreviousData: true }
   );
 
   const rows = useMemo(() => data?.rows ?? [], [data?.rows]);
+  const showInitialLoading = isLoading && !data;
 
   return (
     <div className="space-y-5">
@@ -1002,14 +1003,14 @@ export default function EvalPage() {
         />
       </div>
 
-      {isLoading && (
+      {showInitialLoading && (
         <div className="flex h-64 items-center justify-center gap-3">
           <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600 dark:border-zinc-600 dark:border-t-zinc-300" />
           <span className="text-sm text-zinc-400">Loading evaluations...</span>
         </div>
       )}
 
-      {!isLoading && rows.length === 0 && (
+      {!showInitialLoading && rows.length === 0 && (
         <div className="flex h-64 items-center justify-center rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700">
           <span className="text-sm text-zinc-400">
             No evaluation runs found.
@@ -1017,7 +1018,7 @@ export default function EvalPage() {
         </div>
       )}
 
-      {!isLoading && rows.length > 0 && (
+      {!showInitialLoading && rows.length > 0 && (
         <>
           {!model && <EvaluationOverview rows={rows} />}
           {model && (

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -145,9 +145,10 @@ function JobAnalysisTab({
 
   const { data, error, isLoading } = useSWR<JobsResponse>(apiUrl, fetcher, {
     refreshInterval: 5 * 60 * 1000,
+    keepPreviousData: true,
   });
 
-  if (isLoading) {
+  if (isLoading && !data) {
     return (
       <div className="flex h-64 items-center justify-center text-zinc-400">
         Loading job statistics...

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,6 @@ import { BuildsTable, Build } from "@/components/builds-table";
 import { SearchableSelect } from "@/components/searchable-select";
 import { MultiSelect } from "@/components/multi-select";
 import { DateRangePicker } from "@/components/date-range-picker";
-import { isOptionalJob, isSoftFailJob } from "@/lib/optional-jobs";
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
@@ -68,6 +67,7 @@ export default function BuildsPage() {
 
   const { data, error, isLoading } = useSWR<BuildsResponse>(apiUrl, fetcher, {
     refreshInterval: 5 * 60 * 1000,
+    keepPreviousData: true,
   });
 
   const {
@@ -111,7 +111,7 @@ export default function BuildsPage() {
     return [...jobs].sort();
   }, [builds, selectedGroups]);
 
-  if (isLoading) {
+  if (isLoading && !data) {
     return (
       <div className="flex h-64 items-center justify-center text-zinc-400">
         Loading builds...

--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -76,6 +76,7 @@ export default function QueuePage() {
   const metricsUrl = `/api/metrics?hours=${metricsHours}${queue ? `&queue=${encodeURIComponent(queue)}` : ""}`;
   const { data: metricsData, error, isLoading } = useSWR<MetricsResponse>(metricsUrl, fetcher, {
     refreshInterval: 60 * 1000,
+    keepPreviousData: true,
   });
 
   interface WaitingBuild {
@@ -131,7 +132,7 @@ export default function QueuePage() {
     return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
   }
 
-  if (isLoading) {
+  if (isLoading && !metricsData) {
     return (
       <div className="flex h-64 items-center justify-center text-zinc-400">
         Loading queue data...

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { preload } from "swr";
 import { ThemeToggle } from "@/components/theme-toggle";
 
 const links = [
@@ -17,9 +18,93 @@ const links = [
   { href: "/compare", label: "Compare" },
 ];
 
+const prefetchedRoutes = new Set<string>();
+const fetcher = async (url: string) => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to prefetch ${url}: ${response.status}`);
+  }
+  return response.json();
+};
+
+function isoDateDaysAgo(days: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date.toISOString().slice(0, 10);
+}
+
+function defaultDataUrls(href: string): string[] {
+  const startDate = isoDateDaysAgo(14);
+  const endDate = isoDateDaysAgo(0);
+  const buildParams =
+    `pipeline=CI&branch=main&startDate=${startDate}&endDate=${endDate}`;
+
+  switch (href) {
+    case "/":
+      return [
+        `/api/builds?${buildParams}&page=0`,
+        "/api/builds/filters",
+      ];
+    case "/jobs":
+      return [
+        `/api/jobs?${buildParams}`,
+        "/api/builds/filters",
+      ];
+    case "/nightly":
+      return ["/api/nightly"];
+    case "/queue":
+      return [
+        "/api/metrics?hours=24&queue=gpu_1_queue",
+        "/api/metrics/waiting-builds?queue=gpu_1_queue",
+      ];
+    case "/cost":
+      return [
+        `/api/cost?pipeline=CI&startDate=${startDate}&endDate=${endDate}`,
+        "/api/builds/filters",
+      ];
+    case "/perf":
+      return ["/api/perf/filters?start=2026-06-14"];
+    case "/eval":
+      return ["/api/eval/filters", "/api/eval"];
+    case "/compare":
+      return [
+        "/api/perf/filters",
+        "/api/eval/filters",
+      ];
+    default:
+      return [];
+  }
+}
+
 export function Nav() {
   const pathname = usePathname();
   const mobileNavRef = useRef<HTMLDivElement>(null);
+  const prefetchTimerRef = useRef<number | null>(null);
+
+  function prefetchRouteData(href: string) {
+    if (prefetchedRoutes.has(href)) return;
+    prefetchedRoutes.add(href);
+    const requests = defaultDataUrls(href).map((url) => preload(url, fetcher));
+    void Promise.all(requests).catch(() => {
+      prefetchedRoutes.delete(href);
+    });
+  }
+
+  function scheduleRoutePrefetch(href: string) {
+    if (prefetchTimerRef.current !== null) {
+      window.clearTimeout(prefetchTimerRef.current);
+    }
+    prefetchTimerRef.current = window.setTimeout(() => {
+      prefetchTimerRef.current = null;
+      prefetchRouteData(href);
+    }, 100);
+  }
+
+  function cancelScheduledPrefetch() {
+    if (prefetchTimerRef.current === null) return;
+    window.clearTimeout(prefetchTimerRef.current);
+    prefetchTimerRef.current = null;
+  }
 
   useEffect(() => {
     const container = mobileNavRef.current;
@@ -36,6 +121,15 @@ export function Nav() {
       container.scrollLeft = rightEdge - container.clientWidth + 16;
     }
   }, [pathname]);
+
+  useEffect(
+    () => () => {
+      if (prefetchTimerRef.current !== null) {
+        window.clearTimeout(prefetchTimerRef.current);
+      }
+    },
+    [],
+  );
 
   function isActive(href: string): boolean {
     return href === "/"
@@ -61,6 +155,10 @@ export function Nav() {
                   key={link.href}
                   href={link.href}
                   aria-current={active ? "page" : undefined}
+                  onPointerEnter={() => scheduleRoutePrefetch(link.href)}
+                  onPointerLeave={cancelScheduledPrefetch}
+                  onFocus={() => prefetchRouteData(link.href)}
+                  onPointerDown={() => prefetchRouteData(link.href)}
                   className={`dashboard-control inline-flex min-h-10 items-center whitespace-nowrap rounded-md px-3 text-sm font-medium ${
                     active
                       ? "bg-zinc-950/[0.06] text-zinc-950 shadow-sm ring-1 ring-black/[0.04] dark:bg-white/10 dark:text-zinc-50 dark:ring-white/10"
@@ -88,6 +186,10 @@ export function Nav() {
                 key={link.href}
                 href={link.href}
                 aria-current={active ? "page" : undefined}
+                onPointerEnter={() => scheduleRoutePrefetch(link.href)}
+                onPointerLeave={cancelScheduledPrefetch}
+                onFocus={() => prefetchRouteData(link.href)}
+                onPointerDown={() => prefetchRouteData(link.href)}
                 className={`inline-flex min-h-11 shrink-0 items-center rounded-md px-3 py-2 text-sm font-medium ${
                   active
                     ? "bg-zinc-950/[0.07] text-zinc-950 shadow-sm ring-1 ring-black/[0.04] dark:bg-white/10 dark:text-zinc-50 dark:ring-white/10"

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+interface SharedCachePolicy {
+  maxAge: number;
+  staleWhileRevalidate: number;
+}
+
+/**
+ * Keep browser data fresh while letting Vercel's shared cache absorb cold
+ * serverless starts and expensive backend queries. Once fresh data expires,
+ * stale-while-revalidate serves the last useful response immediately and
+ * refreshes it in the background.
+ */
+export function cachedJson<T>(
+  data: T,
+  { maxAge, staleWhileRevalidate }: SharedCachePolicy,
+) {
+  return NextResponse.json(data, {
+    headers: {
+      "Cache-Control": "public, max-age=0, must-revalidate",
+      "Vercel-CDN-Cache-Control":
+        `public, s-maxage=${maxAge}, stale-while-revalidate=${staleWhileRevalidate}`,
+    },
+  });
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -8,7 +8,16 @@ export function getDb() {
     if (!url) {
       throw new Error("DATABASE_URL is not set");
     }
-    sql = postgres(url, { ssl: "require" });
+    sql = postgres(url, {
+      ssl: "require",
+      // Serverless instances should fail quickly and keep a deliberately small
+      // pool. The dashboard only fans out three PostgreSQL queries at once;
+      // larger per-instance pools amplify connection pressure during bursts.
+      max: 3,
+      connect_timeout: 10,
+      idle_timeout: 20,
+      max_lifetime: 10 * 60,
+    });
   }
   return sql;
 }


### PR DESCRIPTION
## What changed

- adds shared Vercel CDN caching with stale-while-revalidate to the read-heavy dashboard APIs
- serves the last useful response immediately while expensive Databricks/Postgres refreshes run in the background
- preloads each tab's exact default data after a deliberate 100ms hover, focus, or pointer-down
- keeps the current result visible when filters change instead of replacing the whole view with a loading state
- caps the serverless PostgreSQL pool at three connections and fails stalled connection attempts after 10 seconds
- rewrites the waiting-build total query so it counts jobs for only the five relevant builds instead of grouping the full job table

No application data is persisted to localStorage.

## Why

Production baselines showed:

- Builds data-ready: 3.28s
- Cost data-ready: 3.56s
- Nightly data-ready: 2.65s
- default API latency: 1.3–3.3s
- every non-GPU data request: Vercel CDN MISS with no shared cache policy
- queue metrics cold outlier: 76.7s, versus 160–200ms for the underlying warm PostgreSQL queries

The shell was not the bottleneck. Users were repeatedly paying serverless cold-start, database connection, and backend query time.

## Early result

With exact-key preload enabled locally:

- Cost navigation is 58ms and does not issue a duplicate request after navigation
- the production baseline for the same interaction was 1.17s even with a warm backend
- warm API responses across Builds, Jobs, Cost, Evaluation, Nightly, Queue, and Performance are 1–29ms before network latency
- all targeted routes emit the intended `Vercel-CDN-Cache-Control` policy

The Vercel preview is deployment-protected, so unauthenticated API probes receive 401. Production edge HIT/MISS timings will be captured immediately after approval and merge.

## Validation

- targeted ESLint across every changed file
- `npx tsc --noEmit`
- `npm run build`
- local header checks for `Vercel-CDN-Cache-Control`
- local PostgreSQL profiling against the 3M-row queue snapshot table
- automated Chromium navigation and data-ready measurements

The Vercel build, DCO, and preview deployment checks pass.
