### PR TITLE
Reshape dashboard bootstrap payloads

### DIFF
--- a/src/app/api/builds/groups/route.ts
+++ b/src/app/api/builds/groups/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { queryDatabricks } from "@/lib/databricks";
+import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
+import { aggregateJobsByGroup, type GroupStatus } from "@/lib/test-groups";
+
+const TTL = 30_000;
+const CDN_CACHE = { maxAge: 60, staleWhileRevalidate: 3_600 };
+const MAX_BUILD_IDS = 50;
+
+type GroupSummary = Omit<GroupStatus, "jobs">;
+
+function escapeSql(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const buildIds = [
+      ...new Set(
+        (request.nextUrl.searchParams.get("buildIds") ?? "")
+          .split(",")
+          .map((value) => value.trim())
+          .filter((value) => value.length > 0 && value.length <= 100),
+      ),
+    ].slice(0, MAX_BUILD_IDS);
+
+    if (buildIds.length === 0) {
+      return cachedJson(
+        { groupsByBuild: {}, jobOptions: [] },
+        CDN_CACHE,
+      );
+    }
+
+    const cacheKey = `build-groups:${buildIds.join(",")}`;
+    const cached = getCached(cacheKey);
+    if (cached) return cachedJson(cached, CDN_CACHE);
+
+    const idList = buildIds.map((id) => `'${escapeSql(id)}'`).join(",");
+    const jobs = await queryDatabricks(`
+      SELECT
+        j.build_id,
+        j.name,
+        j.state
+      FROM vllm_data_warehouse.buildkite.build_job AS j
+      WHERE j.build_id IN (${idList})
+        AND j._fivetran_deleted = false
+        AND j.type = 'script'
+        AND j.name IS NOT NULL
+    `);
+
+    const jobsByBuild = new Map<
+      string,
+      { name: string; state: string }[]
+    >();
+    for (const job of jobs) {
+      const row = job as Record<string, string>;
+      const buildJobs = jobsByBuild.get(row.build_id) ?? [];
+      buildJobs.push({ name: row.name, state: row.state });
+      jobsByBuild.set(row.build_id, buildJobs);
+    }
+
+    const groupsByBuild: Record<string, GroupSummary[]> = {};
+    const jobToGroup = new Map<string, string>();
+    for (const buildId of buildIds) {
+      const groups = aggregateJobsByGroup(jobsByBuild.get(buildId) ?? []);
+      groupsByBuild[buildId] = groups.map(({ jobs: groupJobs, ...summary }) => {
+        for (const job of groupJobs) {
+          if (!jobToGroup.has(job.name)) {
+            jobToGroup.set(job.name, summary.group);
+          }
+        }
+        return summary;
+      });
+    }
+
+    const result = {
+      groupsByBuild,
+      jobOptions: [...jobToGroup.entries()]
+        .map(([name, group]) => ({ name, group }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    };
+    setCache(cacheKey, result, TTL);
+
+    return cachedJson(result, CDN_CACHE);
+  } catch (error) {
+    console.error("Failed to fetch build group summaries:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch build group summaries" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/builds/jobs/route.ts
+++ b/src/app/api/builds/jobs/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { queryDatabricks } from "@/lib/databricks";
+import { getCached, setCache } from "@/lib/api-cache";
+import { cachedJson } from "@/lib/api-response";
+import { aggregateJobsByGroup, type JobInfo } from "@/lib/test-groups";
+
+const TTL = 30_000;
+const CDN_CACHE = { maxAge: 60, staleWhileRevalidate: 3_600 };
+const MAX_BUILD_IDS = 50;
+const MAX_GROUPS = 20;
+
+function escapeSql(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const buildIds = [
+      ...new Set(
+        (searchParams.get("buildIds") ?? "")
+          .split(",")
+          .map((value) => value.trim())
+          .filter((value) => value.length > 0 && value.length <= 100),
+      ),
+    ].slice(0, MAX_BUILD_IDS);
+    const groups = [
+      ...new Set(
+        (searchParams.get("groups") ?? "")
+          .split(",")
+          .map((value) => value.trim())
+          .filter((value) => value.length > 0 && value.length <= 200),
+      ),
+    ].slice(0, MAX_GROUPS);
+
+    if (buildIds.length === 0 || groups.length === 0) {
+      return cachedJson({ jobsByBuild: {} }, CDN_CACHE);
+    }
+
+    const cacheKey = `build-jobs:${buildIds.join(",")}:${groups.join(",")}`;
+    const cached = getCached(cacheKey);
+    if (cached) return cachedJson(cached, CDN_CACHE);
+
+    const idList = buildIds.map((id) => `'${escapeSql(id)}'`).join(",");
+    const jobs = await queryDatabricks(`
+      SELECT
+        j.build_id,
+        j.name,
+        j.state,
+        j.web_url
+      FROM vllm_data_warehouse.buildkite.build_job AS j
+      WHERE j.build_id IN (${idList})
+        AND j._fivetran_deleted = false
+        AND j.type = 'script'
+        AND j.name IS NOT NULL
+    `);
+
+    const rawJobsByBuild = new Map<
+      string,
+      { name: string; state: string; web_url?: string }[]
+    >();
+    for (const job of jobs) {
+      const row = job as Record<string, string>;
+      const buildJobs = rawJobsByBuild.get(row.build_id) ?? [];
+      buildJobs.push({
+        name: row.name,
+        state: row.state,
+        web_url: row.web_url,
+      });
+      rawJobsByBuild.set(row.build_id, buildJobs);
+    }
+
+    const groupSet = new Set(groups);
+    const jobsByBuild: Record<string, Record<string, JobInfo[]>> = {};
+    for (const buildId of buildIds) {
+      const grouped = aggregateJobsByGroup(rawJobsByBuild.get(buildId) ?? []);
+      jobsByBuild[buildId] = Object.fromEntries(
+        grouped
+          .filter((group) => groupSet.has(group.group))
+          .map((group) => [group.group, group.jobs]),
+      );
+    }
+
+    const result = { jobsByBuild };
+    setCache(cacheKey, result, TTL);
+    return cachedJson(result, CDN_CACHE);
+  } catch (error) {
+    console.error("Failed to fetch expanded build jobs:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch expanded build jobs" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/builds/route.ts
+++ b/src/app/api/builds/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
-import { aggregateJobsByGroup, resolveGroupsToJobConditions } from "@/lib/test-groups";
+import { resolveGroupsToJobConditions } from "@/lib/test-groups";
 import { getCached, setCache } from "@/lib/api-cache";
 import { cachedJson } from "@/lib/api-response";
 
@@ -126,46 +126,18 @@ export async function GET(request: NextRequest) {
       `),
     ]);
 
-    // Second: fetch jobs only for the builds on this page
-    const buildIds = builds.map((b) => (b as Record<string, unknown>).id as string);
-    const jobsByBuild = new Map<string, { name: string; state: string; web_url?: string }[]>();
-
-    if (buildIds.length > 0) {
-      const idList = buildIds.map((id) => `'${id}'`).join(",");
-      const jobs = await queryDatabricks(`
-        SELECT
-          j.build_id,
-          j.name,
-          j.state,
-          j.web_url
-        FROM vllm_data_warehouse.buildkite.build_job AS j
-        WHERE j.build_id IN (${idList})
-          AND j._fivetran_deleted = false
-          AND j.type = 'script'
-          AND j.name IS NOT NULL
-      `);
-
-      for (const job of jobs) {
-        const j = job as Record<string, string>;
-        if (!jobsByBuild.has(j.build_id)) {
-          jobsByBuild.set(j.build_id, []);
-        }
-        jobsByBuild.get(j.build_id)!.push({ name: j.name, state: j.state, web_url: j.web_url });
-      }
-    }
-
-    // Attach test group statuses and parse PR number from commit message
-    const buildsWithGroups = builds.map((build) => {
+    // Keep the bootstrap response focused on the chart, summary, and build
+    // rows. Group summaries and expanded job details are normalized behind
+    // dedicated endpoints so the first screen does not carry 10k+ nested jobs.
+    const buildsWithMetadata = builds.map((build) => {
       const b = build as Record<string, unknown>;
-      const buildJobs = jobsByBuild.get(b.id as string) ?? [];
-      const testGroups = aggregateJobsByGroup(buildJobs);
       // Parse PR number from commit message if not set (e.g. main branch)
       let prNumber = b.pr_number as string | null;
       if (!prNumber && b.message) {
         const match = (b.message as string).match(/\(#(\d+)\)/);
         if (match) prNumber = match[1];
       }
-      return { ...b, pr_number: prNumber, testGroups };
+      return { ...b, pr_number: prNumber };
     });
 
     const counts = countResult[0] as Record<string, string> ?? { total: "0", passed: "0", failed: "0" };
@@ -176,7 +148,7 @@ export async function GET(request: NextRequest) {
       passed + failed > 0 ? Math.round((passed / (passed + failed)) * 100) : 0;
 
     const result = {
-      builds: buildsWithGroups,
+      builds: buildsWithMetadata,
       buildDurations,
       summary: { total, passed, failed, passRate },
       pagination: { page, pageSize: PAGE_SIZE, totalPages: Math.ceil(total / PAGE_SIZE) },

--- a/src/app/api/nightly/route.ts
+++ b/src/app/api/nightly/route.ts
@@ -12,7 +12,6 @@ import {
   parseThreshold,
   sortDeltas,
   type CompareSummary,
-  type CoverageItem,
   type DeltaItem,
   type PerfRun,
 } from "@/lib/compare";
@@ -107,10 +106,6 @@ interface NightlyEntry {
     worstRegressions: DeltaItem[];
     perfDeltas: DeltaItem[];
     evalDeltas: DeltaItem[];
-    perfMissingBaseline: CoverageItem[];
-    perfMissingCandidate: CoverageItem[];
-    evalMissingBaseline: CoverageItem[];
-    evalMissingCandidate: CoverageItem[];
   };
 }
 
@@ -421,11 +416,6 @@ export async function GET(request: NextRequest) {
       let worstRegressions: DeltaItem[] = [];
       let perfDeltas: DeltaItem[] = [];
       let evalDeltas: DeltaItem[] = [];
-      let perfMissingBaseline: CoverageItem[] = [];
-      let perfMissingCandidate: CoverageItem[] = [];
-      let evalMissingBaseline: CoverageItem[] = [];
-      let evalMissingCandidate: CoverageItem[] = [];
-
       if (prev) {
         const candidatePerf = perfByImage.get(n.sourceImage) ?? [];
         const baselinePerf = perfByImage.get(prev.sourceImage) ?? [];
@@ -450,12 +440,11 @@ export async function GET(request: NextRequest) {
         worstRegressions = allDeltas
           .filter((d) => d.status === "regression")
           .slice(0, 5);
-        perfDeltas = perfResult.deltas.sort(sortDeltas);
-        evalDeltas = evalResult.deltas.sort(sortDeltas);
-        perfMissingBaseline = perfResult.missingBaseline;
-        perfMissingCandidate = perfResult.missingCandidate;
-        evalMissingBaseline = evalResult.missingBaseline;
-        evalMissingCandidate = evalResult.missingCandidate;
+        // The Nightly UI renders at most eight rows per section. Keep the
+        // complete comparison behind /compare instead of repeating hundreds
+        // of detail rows in every Nightly bootstrap entry.
+        perfDeltas = perfResult.deltas.sort(sortDeltas).slice(0, 8);
+        evalDeltas = evalResult.deltas.sort(sortDeltas).slice(0, 8);
       }
 
       entries.push({
@@ -484,10 +473,6 @@ export async function GET(request: NextRequest) {
           worstRegressions,
           perfDeltas,
           evalDeltas,
-          perfMissingBaseline,
-          perfMissingCandidate,
-          evalMissingBaseline,
-          evalMissingCandidate,
         },
       });
     }

--- a/src/app/eval/page.tsx
+++ b/src/app/eval/page.tsx
@@ -34,19 +34,14 @@ interface EvalRow {
   task: string;
   n_shot: number;
   n_samples: number;
-  version: number;
   git_hash: string | null;
-  lm_eval_version: string | null;
   eval_seconds: number;
   metrics: EvalMetric[];
-  config: Record<string, unknown>;
-  model_args: Record<string, unknown>;
   image: string | null;
   buildkite_build_id: string | null;
   buildkite_build_number: string | null;
   buildkite_build_url: string | null;
   buildkite_commit: string | null;
-  buildkite_branch: string | null;
   vllm_commit: string | null;
   workload: string | null;
 }

--- a/src/app/gpu/gpu-dashboard.tsx
+++ b/src/app/gpu/gpu-dashboard.tsx
@@ -9,6 +9,7 @@ import type {
   GpuHistoryResponse,
   GpuLatest,
   GpuLatestResponse,
+  GpuOverviewPoint,
 } from "@/lib/gpu-types";
 
 const GpuMemChart = dynamic(
@@ -42,6 +43,7 @@ const OVERVIEW_SERIES = [
   "High (P90)",
   "Peak",
 ] as const;
+const EMPTY_SNAPSHOTS: GpuHistoryResponse["snapshots"] = [];
 
 function percentile(values: number[], quantile: number): number {
   if (values.length === 0) return 0;
@@ -89,14 +91,14 @@ function gpuType(name: string | null): string {
 }
 
 interface GpuDashboardProps {
-  initialHistory: GpuHistoryResponse;
+  initialOverview: GpuOverviewPoint[];
   initialLatest: GpuLatest[];
   initialLatestCheckedAt: string;
   initialNow: number;
 }
 
 export function GpuDashboard({
-  initialHistory,
+  initialOverview,
   initialLatest,
   initialLatestCheckedAt,
   initialNow,
@@ -132,27 +134,34 @@ export function GpuDashboard({
     refreshInterval: 30_000,
   });
 
-  const historyUrl = `/api/gpu/history?hours=${hours}${
-    hostFilter ? `&hostname=${encodeURIComponent(hostFilter)}` : ""
-  }`;
+  const needsRawHistory =
+    hours !== 24 ||
+    Boolean(hostFilter) ||
+    Boolean(gpuTypeFilter) ||
+    chartMode !== "overview";
+  const historyUrl = needsRawHistory
+    ? `/api/gpu/history?hours=${hours}${
+        hostFilter ? `&hostname=${encodeURIComponent(hostFilter)}` : ""
+      }`
+    : null;
   const {
     data: historyData,
     error: historyError,
     isLoading: historyIsLoading,
     isValidating: historyIsValidating,
   } = useSWR<GpuHistoryResponse>(historyUrl, fetcher, {
-    fallbackData: hours === 24 && !hostFilter ? initialHistory : undefined,
     keepPreviousData: true,
-    revalidateOnMount:
-      initialHistory.snapshots.length === 0 || hours !== 24 || Boolean(hostFilter),
     refreshInterval: 60_000,
   });
 
   const latest = latestData?.latest ?? initialLatest;
   const latestCheckedAt = latestData?.checked_at ?? initialLatestCheckedAt;
-  const snapshots = historyData?.snapshots ?? initialHistory.snapshots;
-  const displayedHours = historyData?.hours ?? initialHistory.hours;
-  const historyPending = historyIsLoading || historyIsValidating;
+  const snapshots = needsRawHistory
+    ? historyData?.snapshots ?? EMPTY_SNAPSHOTS
+    : EMPTY_SNAPSHOTS;
+  const displayedHours = historyData?.hours ?? hours;
+  const historyPending =
+    needsRawHistory && (historyIsLoading || historyIsValidating);
 
   const gpuTypes = useMemo(() => {
     const types = new Set(latest.map((g) => gpuType(g.gpu_name)));
@@ -191,6 +200,23 @@ export function GpuDashboard({
   );
 
   const chartData = useMemo(() => {
+    if (
+      chartMode === "overview" &&
+      hours === 24 &&
+      !hostFilter &&
+      !gpuTypeFilter &&
+      snapshots.length === 0
+    ) {
+      return {
+        data: initialOverview.map((point) => ({
+          time: point.time,
+          [OVERVIEW_SERIES[0]]: point.p50,
+          [OVERVIEW_SERIES[1]]: point.p90,
+          [OVERVIEW_SERIES[2]]: point.peak,
+        })),
+        hosts: [...OVERVIEW_SERIES],
+      };
+    }
     if (snapshots.length === 0) return { data: [] as Array<Record<string, number>>, hosts: [] as string[] };
 
     const relevantHosts = new Set(filteredHosts);
@@ -261,7 +287,16 @@ export function GpuDashboard({
       data: rows,
       hosts: chartMode === "overview" ? overviewSeries : hosts,
     };
-  }, [snapshots, filteredHosts, gpuTypeFilter, chartMode, hostCapacityGb]);
+  }, [
+    snapshots,
+    filteredHosts,
+    gpuTypeFilter,
+    chartMode,
+    hostCapacityGb,
+    hours,
+    hostFilter,
+    initialOverview,
+  ]);
 
   const tickInterval = Math.max(1, Math.floor(chartData.data.length / 10));
 
@@ -314,7 +349,7 @@ export function GpuDashboard({
 
   return (
     <div className="space-y-6">
-      {historyError && snapshots.length === 0 && (
+      {needsRawHistory && historyError && snapshots.length === 0 && (
         <div className="rounded-md border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-400">
           GPU history could not be loaded. Current host readings may still be available below.
         </div>

--- a/src/app/gpu/page.tsx
+++ b/src/app/gpu/page.tsx
@@ -1,18 +1,18 @@
 import { GpuDashboard } from "@/app/gpu/gpu-dashboard";
 import { getInitialGpuData } from "@/lib/gpu-data";
-import type { GpuHistoryResponse, GpuLatest } from "@/lib/gpu-types";
+import type { GpuLatest, GpuOverviewPoint } from "@/lib/gpu-types";
 
 export const dynamic = "force-dynamic";
 
 export default async function GpuPage() {
-  let initialHistory: GpuHistoryResponse = { hours: 24, snapshots: [] };
+  let initialOverview: GpuOverviewPoint[] = [];
   let initialLatest: GpuLatest[] = [];
   let initialLatestCheckedAt = "";
   let initialNow = 0;
 
   try {
     const initial = await getInitialGpuData();
-    initialHistory = initial.history;
+    initialOverview = initial.overview;
     initialLatest = initial.latest;
     initialLatestCheckedAt = initial.latestCheckedAt;
     initialNow = initial.asOf;
@@ -22,7 +22,7 @@ export default async function GpuPage() {
 
   return (
     <GpuDashboard
-      initialHistory={initialHistory}
+      initialOverview={initialOverview}
       initialLatest={initialLatest}
       initialLatestCheckedAt={initialLatestCheckedAt}
       initialNow={initialNow}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,23 @@ interface FiltersResponse {
   error?: string;
 }
 
+interface BuildGroupsResponse {
+  groupsByBuild: Record<
+    string,
+    Array<{
+      group: string;
+      state: "passed" | "failed" | "running" | "blocked";
+      passed: number;
+      failed: number;
+      running: number;
+      blocked: number;
+      total: number;
+    }>
+  >;
+  jobOptions: Array<{ name: string; group: string }>;
+  error?: string;
+}
+
 export default function BuildsPage() {
   const [pipeline, setPipeline] = useState("CI");
   const [branch, setBranch] = useState("main");
@@ -71,11 +88,36 @@ export default function BuildsPage() {
   });
 
   const {
-    builds = [],
+    builds: buildRows = [],
     buildDurations = [],
     summary = { total: 0, passed: 0, failed: 0, passRate: 0 },
     pagination = { page: 0, pageSize: 50, totalPages: 0 },
   } = data ?? {};
+
+  const buildIds = useMemo(
+    () => buildRows.map((build) => build.id),
+    [buildRows],
+  );
+  const groupsUrl =
+    buildIds.length > 0
+      ? `/api/builds/groups?buildIds=${encodeURIComponent(buildIds.join(","))}`
+      : null;
+  const { data: groupData } = useSWR<BuildGroupsResponse>(groupsUrl, fetcher, {
+    refreshInterval: 5 * 60 * 1000,
+    keepPreviousData: true,
+  });
+
+  const builds = useMemo(
+    () =>
+      buildRows.map((build) => ({
+        ...build,
+        testGroups: (groupData?.groupsByBuild[build.id] ?? []).map((group) => ({
+          ...group,
+          jobs: [],
+        })),
+      })),
+    [buildRows, groupData?.groupsByBuild],
+  );
 
   const allGroupNames = useMemo(() => {
     const groups = new Set<string>();
@@ -89,27 +131,18 @@ export default function BuildsPage() {
 
   const jobToGroup = useMemo(() => {
     const map = new Map<string, string>();
-    for (const build of builds) {
-      for (const g of build.testGroups ?? []) {
-        for (const j of g.jobs) {
-          if (!map.has(j.name)) map.set(j.name, g.group);
-        }
-      }
+    for (const option of groupData?.jobOptions ?? []) {
+      map.set(option.name, option.group);
     }
     return map;
-  }, [builds]);
+  }, [groupData?.jobOptions]);
 
   const availableJobNames = useMemo(() => {
-    const jobs = new Set<string>();
     const groupFilter = selectedGroups.size > 0 ? selectedGroups : null;
-    for (const build of builds) {
-      for (const g of build.testGroups ?? []) {
-        if (groupFilter && !groupFilter.has(g.group)) continue;
-        for (const j of g.jobs) jobs.add(j.name);
-      }
-    }
-    return [...jobs].sort();
-  }, [builds, selectedGroups]);
+    return (groupData?.jobOptions ?? [])
+      .filter((option) => !groupFilter || groupFilter.has(option.group))
+      .map((option) => option.name);
+  }, [groupData?.jobOptions, selectedGroups]);
 
   if (isLoading && !data) {
     return (
@@ -185,12 +218,9 @@ export default function BuildsPage() {
               setSelectedJobs((prev) => {
                 if (v.size === 0) return prev;
                 const valid = new Set<string>();
-                for (const build of builds) {
-                  for (const g of build.testGroups ?? []) {
-                    if (!v.has(g.group)) continue;
-                    for (const j of g.jobs) {
-                      if (prev.has(j.name)) valid.add(j.name);
-                    }
+                for (const option of groupData?.jobOptions ?? []) {
+                  if (v.has(option.group) && prev.has(option.name)) {
+                    valid.add(option.name);
                   }
                 }
                 return valid;

--- a/src/components/builds-table.tsx
+++ b/src/components/builds-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
+import useSWR from "swr";
 import type { GroupStatus } from "@/lib/test-groups";
 import { isOptionalJob, isSoftFailJob } from "@/lib/optional-jobs";
 
@@ -144,8 +145,34 @@ interface Column {
   jobName?: string;
 }
 
+interface BuildJobsResponse {
+  jobsByBuild: Record<
+    string,
+    Record<string, Array<{ name: string; state: string; web_url?: string }>>
+  >;
+}
+
+const fetcher = (url: string) => fetch(url).then((response) => response.json());
+
 export function BuildsTable({ builds, showBranch, hideSoftFail, hideOptional, selectedGroups, selectedJobs }: { builds: Build[]; showBranch?: boolean; hideSoftFail?: boolean; hideOptional?: boolean; selectedGroups?: Set<string>; selectedJobs?: Set<string> }) {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const buildIds = useMemo(
+    () => builds.map((build) => build.id),
+    [builds],
+  );
+  const expandedGroupList = useMemo(
+    () => [...expandedGroups].sort(),
+    [expandedGroups],
+  );
+  const jobDetailsUrl =
+    buildIds.length > 0 && expandedGroupList.length > 0
+      ? `/api/builds/jobs?buildIds=${encodeURIComponent(buildIds.join(","))}&groups=${encodeURIComponent(expandedGroupList.join(","))}`
+      : null;
+  const { data: jobDetails } = useSWR<BuildJobsResponse>(
+    jobDetailsUrl,
+    fetcher,
+    { keepPreviousData: true },
+  );
 
   const shouldHideJob = (name: string): boolean => {
     if (hideSoftFail && isSoftFailJob(name)) return true;
@@ -158,7 +185,8 @@ export function BuildsTable({ builds, showBranch, hideSoftFail, hideOptional, se
     for (const g of build.testGroups ?? []) {
       if (!allGroups.has(g.group)) allGroups.set(g.group, new Set());
       const jobSet = allGroups.get(g.group)!;
-      for (const j of g.jobs) {
+      const jobs = jobDetails?.jobsByBuild[build.id]?.[g.group] ?? [];
+      for (const j of jobs) {
         if (!shouldHideJob(j.name)) jobSet.add(j.name);
       }
     }
@@ -277,7 +305,14 @@ export function BuildsTable({ builds, showBranch, hideSoftFail, hideOptional, se
           <tbody>
             {builds.map((build) => {
               const groupMap = new Map(
-                (build.testGroups ?? []).map((g) => [g.group, g])
+                (build.testGroups ?? []).map((g) => [
+                  g.group,
+                  {
+                    ...g,
+                    jobs:
+                      jobDetails?.jobsByBuild[build.id]?.[g.group] ?? [],
+                  },
+                ])
               );
 
               return (

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -84,7 +84,36 @@ export function Nav() {
   function prefetchRouteData(href: string) {
     if (prefetchedRoutes.has(href)) return;
     prefetchedRoutes.add(href);
-    const requests = defaultDataUrls(href).map((url) => preload(url, fetcher));
+    const requests = defaultDataUrls(href).map(async (url) => {
+      const data = await preload(url, fetcher);
+      if (href === "/" && url.startsWith("/api/builds?")) {
+        const buildIds = (
+          data as { builds?: Array<{ id?: string }> }
+        ).builds
+          ?.map((build) => build.id)
+          .filter((id): id is string => Boolean(id));
+        if (buildIds?.length) {
+          const groupsUrl =
+            `/api/builds/groups?buildIds=${encodeURIComponent(buildIds.join(","))}`;
+          await preload(groupsUrl, fetcher);
+        }
+      }
+      if (href === "/perf" && url.startsWith("/api/perf/filters?")) {
+        const defaultModel = (
+          data as { models?: string[] }
+        ).models?.[0];
+        if (defaultModel) {
+          const start = new URL(url, window.location.origin).searchParams.get(
+            "start",
+          );
+          const perfUrl =
+            `/api/perf?model=${encodeURIComponent(defaultModel)}` +
+            (start ? `&start=${encodeURIComponent(start)}` : "");
+          await preload(perfUrl, fetcher);
+        }
+      }
+      return data;
+    });
     void Promise.all(requests).catch(() => {
       prefetchedRoutes.delete(href);
     });

--- a/src/lib/eval-data.ts
+++ b/src/lib/eval-data.ts
@@ -21,19 +21,14 @@ export interface EvalRow {
   task: string;
   n_shot: number;
   n_samples: number;
-  version: number;
   git_hash: string | null;
-  lm_eval_version: string | null;
   eval_seconds: number;
   metrics: EvalMetric[];
-  config: Record<string, unknown>;
-  model_args: Record<string, unknown>;
   image: string | null;
   buildkite_build_id: string | null;
   buildkite_build_number: string | null;
   buildkite_build_url: string | null;
   buildkite_commit: string | null;
-  buildkite_branch: string | null;
   vllm_commit: string | null;
   workload: string | null;
 }
@@ -192,22 +187,17 @@ export async function loadEvalRows({
         task: taskName,
         n_shot: core["n-shot"]?.[taskName] ?? 0,
         n_samples: core["n-samples"]?.[taskName]?.effective ?? 0,
-        version: core.versions?.[taskName] ?? 0,
         git_hash: core.git_hash ?? null,
-        lm_eval_version: core.lm_eval_version ?? null,
         eval_seconds:
           typeof core.total_evaluation_time_seconds === "number"
             ? core.total_evaluation_time_seconds
             : parseFloat(String(core.total_evaluation_time_seconds ?? "0")),
         metrics,
-        config: core.configs?.[taskName] ?? {},
-        model_args: core.config?.model_args ?? {},
         image: imageFromMessage(raw, core, taskName),
         buildkite_build_id: raw.buildkite_build_id ?? null,
         buildkite_build_number: raw.buildkite_build_number ?? null,
         buildkite_build_url: raw.buildkite_build_url ?? null,
         buildkite_commit: raw.buildkite_commit ?? null,
-        buildkite_branch: raw.buildkite_branch ?? null,
         vllm_commit: raw.vllm_commit ?? null,
         workload,
       };

--- a/src/lib/gpu-data.ts
+++ b/src/lib/gpu-data.ts
@@ -4,6 +4,7 @@ import type {
   GpuHistoryResponse,
   GpuLatest,
   GpuLatestResponse,
+  GpuOverviewPoint,
   GpuSnapshot,
 } from "@/lib/gpu-types";
 
@@ -49,6 +50,52 @@ function normalizeLatest(rows: DbRow[]): GpuLatest[] {
     mem_total_mb: Number(row.mem_total_mb),
     reported_at: isoString(row.reported_at),
   }));
+}
+
+function percentile(values: number[], quantile: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const position = (sorted.length - 1) * quantile;
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  if (lower === upper) return sorted[lower];
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
+}
+
+function summarizeGpuHistory(
+  history: GpuHistoryResponse,
+): GpuOverviewPoint[] {
+  const buckets = new Map<
+    number,
+    Map<string, { memPctSum: number; sampleCount: number }>
+  >();
+
+  for (const snapshot of history.snapshots) {
+    const time = new Date(snapshot.time_bucket).getTime();
+    const hosts = buckets.get(time) ?? new Map();
+    const host = hosts.get(snapshot.hostname) ?? {
+      memPctSum: 0,
+      sampleCount: 0,
+    };
+    host.memPctSum += snapshot.mem_pct_sum;
+    host.sampleCount += snapshot.sample_count;
+    hosts.set(snapshot.hostname, host);
+    buckets.set(time, hosts);
+  }
+
+  return [...buckets.entries()]
+    .map(([time, hosts]) => {
+      const values = [...hosts.values()]
+        .filter((host) => host.sampleCount > 0)
+        .map((host) => host.memPctSum / host.sampleCount);
+      return {
+        time,
+        p50: Math.round(percentile(values, 0.5)),
+        p90: Math.round(percentile(values, 0.9)),
+        peak: Math.round(Math.max(...values, 0)),
+      };
+    })
+    .sort((a, b) => a.time - b.time);
 }
 
 export async function queryGpuHistory(
@@ -167,7 +214,7 @@ export async function getInitialGpuData() {
     getCachedInitialLatest(),
   ]);
   return {
-    history,
+    overview: summarizeGpuHistory(history),
     latest: latestResponse.latest,
     latestCheckedAt: latestResponse.checked_at,
     asOf: Date.now(),

--- a/src/lib/gpu-types.ts
+++ b/src/lib/gpu-types.ts
@@ -21,6 +21,13 @@ export interface GpuHistoryResponse {
   error?: string;
 }
 
+export interface GpuOverviewPoint {
+  time: number;
+  p50: number;
+  p90: number;
+  peak: number;
+}
+
 export interface GpuLatestResponse {
   latest: GpuLatest[];
   checked_at: string;


### PR DESCRIPTION
## Summary
- split Builds into a 154KB bootstrap, normalized group summaries, and job details fetched only when a group is expanded
- strip unused 1.5MB configuration blobs from Evaluation responses
- cap Nightly detail arrays to the eight rows the UI renders and keep full comparisons in Compare
- server-render a compact GPU P50/P90/Peak overview and fetch raw host history only for filtered, Hosts, Stacked, or non-24h views
- chain-preload the normalized Builds groups and Performance default-model series

## Measured locally against the same live data
| Surface | Before | After | Reduction |
|---|---:|---:|---:|
| Builds bootstrap | 1.94MB | 154KB | 92% |
| Builds bootstrap + groups | 1.94MB | 310KB | 84% |
| Evaluation | 2.28MB | 733KB | 68% |
| Nightly | 773KB | 245KB | 68% |
| GPU initial HTML | 1.03MB | 204KB | 80% |

The default GPU view no longer requests the separate 774KB raw history payload. Builds job URLs are loaded only when a group is expanded.

## Validation
- targeted ESLint
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
- live-data interaction check: Builds group expansion, Evaluation, Nightly, GPU overview
- 390x844 and 1440x1100 checks: no document overflow on Builds, Evaluation, Nightly, or GPU