### PR TITLE
Report GPU utilization on dashboard

### DIFF
--- a/scripts/migrate-gpu-rollups.mjs
+++ b/scripts/migrate-gpu-rollups.mjs
@@ -42,9 +42,14 @@ try {
       hostname      TEXT NOT NULL,
       gpu_name      TEXT NOT NULL,
       mem_pct_sum   DOUBLE PRECISION NOT NULL,
+      gpu_util_sum  DOUBLE PRECISION NOT NULL,
       sample_count  BIGINT NOT NULL,
       PRIMARY KEY (time_bucket, hostname, gpu_name)
     )
+  `;
+  await sql`
+    ALTER TABLE gpu_history_5m
+    ADD COLUMN IF NOT EXISTS gpu_util_sum DOUBLE PRECISION NOT NULL DEFAULT 0
   `;
   await sql`
     CREATE INDEX IF NOT EXISTS idx_gpu_history_5m_time_host
@@ -56,7 +61,7 @@ try {
     await tx`LOCK TABLE gpu_history_5m IN ACCESS EXCLUSIVE MODE`;
     await tx`
       INSERT INTO gpu_history_5m (
-        time_bucket, hostname, gpu_name, mem_pct_sum, sample_count
+        time_bucket, hostname, gpu_name, mem_pct_sum, gpu_util_sum, sample_count
       )
       SELECT
         date_bin(INTERVAL '5 minutes', reported_at, TIMESTAMPTZ 'epoch'),
@@ -66,11 +71,13 @@ try {
           WHEN mem_total_mb > 0 THEN mem_used_mb / mem_total_mb * 100
           ELSE 0
         END)::double precision,
+        SUM(gpu_util)::double precision,
         COUNT(*)::bigint
       FROM gpu_snapshots
       GROUP BY 1, hostname, COALESCE(gpu_name, 'Unknown')
       ON CONFLICT (time_bucket, hostname, gpu_name) DO UPDATE SET
         mem_pct_sum = EXCLUDED.mem_pct_sum,
+        gpu_util_sum = EXCLUDED.gpu_util_sum,
         sample_count = EXCLUDED.sample_count
     `;
   });

--- a/src/app/api/gpu/report/route.ts
+++ b/src/app/api/gpu/report/route.ts
@@ -50,13 +50,21 @@ export async function POST(request: NextRequest) {
       power_limit_w: gpu.power_limit_w ?? null,
     }));
 
-    const rollupsByName = new Map<string, { memPctSum: number; count: number }>();
+    const rollupsByName = new Map<
+      string,
+      { memPctSum: number; gpuUtilSum: number; count: number }
+    >();
     for (const gpu of body.gpus) {
       const name = gpu.name ?? "Unknown";
-      const current = rollupsByName.get(name) ?? { memPctSum: 0, count: 0 };
+      const current = rollupsByName.get(name) ?? {
+        memPctSum: 0,
+        gpuUtilSum: 0,
+        count: 0,
+      };
       current.memPctSum += gpu.mem_total_mb > 0
         ? (gpu.mem_used_mb / gpu.mem_total_mb) * 100
         : 0;
+      current.gpuUtilSum += gpu.gpu_util;
       current.count += 1;
       rollupsByName.set(name, current);
     }
@@ -65,6 +73,7 @@ export async function POST(request: NextRequest) {
       hostname: body.hostname,
       gpu_name: gpuName,
       mem_pct_sum: values.memPctSum,
+      gpu_util_sum: values.gpuUtilSum,
       sample_count: values.count,
     }));
 
@@ -94,10 +103,12 @@ export async function POST(request: NextRequest) {
           "hostname",
           "gpu_name",
           "mem_pct_sum",
+          "gpu_util_sum",
           "sample_count",
         )}
         ON CONFLICT (time_bucket, hostname, gpu_name) DO UPDATE SET
           mem_pct_sum = gpu_history_5m.mem_pct_sum + EXCLUDED.mem_pct_sum,
+          gpu_util_sum = gpu_history_5m.gpu_util_sum + EXCLUDED.gpu_util_sum,
           sample_count = gpu_history_5m.sample_count + EXCLUDED.sample_count
       `;
     });

--- a/src/app/gpu/gpu-dashboard.tsx
+++ b/src/app/gpu/gpu-dashboard.tsx
@@ -44,6 +44,7 @@ const OVERVIEW_SERIES = [
   "Peak",
 ] as const;
 const EMPTY_SNAPSHOTS: GpuHistoryResponse["snapshots"] = [];
+type GpuMetric = "memory" | "utilization";
 
 function percentile(values: number[], quantile: number): number {
   if (values.length === 0) return 0;
@@ -106,6 +107,7 @@ export function GpuDashboard({
   const [gpuTypeFilter, setGpuTypeFilter] = useState("");
   const [hostFilter, setHostFilter] = useState("");
   const [hours, setHours] = useState(24);
+  const [metric, setMetric] = useState<GpuMetric>("memory");
   const [chartMode, setChartMode] = useState<GpuChartMode>("overview");
   const [now, setNow] = useState(initialNow);
 
@@ -210,9 +212,12 @@ export function GpuDashboard({
       return {
         data: initialOverview.map((point) => ({
           time: point.time,
-          [OVERVIEW_SERIES[0]]: point.p50,
-          [OVERVIEW_SERIES[1]]: point.p90,
-          [OVERVIEW_SERIES[2]]: point.peak,
+          [OVERVIEW_SERIES[0]]:
+            metric === "memory" ? point.memoryP50 : point.gpuP50,
+          [OVERVIEW_SERIES[1]]:
+            metric === "memory" ? point.memoryP90 : point.gpuP90,
+          [OVERVIEW_SERIES[2]]:
+            metric === "memory" ? point.memoryPeak : point.gpuPeak,
         })),
         hosts: [...OVERVIEW_SERIES],
       };
@@ -225,7 +230,10 @@ export function GpuDashboard({
     // empty legend lines here.
     const hostsWithData = new Set<string>();
 
-    const bucketMap = new Map<number, Map<string, { memPctSum: number; count: number }>>();
+    const bucketMap = new Map<
+      number,
+      Map<string, { memPctSum: number; gpuUtilSum: number; count: number }>
+    >();
 
     for (const row of snapshots) {
       if (!relevantHosts.has(row.hostname)) continue;
@@ -235,9 +243,12 @@ export function GpuDashboard({
       const t = new Date(row.time_bucket).getTime();
       if (!bucketMap.has(t)) bucketMap.set(t, new Map());
       const hostMap = bucketMap.get(t)!;
-      if (!hostMap.has(row.hostname)) hostMap.set(row.hostname, { memPctSum: 0, count: 0 });
+      if (!hostMap.has(row.hostname)) {
+        hostMap.set(row.hostname, { memPctSum: 0, gpuUtilSum: 0, count: 0 });
+      }
       const entry = hostMap.get(row.hostname)!;
       entry.memPctSum += Number(row.mem_pct_sum);
+      entry.gpuUtilSum += Number(row.gpu_util_sum);
       entry.count += Number(row.sample_count);
     }
 
@@ -250,7 +261,10 @@ export function GpuDashboard({
         for (const host of hosts) {
           const entry = hostMap.get(host);
           if (entry) {
-            const averagePercent = entry.memPctSum / entry.count;
+            const total = metric === "memory"
+              ? entry.memPctSum
+              : entry.gpuUtilSum;
+            const averagePercent = total / entry.count;
             utilizationValues.push(averagePercent);
             if (chartMode === "stacked") {
               row[host] =
@@ -296,6 +310,7 @@ export function GpuDashboard({
     hours,
     hostFilter,
     initialOverview,
+    metric,
   ]);
 
   const tickInterval = Math.max(1, Math.floor(chartData.data.length / 10));
@@ -305,19 +320,31 @@ export function GpuDashboard({
       hostname: string;
       gpuType: string;
       gpuCount: number;
+      gpuUtil: number;
       memUsedMb: number;
       memTotalMb: number;
       lastSeen: string;
-      gpus: Array<{ index: number; memUsedMb: number; memTotalMb: number }>;
+      gpus: Array<{
+        index: number;
+        gpuUtil: number;
+        memUsedMb: number;
+        memTotalMb: number;
+      }>;
     }>();
     for (const g of filtered) {
       const existing = map.get(g.hostname);
-      const gpu = { index: g.gpu_index, memUsedMb: g.mem_used_mb, memTotalMb: g.mem_total_mb };
+      const gpu = {
+        index: g.gpu_index,
+        gpuUtil: g.gpu_util,
+        memUsedMb: g.mem_used_mb,
+        memTotalMb: g.mem_total_mb,
+      };
       if (!existing) {
         map.set(g.hostname, {
           hostname: g.hostname,
           gpuType: gpuType(g.gpu_name),
           gpuCount: 1,
+          gpuUtil: g.gpu_util,
           memUsedMb: g.mem_used_mb,
           memTotalMb: g.mem_total_mb,
           lastSeen: g.reported_at,
@@ -325,6 +352,7 @@ export function GpuDashboard({
         });
       } else {
         existing.gpuCount++;
+        existing.gpuUtil += g.gpu_util;
         existing.memUsedMb += g.mem_used_mb;
         existing.memTotalMb += g.mem_total_mb;
         existing.gpus.push(gpu);
@@ -357,7 +385,7 @@ export function GpuDashboard({
       <div className="space-y-5">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
-            <h1 className="text-3xl font-semibold tracking-[-0.03em]">GPU Memory</h1>
+            <h1 className="text-3xl font-semibold tracking-[-0.03em]">GPU Metrics</h1>
             <p className="mt-1.5 text-sm text-zinc-500 dark:text-zinc-400">
               {filteredHosts.length.toLocaleString()} hosts · {filtered.length.toLocaleString()} GPUs ·{" "}
               {formatCapacityGb(totalCapacityGb)} total memory
@@ -481,16 +509,20 @@ export function GpuDashboard({
         </div>
       </div>
 
-      {/* Per-host memory chart */}
+      {/* Per-host GPU metric chart */}
       <div className="min-w-0 overflow-hidden rounded-lg border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none sm:p-6">
         <div className="mb-5 flex flex-wrap items-start justify-between gap-4">
           <div>
             <h2 className="text-lg font-semibold tracking-[-0.02em]">
-              {chartMode === "overview"
-                ? "Fleet Memory Overview"
-                : chartMode === "hosts"
-                  ? "Memory Utilization by Host"
-                  : "Stacked Memory by Host"}
+              {metric === "utilization"
+                ? chartMode === "overview"
+                  ? "Fleet GPU Utilization Overview"
+                  : "GPU Utilization by Host"
+                : chartMode === "overview"
+                  ? "Fleet Memory Overview"
+                  : chartMode === "hosts"
+                    ? "Memory Utilization by Host"
+                    : "Stacked Memory by Host"}
             </h2>
             <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
               {chartMode === "overview"
@@ -502,7 +534,7 @@ export function GpuDashboard({
                   : `Aggregate usage across ${filtered.length} GPUs, stacked by host.`}
             </p>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center justify-end gap-3">
             {historyPending && (
               <span className="inline-flex items-center gap-1.5 text-xs text-zinc-400" role="status">
                 <span className="h-3 w-3 animate-spin rounded-full border border-zinc-300 border-t-zinc-600 motion-reduce:animate-none dark:border-zinc-700 dark:border-t-zinc-300" aria-hidden="true" />
@@ -512,20 +544,24 @@ export function GpuDashboard({
             <div
               className="flex gap-1 rounded-md border border-zinc-200 p-0.5 dark:border-zinc-700"
               role="group"
-              aria-label="GPU chart mode"
+              aria-label="GPU chart metric"
             >
               {([
-                { label: "Overview", value: "overview" },
-                { label: "Hosts", value: "hosts" },
-                { label: "Stacked", value: "stacked" },
+                { label: "Memory", value: "memory" },
+                { label: "GPU Utilization", value: "utilization" },
               ] as const).map((option) => (
                 <button
                   key={option.value}
                   type="button"
-                  onClick={() => setChartMode(option.value)}
-                  aria-pressed={chartMode === option.value}
+                  onClick={() => {
+                    setMetric(option.value);
+                    if (option.value === "utilization" && chartMode === "stacked") {
+                      setChartMode("overview");
+                    }
+                  }}
+                  aria-pressed={metric === option.value}
                   className={`dashboard-control min-h-11 rounded px-3 py-2 text-sm font-medium sm:min-h-10 ${
-                    chartMode === option.value
+                    metric === option.value
                       ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                       : "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
                   }`}
@@ -533,6 +569,33 @@ export function GpuDashboard({
                   {option.label}
                 </button>
               ))}
+            </div>
+            <div
+              className="flex gap-1 rounded-md border border-zinc-200 p-0.5 dark:border-zinc-700"
+              role="group"
+              aria-label="GPU chart mode"
+            >
+              {([
+                { label: "Overview", value: "overview" },
+                { label: "Hosts", value: "hosts" },
+                { label: "Stacked", value: "stacked" },
+              ] as const)
+                .filter((option) => metric === "memory" || option.value !== "stacked")
+                .map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setChartMode(option.value)}
+                    aria-pressed={chartMode === option.value}
+                    className={`dashboard-control min-h-11 rounded px-3 py-2 text-sm font-medium sm:min-h-10 ${
+                      chartMode === option.value
+                        ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                        : "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
             </div>
           </div>
         </div>
@@ -556,19 +619,21 @@ export function GpuDashboard({
           </span>
         </div>
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[760px] text-sm">
+          <table className="w-full min-w-[920px] text-sm">
             <thead>
               <tr className="border-b border-zinc-200 text-left text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
                 <th className="px-5 py-3 font-medium sm:px-6">Host</th>
                 <th className="px-5 py-3 font-medium sm:px-6">GPU Type</th>
                 <th className="px-5 py-3 font-medium sm:px-6">Memory</th>
-                <th className="px-5 py-3 font-medium sm:px-6">Per-GPU</th>
+                <th className="px-5 py-3 font-medium sm:px-6">GPU Utilization</th>
+                <th className="px-5 py-3 font-medium sm:px-6">Per-GPU Memory</th>
                 <th className="px-5 py-3 font-medium sm:px-6">Last Seen</th>
               </tr>
             </thead>
             <tbody>
               {hostRows.map((h) => {
                 const memPct = h.memTotalMb > 0 ? Math.round((h.memUsedMb / h.memTotalMb) * 100) : 0;
+                const gpuUtil = h.gpuCount > 0 ? Math.round(h.gpuUtil / h.gpuCount) : 0;
                 const ago = now > 0
                   ? Math.round((now - new Date(h.lastSeen).getTime()) / 60_000)
                   : 0;
@@ -596,6 +661,17 @@ export function GpuDashboard({
                       <span className="ml-1 text-xs text-zinc-400">({memPct}%)</span>
                     </td>
                     <td className="px-5 py-3.5 sm:px-6">
+                      <div className="flex min-w-28 items-center gap-2">
+                        <span className="w-10 tabular-nums">{gpuUtil}%</span>
+                        <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+                          <div
+                            className="h-full rounded-full bg-emerald-500 dark:bg-emerald-400"
+                            style={{ width: `${Math.min(Math.max(gpuUtil, 0), 100)}%` }}
+                          />
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-5 py-3.5 sm:px-6">
                       <div className="flex items-end gap-1.5" style={{ height: 40 }}>
                         {h.gpus.map((gpu) => {
                           const pct = gpu.memTotalMb > 0 ? Math.round((gpu.memUsedMb / gpu.memTotalMb) * 100) : 0;
@@ -618,10 +694,13 @@ export function GpuDashboard({
                                   style={{ height: `${Math.max(pct, 2)}%` }}
                                 />
                               </div>
-                              <div className="pointer-events-none absolute -top-10 left-1/2 z-50 hidden -translate-x-1/2 whitespace-nowrap rounded border border-zinc-200 bg-white px-2 py-1 text-xs shadow-lg group-hover:block dark:border-zinc-700 dark:bg-zinc-900">
+                              <div className="pointer-events-none absolute -top-14 left-1/2 z-50 hidden -translate-x-1/2 whitespace-nowrap rounded border border-zinc-200 bg-white px-2 py-1 text-xs shadow-lg group-hover:block dark:border-zinc-700 dark:bg-zinc-900">
                                 <span className="font-medium">GPU {gpu.index}</span>
                                 <span className="ml-1 text-zinc-400">
                                   {formatMemory(gpu.memUsedMb)} / {formatMemory(gpu.memTotalMb)} ({pct}%)
+                                </span>
+                                <span className="block text-zinc-400">
+                                  GPU utilization: {Math.round(gpu.gpuUtil)}%
                                 </span>
                               </div>
                             </div>
@@ -645,7 +724,7 @@ export function GpuDashboard({
               })}
               {hostRows.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="px-5 py-12 text-center text-zinc-400">
+                  <td colSpan={6} className="px-5 py-12 text-center text-zinc-400">
                     No GPU data found. Deploy the reporting script to start collecting metrics.
                   </td>
                 </tr>

--- a/src/lib/gpu-data.ts
+++ b/src/lib/gpu-data.ts
@@ -37,6 +37,7 @@ function normalizeSnapshots(rows: DbRow[]): GpuSnapshot[] {
     hostname: String(row.hostname),
     gpu_name: row.gpu_name == null ? null : String(row.gpu_name),
     mem_pct_sum: Number(row.mem_pct_sum),
+    gpu_util_sum: Number(row.gpu_util_sum),
     sample_count: Number(row.sample_count),
   }));
 }
@@ -46,6 +47,7 @@ function normalizeLatest(rows: DbRow[]): GpuLatest[] {
     hostname: String(row.hostname),
     gpu_index: Number(row.gpu_index),
     gpu_name: row.gpu_name == null ? null : String(row.gpu_name),
+    gpu_util: Number(row.gpu_util),
     mem_used_mb: Number(row.mem_used_mb),
     mem_total_mb: Number(row.mem_total_mb),
     reported_at: isoString(row.reported_at),
@@ -67,7 +69,7 @@ function summarizeGpuHistory(
 ): GpuOverviewPoint[] {
   const buckets = new Map<
     number,
-    Map<string, { memPctSum: number; sampleCount: number }>
+    Map<string, { memPctSum: number; gpuUtilSum: number; sampleCount: number }>
   >();
 
   for (const snapshot of history.snapshots) {
@@ -75,9 +77,11 @@ function summarizeGpuHistory(
     const hosts = buckets.get(time) ?? new Map();
     const host = hosts.get(snapshot.hostname) ?? {
       memPctSum: 0,
+      gpuUtilSum: 0,
       sampleCount: 0,
     };
     host.memPctSum += snapshot.mem_pct_sum;
+    host.gpuUtilSum += snapshot.gpu_util_sum;
     host.sampleCount += snapshot.sample_count;
     hosts.set(snapshot.hostname, host);
     buckets.set(time, hosts);
@@ -85,14 +89,23 @@ function summarizeGpuHistory(
 
   return [...buckets.entries()]
     .map(([time, hosts]) => {
-      const values = [...hosts.values()]
-        .filter((host) => host.sampleCount > 0)
-        .map((host) => host.memPctSum / host.sampleCount);
+      const activeHosts = [...hosts.values()].filter(
+        (host) => host.sampleCount > 0,
+      );
+      const memoryValues = activeHosts.map(
+        (host) => host.memPctSum / host.sampleCount,
+      );
+      const gpuValues = activeHosts.map(
+        (host) => host.gpuUtilSum / host.sampleCount,
+      );
       return {
         time,
-        p50: Math.round(percentile(values, 0.5)),
-        p90: Math.round(percentile(values, 0.9)),
-        peak: Math.round(Math.max(...values, 0)),
+        memoryP50: Math.round(percentile(memoryValues, 0.5)),
+        memoryP90: Math.round(percentile(memoryValues, 0.9)),
+        memoryPeak: Math.round(Math.max(...memoryValues, 0)),
+        gpuP50: Math.round(percentile(gpuValues, 0.5)),
+        gpuP90: Math.round(percentile(gpuValues, 0.9)),
+        gpuPeak: Math.round(Math.max(...gpuValues, 0)),
       };
     })
     .sort((a, b) => a.time - b.time);
@@ -123,6 +136,7 @@ export async function queryGpuHistory(
             WHEN mem_total_mb > 0 THEN mem_used_mb / mem_total_mb * 100
             ELSE 0
           END)::numeric, 2) AS mem_pct_sum,
+          ROUND(SUM(gpu_util)::numeric, 2) AS gpu_util_sum,
           COUNT(*)::bigint AS sample_count
         FROM gpu_snapshots
         WHERE reported_at > NOW() - INTERVAL '1 hour' * ${hours}
@@ -140,6 +154,7 @@ export async function queryGpuHistory(
           hostname,
           NULLIF(gpu_name, 'Unknown') AS gpu_name,
           ROUND(SUM(mem_pct_sum)::numeric, 2) AS mem_pct_sum,
+          ROUND(SUM(gpu_util_sum)::numeric, 2) AS gpu_util_sum,
           SUM(sample_count)::bigint AS sample_count
         FROM gpu_history_5m
         WHERE time_bucket > NOW() - INTERVAL '1 hour' * ${hours}
@@ -177,11 +192,11 @@ export async function queryGpuLatest(): Promise<GpuLatest[]> {
         LIMIT 1
       ) next_key
     )
-    SELECT l.hostname, l.gpu_index, l.gpu_name, l.mem_used_mb,
-           l.mem_total_mb, l.reported_at
+    SELECT l.hostname, l.gpu_index, l.gpu_name, l.gpu_util,
+           l.mem_used_mb, l.mem_total_mb, l.reported_at
     FROM gpu_keys k
     CROSS JOIN LATERAL (
-      SELECT hostname, gpu_index, gpu_name, mem_used_mb, mem_total_mb, reported_at
+      SELECT hostname, gpu_index, gpu_name, gpu_util, mem_used_mb, mem_total_mb, reported_at
       FROM gpu_snapshots s
       WHERE s.hostname = k.hostname AND s.gpu_index = k.gpu_index
       ORDER BY s.reported_at DESC
@@ -195,7 +210,7 @@ export async function queryGpuLatest(): Promise<GpuLatest[]> {
 
 const getCachedInitialHistory = unstable_cache(
   () => queryGpuHistory(24),
-  ["gpu-initial-history-v1"],
+  ["gpu-initial-history-v2"],
   { revalidate: 60, tags: ["gpu-history"] },
 );
 
@@ -204,7 +219,7 @@ const getCachedInitialLatest = unstable_cache(
     latest: await queryGpuLatest(),
     checked_at: new Date().toISOString(),
   }),
-  ["gpu-initial-latest-v2"],
+  ["gpu-initial-latest-v3"],
   { revalidate: 30, tags: ["gpu-latest"] },
 );
 

--- a/src/lib/gpu-types.ts
+++ b/src/lib/gpu-types.ts
@@ -3,6 +3,7 @@ export interface GpuSnapshot {
   hostname: string;
   gpu_name: string | null;
   mem_pct_sum: number;
+  gpu_util_sum: number;
   sample_count: number;
 }
 
@@ -10,6 +11,7 @@ export interface GpuLatest {
   hostname: string;
   gpu_index: number;
   gpu_name: string | null;
+  gpu_util: number;
   mem_used_mb: number;
   mem_total_mb: number;
   reported_at: string;
@@ -23,9 +25,12 @@ export interface GpuHistoryResponse {
 
 export interface GpuOverviewPoint {
   time: number;
-  p50: number;
-  p90: number;
-  peak: number;
+  memoryP50: number;
+  memoryP90: number;
+  memoryPeak: number;
+  gpuP50: number;
+  gpuP90: number;
+  gpuPeak: number;
 }
 
 export interface GpuLatestResponse {


### PR DESCRIPTION
## Summary

- include current GPU utilization in the latest telemetry response and host summary
- add a Memory / GPU Utilization selector for fleet overview and per-host history
- persist utilization in the 5-minute rollup and backfill existing history
- keep the stacked chart memory-only because stacked utilization percentages are misleading

## Why

The reporters already send `gpu_util` and raw snapshots already store it, but the read models, rollup table, and dashboard only exposed memory usage.

## Validation

- targeted ESLint on all changed files
- `npx tsc --noEmit`
- production `npm run build`
- browser-tested the live-data host table and 1-hour utilization Overview/Hosts controls

## Deployment note

Run `npm run migrate:gpu-rollups` against production immediately before deploying this change. The migration adds and backfills `gpu_util_sum`; running it significantly earlier would let the old reporter create incomplete utilization rollups before the new ingestion code is live.