### PR TITLE
Add longer queue history ranges

### DIFF
--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -5,6 +5,7 @@ import { cachedJson } from "@/lib/api-response";
 
 const TTL = 15_000;
 const CDN_CACHE = { maxAge: 15, staleWhileRevalidate: 3_600 };
+const MAX_HISTORY_HOURS = 90 * 24;
 
 export async function GET(request: NextRequest) {
   try {
@@ -12,7 +13,7 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const hours = Math.min(
       parseInt(searchParams.get("hours") ?? "24", 10) || 24,
-      720,
+      MAX_HISTORY_HOURS,
     );
     const queue = searchParams.get("queue") || null;
     const cacheKey = `metrics:${hours}:${queue ?? "all"}`;

--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -73,7 +73,14 @@ const METRICS_HOURS_OPTIONS = [
   { label: "6h", value: 6 },
   { label: "24h", value: 24 },
   { label: "7d", value: 168 },
+  { label: "14d", value: 14 * 24 },
+  { label: "30d", value: 30 * 24 },
+  { label: "90d", value: 90 * 24 },
 ];
+
+function formatMetricsRange(hours: number): string {
+  return hours <= 24 ? `${hours}h` : `${hours / 24}d`;
+}
 
 // Queues whose raw jobs_waiting count is meaningful and should be charted as
 // a separate grey bar (in addition to the yellow scheduled "Waiting" bar).
@@ -281,10 +288,10 @@ export default function QueuePage() {
                 {error
                   ? historyMatchesSelection
                     ? "Refresh paused — showing saved data"
-                    : `Couldn’t load ${metricsHours <= 24 ? `${metricsHours}h` : "7d"} — showing ${displayedMetricsHours <= 24 ? `${displayedMetricsHours}h` : "7d"}`
+                    : `Couldn’t load ${formatMetricsRange(metricsHours)} — showing ${formatMetricsRange(displayedMetricsHours)}`
                   : historyMatchesSelection
                     ? "Updating history"
-                    : `Loading ${metricsHours <= 24 ? `${metricsHours}h` : "7d"} — showing ${displayedMetricsHours <= 24 ? `${displayedMetricsHours}h` : "7d"}`}
+                    : `Loading ${formatMetricsRange(metricsHours)} — showing ${formatMetricsRange(displayedMetricsHours)}`}
               </span>
               {error && (
                 <button
@@ -314,7 +321,7 @@ export default function QueuePage() {
                     : "ready"
             }
             queue={queue}
-            rangeLabel={metricsHours <= 24 ? `${metricsHours}h` : "7d"}
+            rangeLabel={formatMetricsRange(metricsHours)}
             emptyMessage={`No snapshots recorded for ${queue || "these queues"} in this timeframe.`}
             onRetry={() => void refreshMetrics()}
           />


### PR DESCRIPTION
## Summary

- add 14d, 30d, and 90d options to the Queue Metrics history selector
- extend the metrics API history limit to 90 days
- show the actual selected range in loading, error, and empty chart states

## Why

The queue tab previously stopped at 7 days in the UI, while operators need longer windows for capacity and queue trend analysis. The API was also capped at 30 days, and status labels hardcoded every range above 24 hours as 7d.

## Validation

- `npm run lint -- src/app/queue/page.tsx src/app/api/metrics/route.ts`
- `npx tsc --noEmit`
- `git diff --check`
- `npm run build -- --webpack`