### PR TITLE
Remove flaky test filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Next.js dashboard for observing vLLM's Buildkite CI: build status, job runtime
 
 - **Builds** — pass/fail rates, durations, and per-job breakdowns for recent pipeline builds.
 - **Jobs** — latest job failures and per-job historical run times.
-- **Tests** — Test Engine reliability, flaky-test filters, execution counts, and duration history.
+- **Tests** — Test Engine reliability, execution counts, and duration history.
 - **Queue** — live agent queue depth, waiting builds, and Slack alerts when queues back up.
 - **Cost** — compute hours and dollar cost per queue, derived from AWS on-demand pricing.
 - **Performance** — benchmark trends ingested into the warehouse.

--- a/src/app/api/tests/route.ts
+++ b/src/app/api/tests/route.ts
@@ -67,9 +67,6 @@ export async function GET(request: NextRequest) {
   upstreamUrl.searchParams.set("page", String(page));
   upstreamUrl.searchParams.set("per_page", String(PAGE_SIZE));
   if (state) upstreamUrl.searchParams.set("state", state);
-  if (params.get("flaky") === "true") {
-    upstreamUrl.searchParams.set("labels", "flaky");
-  }
 
   try {
     const response = await fetch(upstreamUrl, {

--- a/src/app/tests/page.tsx
+++ b/src/app/tests/page.tsx
@@ -211,7 +211,6 @@ function LoadingRows() {
 export default function TestsPage() {
   const [period, setPeriod] = useState<Period>("1day");
   const [state, setState] = useState<TestState>("all");
-  const [flakyOnly, setFlakyOnly] = useState(false);
   const [sortBy, setSortBy] = useState<SortBy>("reliability");
   const [order, setOrder] = useState<"asc" | "desc">("asc");
   const [page, setPage] = useState(1);
@@ -226,7 +225,6 @@ export default function TestsPage() {
     page: String(page),
   });
   if (state !== "all") params.set("state", state);
-  if (flakyOnly) params.set("flaky", "true");
 
   const { data, error, isLoading, isValidating } = useSWR<TestsResponse>(
     `/api/tests?${params.toString()}`,
@@ -315,23 +313,6 @@ export default function TestsPage() {
               <option value="muted">Muted</option>
               <option value="skipped">Skipped</option>
             </select>
-            <button
-              type="button"
-              aria-pressed={flakyOnly}
-              onClick={() => {
-                setFlakyOnly((value) => !value);
-                setPage(1);
-                setExpanded(null);
-              }}
-              className={`dashboard-control inline-flex min-h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium shadow-sm ${
-                flakyOnly
-                  ? "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-300"
-                  : "border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:border-zinc-600"
-              }`}
-            >
-              <span className={`h-2 w-2 rounded-full ${flakyOnly ? "bg-rose-500" : "bg-zinc-300 dark:bg-zinc-600"}`} />
-              Flaky only
-            </button>
           </div>
           <label className="relative block w-full sm:w-72">
             <span className="sr-only">Search tests on this page</span>


### PR DESCRIPTION
## Summary

- remove the **Flaky only** control from the Tests dashboard
- stop forwarding the unsupported `flaky` query filter to Buildkite Test Engine
- update the Tests page documentation

## Why

Flakiness tracking is not mature enough yet to expose as a dashboard filter. Reliability and historical execution data remain available.

Follow-up to #45.

## Validation

- `npm run lint`
- `npm run build -- --webpack`
- visual check against 30 live Test Engine rows with no browser warnings or errors

## Screenshot

<img width="1280" height="2651" alt="Tests dashboard without flaky filter" src="https://github.com/user-attachments/assets/059159c6-2468-4f08-94fb-e2193631fe9d" />