### PR TITLE
Restore direct links for failed build job dots

### DIFF
--- a/src/app/api/builds/groups/route.ts
+++ b/src/app/api/builds/groups/route.ts
@@ -2,13 +2,19 @@ import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
 import { cachedJson } from "@/lib/api-response";
-import { aggregateJobsByGroup, type GroupStatus } from "@/lib/test-groups";
+import {
+  aggregateJobsByGroup,
+  isFailedJobState,
+  type GroupStatus,
+} from "@/lib/test-groups";
 
 const TTL = 30_000;
 const CDN_CACHE = { maxAge: 60, staleWhileRevalidate: 3_600 };
 const MAX_BUILD_IDS = 50;
 
-type GroupSummary = Omit<GroupStatus, "jobs">;
+type GroupSummary = Omit<GroupStatus, "jobs"> & {
+  failedJobs: Array<{ name: string; web_url: string }>;
+};
 
 function escapeSql(value: string): string {
   return value.replace(/'/g, "''");
@@ -46,7 +52,8 @@ export async function GET(request: NextRequest) {
       SELECT
         j.build_id,
         j.name,
-        j.state
+        j.state,
+        j.web_url
       FROM vllm_data_warehouse.buildkite.build_job AS j
       WHERE j.build_id IN (${idList})
         AND j._fivetran_deleted = false
@@ -56,12 +63,16 @@ export async function GET(request: NextRequest) {
 
     const jobsByBuild = new Map<
       string,
-      { name: string; state: string }[]
+      { name: string; state: string; web_url?: string }[]
     >();
     for (const job of jobs) {
       const row = job as Record<string, string>;
       const buildJobs = jobsByBuild.get(row.build_id) ?? [];
-      buildJobs.push({ name: row.name, state: row.state });
+      buildJobs.push({
+        name: row.name,
+        state: row.state,
+        web_url: row.web_url,
+      });
       jobsByBuild.set(row.build_id, buildJobs);
     }
 
@@ -99,7 +110,10 @@ export async function GET(request: NextRequest) {
           jobNameIndex.get(job.name)!,
           job.state,
         ]);
-        return summary;
+        const failedJobs = groupJobs
+          .filter((job) => isFailedJobState(job.state) && job.web_url)
+          .map((job) => ({ name: job.name, web_url: job.web_url! }));
+        return { ...summary, failedJobs };
       });
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,6 +46,7 @@ interface BuildGroupsResponse {
       running: number;
       blocked: number;
       total: number;
+      failedJobs?: Array<{ name: string; web_url: string }>;
     }>
   >;
   jobNames: string[];

--- a/src/components/builds-table.tsx
+++ b/src/components/builds-table.tsx
@@ -18,7 +18,11 @@ export interface Build {
   finished_at: string | null;
   author: string | null;
   pr_number: string | null;
-  testGroups?: GroupStatus[];
+  testGroups?: Array<
+    GroupStatus & {
+      failedJobs?: Array<{ name: string; web_url: string }>;
+    }
+  >;
 }
 
 const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -99,12 +103,14 @@ function DotWithTooltip({
   detail,
   borderClass,
   href,
+  onClick,
 }: {
   color: string;
   label: string;
   detail: string;
   borderClass?: string;
   href?: string;
+  onClick?: () => void;
 }) {
   const [show, setShow] = useState(false);
   return (
@@ -114,12 +120,24 @@ function DotWithTooltip({
           href={href}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex h-5 w-5 items-center justify-center"
+          aria-label={`${label}: ${detail}`}
+          className="inline-flex h-5 w-5 cursor-pointer items-center justify-center"
           onMouseEnter={() => setShow(true)}
           onMouseLeave={() => setShow(false)}
         >
           <span className={`block h-3.5 w-3.5 rounded-sm ${color}`} />
         </a>
+      ) : onClick ? (
+        <button
+          type="button"
+          aria-label={`${label}: ${detail}`}
+          className="inline-flex h-5 w-5 cursor-pointer items-center justify-center"
+          onClick={onClick}
+          onMouseEnter={() => setShow(true)}
+          onMouseLeave={() => setShow(false)}
+        >
+          <span className={`block h-3.5 w-3.5 rounded-sm ${color}`} />
+        </button>
       ) : (
         <div
           className="inline-flex h-5 w-5 cursor-default items-center justify-center"
@@ -337,11 +355,16 @@ export function BuildsTable({
                   const urlsByName = new Map(
                     details.map((job) => [job.name, job.web_url]),
                   );
+                  const failedUrlsByName = new Map(
+                    (g.failedJobs ?? []).map((job) => [job.name, job.web_url]),
+                  );
                   const jobs = (jobsByBuild[build.id]?.[g.group] ?? [])
                     .map(([nameIndex, state]) => ({
                       name: jobNames[nameIndex],
                       state,
-                      web_url: urlsByName.get(jobNames[nameIndex]),
+                      web_url:
+                        urlsByName.get(jobNames[nameIndex]) ??
+                        failedUrlsByName.get(jobNames[nameIndex]),
                     }))
                     .filter((job) => Boolean(job.name));
                   return [g.group, { ...g, jobs }];
@@ -455,6 +478,11 @@ export function BuildsTable({
                           </td>
                         );
                       }
+                      const failedJobLinks = groupStatus.failedJobs ?? [];
+                      const failedJobHref =
+                        groupStatus.failed === 1 && failedJobLinks.length === 1
+                          ? failedJobLinks[0].web_url
+                          : undefined;
                       return (
                         <DotWithTooltip
                           key={key}
@@ -462,6 +490,12 @@ export function BuildsTable({
                           label={groupStatus.group}
                           detail={`${groupStatus.passed} passed, ${groupStatus.failed} failed, ${groupStatus.running} running, ${groupStatus.blocked} blocked`}
                           borderClass={borderL}
+                          href={failedJobHref}
+                          onClick={
+                            groupStatus.failed > 1 && failedJobLinks.length > 0
+                              ? () => toggleGroup(groupStatus.group)
+                              : undefined
+                          }
                         />
                       );
                     }

--- a/src/lib/test-groups.ts
+++ b/src/lib/test-groups.ts
@@ -66,6 +66,15 @@ export interface GroupStatus {
   jobs: JobInfo[];
 }
 
+export function isFailedJobState(state: string): boolean {
+  return (
+    state === "failed" ||
+    state === "failing" ||
+    state === "broken" ||
+    state === "timed_out"
+  );
+}
+
 export function resolveGroupsToJobConditions(groups: string[]): { exactNames: string[]; regexPatterns: string[] } {
   const mapping = getTestAreaMapping();
   const exactNames: string[] = [];
@@ -113,7 +122,7 @@ export function aggregateJobsByGroup(
 
     const state = job.state;
     if (state === "passed") g.passed++;
-    else if (state === "failed" || state === "failing" || state === "broken" || state === "timed_out") g.failed++;
+    else if (isFailedJobState(state)) g.failed++;
     else if (state === "running" || state === "scheduled" || state === "reserved") g.running++;
     else g.blocked++;
   }


### PR DESCRIPTION
## Summary

- include failed-job links in the compact build-group response without restoring every job URL to the bootstrap payload
- make single-failure group dots open the exact Buildkite job directly
- make multi-failure group dots expand the group, with each failed job dot immediately linked
- add accessible labels and pointer affordances to interactive status dots

## Root cause

The instant-expansion optimization moved job names and states into the compact group payload while leaving all job URLs in the lazy `/api/builds/jobs` request. That let red job dots render before they had an anchor, and collapsed red group dots had no navigation target at all.

This keeps the fast summary response while adding URLs only for failed jobs, which are the links needed for failure triage.

## User impact

A red dot with one failed job now opens that job directly. A red dot representing multiple failures expands to show the individual failed jobs, and those dots are already clickable when rendered.

## Validation

- `./node_modules/.bin/eslint src/lib/test-groups.ts src/app/api/builds/groups/route.ts src/app/page.tsx src/components/builds-table.tsx`
- `npm run build`
- `git diff --check`
- local browser verification against live warehouse data:
  - single-failure group dots rendered as anchors to exact `build#job-id` URLs
  - multi-failure group dots expanded successfully
  - revealed failed-job dots all carried exact Buildkite job URLs

Full-repo `npm run lint` still reports the pre-existing `prefer-const` error in `src/app/api/alerts/queue/route.ts:166`; the files changed here pass focused lint.