### PR TITLE
Default Builds chart to Runs

### DIFF
--- a/src/components/build-chart.tsx
+++ b/src/components/build-chart.tsx
@@ -209,7 +209,7 @@ interface BuildChartProps {
 }
 
 export function BuildChart({ data, startDate, endDate }: BuildChartProps) {
-  const [mode, setMode] = useState<ChartMode>("overview");
+  const [mode, setMode] = useState<ChartMode>("runs");
   const rangeLabel =
     startDate && endDate ? `${startDate} — ${endDate}` : "All Time";
 


### PR DESCRIPTION
## Summary
- open the Builds chart on the per-run view by default
- keep the aggregated Overview available as the alternate mode

This restores pass/fail status as the primary chart signal while preserving the duration summary.

## Validation
- `npx eslint src/components/build-chart.tsx`
- `npx tsc --noEmit`
- `git diff --check`
- verified at 1440×1100 in light mode