### PR TITLE
Make build group expansion instant

### DIFF
--- a/src/app/api/builds/groups/route.ts
+++ b/src/app/api/builds/groups/route.ts
@@ -27,7 +27,12 @@ export async function GET(request: NextRequest) {
 
     if (buildIds.length === 0) {
       return cachedJson(
-        { groupsByBuild: {}, jobOptions: [] },
+        {
+          groupsByBuild: {},
+          jobNames: [],
+          jobsByBuild: {},
+          jobOptions: [],
+        },
         CDN_CACHE,
       );
     }
@@ -60,22 +65,48 @@ export async function GET(request: NextRequest) {
       jobsByBuild.set(row.build_id, buildJobs);
     }
 
-    const groupsByBuild: Record<string, GroupSummary[]> = {};
+    const groupedByBuild = new Map<string, GroupStatus[]>();
     const jobToGroup = new Map<string, string>();
     for (const buildId of buildIds) {
       const groups = aggregateJobsByGroup(jobsByBuild.get(buildId) ?? []);
-      groupsByBuild[buildId] = groups.map(({ jobs: groupJobs, ...summary }) => {
-        for (const job of groupJobs) {
+      groupedByBuild.set(buildId, groups);
+      for (const group of groups) {
+        for (const job of group.jobs) {
           if (!jobToGroup.has(job.name)) {
-            jobToGroup.set(job.name, summary.group);
+            jobToGroup.set(job.name, group.group);
           }
         }
+      }
+    }
+
+    // Normalize repeated job names into one dictionary. The compact
+    // name-index/state matrix is small enough to ship with group summaries, so
+    // expanding a group is immediate. Only the much larger job URLs stay lazy.
+    const jobNames = [...jobToGroup.keys()].sort((a, b) => a.localeCompare(b));
+    const jobNameIndex = new Map(
+      jobNames.map((name, index) => [name, index]),
+    );
+    const groupsByBuild: Record<string, GroupSummary[]> = {};
+    const compactJobsByBuild: Record<
+      string,
+      Record<string, Array<[number, string]>>
+    > = {};
+    for (const buildId of buildIds) {
+      const groups = groupedByBuild.get(buildId) ?? [];
+      compactJobsByBuild[buildId] = {};
+      groupsByBuild[buildId] = groups.map(({ jobs: groupJobs, ...summary }) => {
+        compactJobsByBuild[buildId][summary.group] = groupJobs.map((job) => [
+          jobNameIndex.get(job.name)!,
+          job.state,
+        ]);
         return summary;
       });
     }
 
     const result = {
       groupsByBuild,
+      jobNames,
+      jobsByBuild: compactJobsByBuild,
       jobOptions: [...jobToGroup.entries()]
         .map(([name, group]) => ({ name, group }))
         .sort((a, b) => a.name.localeCompare(b.name)),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,6 +48,11 @@ interface BuildGroupsResponse {
       total: number;
     }>
   >;
+  jobNames: string[];
+  jobsByBuild: Record<
+    string,
+    Record<string, Array<[nameIndex: number, state: string]>>
+  >;
   jobOptions: Array<{ name: string; group: string }>;
   error?: string;
 }
@@ -268,7 +273,16 @@ export default function BuildsPage() {
         </div>
       </div>
 
-      <BuildsTable builds={builds} showBranch={!branch} hideSoftFail={hideSoftFail} hideOptional={hideOptional} selectedGroups={selectedGroups} selectedJobs={selectedJobs} />
+      <BuildsTable
+        builds={builds}
+        jobNames={groupData?.jobNames ?? []}
+        jobsByBuild={groupData?.jobsByBuild ?? {}}
+        showBranch={!branch}
+        hideSoftFail={hideSoftFail}
+        hideOptional={hideOptional}
+        selectedGroups={selectedGroups}
+        selectedJobs={selectedJobs}
+      />
       {pagination.totalPages > 1 && (
         <div className="flex items-center justify-between">
           <p className="text-sm text-zinc-500 dark:text-zinc-400">

--- a/src/components/builds-table.tsx
+++ b/src/components/builds-table.tsx
@@ -152,9 +152,34 @@ interface BuildJobsResponse {
   >;
 }
 
+type CompactJobsByBuild = Record<
+  string,
+  Record<string, Array<[nameIndex: number, state: string]>>
+>;
+
+interface BuildsTableProps {
+  builds: Build[];
+  jobNames: string[];
+  jobsByBuild: CompactJobsByBuild;
+  showBranch?: boolean;
+  hideSoftFail?: boolean;
+  hideOptional?: boolean;
+  selectedGroups?: Set<string>;
+  selectedJobs?: Set<string>;
+}
+
 const fetcher = (url: string) => fetch(url).then((response) => response.json());
 
-export function BuildsTable({ builds, showBranch, hideSoftFail, hideOptional, selectedGroups, selectedJobs }: { builds: Build[]; showBranch?: boolean; hideSoftFail?: boolean; hideOptional?: boolean; selectedGroups?: Set<string>; selectedJobs?: Set<string> }) {
+export function BuildsTable({
+  builds,
+  jobNames,
+  jobsByBuild,
+  showBranch,
+  hideSoftFail,
+  hideOptional,
+  selectedGroups,
+  selectedJobs,
+}: BuildsTableProps) {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const buildIds = useMemo(
     () => builds.map((build) => build.id),
@@ -185,9 +210,10 @@ export function BuildsTable({ builds, showBranch, hideSoftFail, hideOptional, se
     for (const g of build.testGroups ?? []) {
       if (!allGroups.has(g.group)) allGroups.set(g.group, new Set());
       const jobSet = allGroups.get(g.group)!;
-      const jobs = jobDetails?.jobsByBuild[build.id]?.[g.group] ?? [];
-      for (const j of jobs) {
-        if (!shouldHideJob(j.name)) jobSet.add(j.name);
+      const compactJobs = jobsByBuild[build.id]?.[g.group] ?? [];
+      for (const [nameIndex] of compactJobs) {
+        const name = jobNames[nameIndex];
+        if (name && !shouldHideJob(name)) jobSet.add(name);
       }
     }
   }
@@ -305,14 +331,21 @@ export function BuildsTable({ builds, showBranch, hideSoftFail, hideOptional, se
           <tbody>
             {builds.map((build) => {
               const groupMap = new Map(
-                (build.testGroups ?? []).map((g) => [
-                  g.group,
-                  {
-                    ...g,
-                    jobs:
-                      jobDetails?.jobsByBuild[build.id]?.[g.group] ?? [],
-                  },
-                ])
+                (build.testGroups ?? []).map((g) => {
+                  const details =
+                    jobDetails?.jobsByBuild[build.id]?.[g.group] ?? [];
+                  const urlsByName = new Map(
+                    details.map((job) => [job.name, job.web_url]),
+                  );
+                  const jobs = (jobsByBuild[build.id]?.[g.group] ?? [])
+                    .map(([nameIndex, state]) => ({
+                      name: jobNames[nameIndex],
+                      state,
+                      web_url: urlsByName.get(jobNames[nameIndex]),
+                    }))
+                    .filter((job) => Boolean(job.name));
+                  return [g.group, { ...g, jobs }];
+                })
               );
 
               return (


### PR DESCRIPTION
## What changed
- include a compact normalized job-name/status matrix in the Builds group response
- render expanded job columns and status dots immediately from that matrix
- keep only the larger job URL details lazy and merge them in by job name when they arrive

## Why
The recent Builds payload split made the initial page much smaller, but it also put status data behind the expansion request. Opening a test group therefore appeared to do nothing for about 1.71 seconds on production.

## Impact
The same expansion renders its job columns in about 5 ms locally, while links become active in the background without a layout shift. The normalized group payload grows from 156 KB to 342 KB, but total Builds startup remains about 496 KB—roughly 74% below the original 1.94 MB payload.

## Validation
- `npx eslint src/app/api/builds/groups/route.ts src/app/page.tsx src/components/builds-table.tsx`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
- local browser check: columns visible before `/api/builds/jobs` completes; 48 job links activate after URL details arrive; no browser exceptions