### PR TITLE
Add Buildkite OTel trace ingestion

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -14,10 +14,19 @@ DATABASE_URL=postgres://user:pass@host:5432/dbname
 # Buildkite Agent Metrics API (required for agent metrics polling)
 BUILDKITE_AGENT_TOKEN=your-agent-registration-token
 
-# Buildkite Test Engine API (requires a personal API token with read_suites)
+# Buildkite API (scope requirements depend on the enabled dashboard features)
 BUILDKITE_API_TOKEN=your-personal-api-token
 BUILDKITE_ORGANIZATION=vllm
 BUILDKITE_TEST_SUITE=ci-1
+
+# Authenticates OTLP/HTTP trace ingestion. Generate a separate random value;
+# configure the same value as a Bearer header in Buildkite.
+OTEL_INGEST_TOKEN=your-random-otel-ingest-token
+# Optional request limit in bytes. Defaults to 4 MiB.
+OTEL_MAX_REQUEST_BYTES=4194304
+# Base URL used by `npm run configure:buildkite-otel`. Buildkite appends
+# /v1/traces automatically.
+OTEL_ENDPOINT=https://ci.vllm.ai/api/otel
 
 # GPU reporting auth (must match GPU_REPORT_SECRET on the node-side script)
 GPU_REPORT_SECRET=your-gpu-report-secret

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ cp .env.local.example .env.local
 # fill in your own credentials
 npm install
 npm run migrate:gpu-rollups
+npm run migrate:otel
 npm run dev
 ```
 
@@ -42,8 +43,11 @@ Open http://localhost:3000.
 | `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, `DATABRICKS_WAREHOUSE_ID` | Databricks SQL Warehouse access |
 | `DATABASE_URL` | Postgres connection string for agent/queue samples |
 | `BUILDKITE_AGENT_TOKEN` | Buildkite agent registration token (for the Agent Metrics API) |
-| `BUILDKITE_API_TOKEN` | Buildkite personal API token with `read_suites` (for Test Engine data) |
+| `BUILDKITE_API_TOKEN` | Buildkite personal API token; needs `read_suites` for Test Engine and notification-service scopes only when running the OTel setup script |
 | `BUILDKITE_ORGANIZATION`, `BUILDKITE_TEST_SUITE` | Test Engine organization and suite slug (defaults: `vllm`, `ci-1`) |
+| `OTEL_INGEST_TOKEN` | Required Bearer token for the OTLP/HTTP trace receiver |
+| `OTEL_MAX_REQUEST_BYTES` | Optional OTLP request limit; defaults to 4 MiB |
+| `OTEL_ENDPOINT` | Buildkite notification-service base URL; defaults operationally to `https://ci.vllm.ai/api/otel` |
 | `SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID` | Slack bot for queue-depth alerts (`chat:write`, `reactions:write`) |
 | `CRON_SECRET` | Optional shared secret required by Vercel cron handlers |
 
@@ -54,6 +58,56 @@ GPU telemetry is written to raw `gpu_snapshots` rows and an incremental
 Run `npm run migrate:gpu-rollups` once before deploying a version that reads
 the rollup. The migration is idempotent and backfills existing raw snapshots;
 schema creation is intentionally kept out of user-facing request handlers.
+
+## OpenTelemetry trace ingestion
+
+The dashboard includes an authenticated OTLP/HTTP protobuf receiver at
+`/api/otel/v1/traces`. It stores normalized spans in the operational Postgres
+database so dashboard features can enrich the canonical Databricks build and
+job history without introducing another dashboard.
+
+1. Generate a dedicated random `OTEL_INGEST_TOKEN` with
+   `openssl rand -hex 32` and add it to the Vercel project. Do not reuse a
+   Buildkite or database credential.
+2. Run `npm run migrate:otel` against the production `DATABASE_URL`.
+3. Deploy the dashboard and verify the authenticated
+   `GET /api/otel/health` endpoint.
+4. Create or reconcile Buildkite's OpenTelemetry notification service:
+
+   ```bash
+   BUILDKITE_API_TOKEN=... \
+   OTEL_INGEST_TOKEN=... \
+   OTEL_ENDPOINT=https://ci.vllm.ai/api/otel \
+   npm run configure:buildkite-otel
+   ```
+
+   `OTEL_ENDPOINT` is the base endpoint. Buildkite appends `/v1/traces`.
+   The API token needs `read_notification_services` and
+   `write_notification_services`, and its owner needs organization admin or
+   Manage Notification Services access.
+
+5. Verify delivery without exposing span data publicly:
+
+   ```bash
+   curl -H "Authorization: Bearer $OTEL_INGEST_TOKEN" \
+     https://ci.vllm.ai/api/otel/health
+   ```
+
+The Vercel receiver accepts OTLP/HTTP protobuf with optional gzip compression;
+it is not a gRPC collector. To add agent-side checkout, hook, plugin, command,
+and artifact spans, Buildkite agent v3.101 or newer can be configured with:
+
+```bash
+BUILDKITE_TRACING_BACKEND=opentelemetry
+BUILDKITE_TRACING_PROPAGATE_TRACEPARENT=true
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_EXPORTER_OTLP_ENDPOINT=https://ci.vllm.ai/api/otel
+OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer $OTEL_INGEST_TOKEN"
+OTEL_TRACES_SAMPLER=always_on
+```
+
+For older agents that only export OTLP/gRPC, put a standard OpenTelemetry
+Collector in front of this HTTP endpoint or upgrade the agents first.
 
 ## Deployment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "next": "16.1.7",
         "plotly.js-basic-dist-min": "^3.4.0",
         "postgres": "^3.4.8",
+        "protobufjs": "^8.7.2",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-plotly.js": "^2.6.0",
@@ -6948,6 +6949,12 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -7980,6 +7987,18 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.2.tgz",
+      "integrity": "sha512-oTVHV+oelUBtiu5iTuTNNZ0eLYsXSMxry4cgr30mayNkgIZL6qZ0IOQVPuSWGcyAaXKl/XgqwWHIC3a0khYVBA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/protocol-buffers-schema": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "migrate:gpu-rollups": "node scripts/migrate-gpu-rollups.mjs"
+    "migrate:gpu-rollups": "node scripts/migrate-gpu-rollups.mjs",
+    "migrate:otel": "node scripts/migrate-otel.mjs",
+    "configure:buildkite-otel": "node scripts/configure-buildkite-otel.mjs"
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
@@ -15,6 +17,7 @@
     "next": "16.1.7",
     "plotly.js-basic-dist-min": "^3.4.0",
     "postgres": "^3.4.8",
+    "protobufjs": "^8.7.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-plotly.js": "^2.6.0",

--- a/scripts/configure-buildkite-otel.mjs
+++ b/scripts/configure-buildkite-otel.mjs
@@ -1,0 +1,127 @@
+const apiToken = process.env.BUILDKITE_API_TOKEN;
+const ingestToken = process.env.OTEL_INGEST_TOKEN;
+const organization =
+  process.env.BUILDKITE_ORGANIZATION ?? process.env.BUILDKITE_ORG_SLUG ?? "vllm";
+const configuredEndpoint = process.env.OTEL_ENDPOINT;
+
+if (!apiToken) throw new Error("BUILDKITE_API_TOKEN is not set");
+if (!ingestToken) throw new Error("OTEL_INGEST_TOKEN is not set");
+if (!configuredEndpoint) throw new Error("OTEL_ENDPOINT is not set");
+
+const endpointUrl = new URL(configuredEndpoint);
+if (endpointUrl.protocol !== "https:") {
+  throw new Error("OTEL_ENDPOINT must use HTTPS");
+}
+if (endpointUrl.search || endpointUrl.hash) {
+  throw new Error("OTEL_ENDPOINT must not contain a query string or fragment");
+}
+
+const endpoint = configuredEndpoint.replace(/\/+$/, "");
+if (endpoint.endsWith("/v1/traces")) {
+  throw new Error("OTEL_ENDPOINT must be the base URL without /v1/traces");
+}
+
+const apiBase = `https://api.buildkite.com/v2/organizations/${encodeURIComponent(organization)}`;
+const buildStates = {
+  build_passed: true,
+  build_fixed: true,
+  build_failed: true,
+  build_blocked: true,
+  build_canceled: true,
+  build_failing: true,
+  job_activated: true,
+};
+
+async function buildkiteRequest(url, init = {}) {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      Accept: "application/json",
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...init.headers,
+    },
+  });
+  const text = await response.text();
+  const body = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    const detail = body?.message ?? body?.error ?? text ?? response.statusText;
+    throw new Error(`Buildkite API ${response.status}: ${detail}`);
+  }
+  return body;
+}
+
+async function listServices() {
+  const services = [];
+  let next = `${apiBase}/services?per_page=100`;
+  while (next) {
+    const page = await buildkiteRequest(next);
+    services.push(...(page.items ?? []));
+    next = page.links?.next ?? null;
+  }
+  return services;
+}
+
+const services = await listServices();
+const matches = services.filter(
+  (service) =>
+    service.provider?.id === "open_telemetry_tracing" &&
+    service.settings?.endpoint?.replace(/\/+$/, "") === endpoint,
+);
+
+if (matches.length > 1) {
+  throw new Error(
+    `Found ${matches.length} OpenTelemetry services for ${endpoint}; reconcile them manually`,
+  );
+}
+
+const payload = {
+  provider: "open_telemetry_tracing",
+  description: "vLLM CI dashboard trace ingestion",
+  scope: "all",
+  branch_configuration: "",
+  build_states: buildStates,
+  settings: {
+    endpoint,
+    service_name: "buildkite",
+    headers: { Authorization: `Bearer ${ingestToken}` },
+    resource_attributes: { destination: "vllm-ci-dashboard" },
+  },
+};
+
+let service;
+if (matches.length === 0) {
+  service = await buildkiteRequest(`${apiBase}/services`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  console.log(`Created Buildkite OpenTelemetry service ${service.id}`);
+} else {
+  service = await buildkiteRequest(matches[0].url, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+  console.log(`Updated Buildkite OpenTelemetry service ${service.id}`);
+}
+
+if (!service.enabled) {
+  service = await buildkiteRequest(`${service.url}/enable`, { method: "PUT" });
+  console.log(`Enabled Buildkite OpenTelemetry service ${service.id}`);
+}
+
+const verified = await buildkiteRequest(service.url);
+if (
+  verified.provider?.id !== "open_telemetry_tracing" ||
+  verified.settings?.endpoint?.replace(/\/+$/, "") !== endpoint ||
+  verified.scope !== "all" ||
+  Object.keys(buildStates).some(
+    (state) => verified.build_states?.[state] !== true,
+  ) ||
+  !verified.enabled
+) {
+  throw new Error("Buildkite OpenTelemetry service verification failed");
+}
+
+console.log(
+  `Verified Buildkite OpenTelemetry service ${verified.id}: enabled, scope=all, endpoint=${endpoint}`,
+);

--- a/scripts/migrate-otel.mjs
+++ b/scripts/migrate-otel.mjs
@@ -1,0 +1,84 @@
+import postgres from "postgres";
+
+const url = process.env.DATABASE_URL;
+if (!url) {
+  throw new Error("DATABASE_URL is not set");
+}
+
+const sql = postgres(url, { ssl: "require", max: 1, prepare: false });
+const startedAt = Date.now();
+
+try {
+  await sql`
+    CREATE TABLE IF NOT EXISTS otel_spans (
+      trace_id                   TEXT NOT NULL,
+      span_id                    TEXT NOT NULL,
+      parent_span_id             TEXT,
+      trace_state                TEXT,
+      trace_flags                INTEGER NOT NULL DEFAULT 0,
+      span_name                  TEXT NOT NULL,
+      span_kind                  SMALLINT NOT NULL DEFAULT 0,
+      start_time                 TIMESTAMPTZ NOT NULL,
+      end_time                   TIMESTAMPTZ NOT NULL,
+      duration_ms                DOUBLE PRECISION NOT NULL,
+      status_code                SMALLINT NOT NULL DEFAULT 0,
+      status_message             TEXT,
+      service_name               TEXT,
+      scope_name                 TEXT,
+      scope_version              TEXT,
+      resource_schema_url        TEXT,
+      scope_schema_url           TEXT,
+      organization_slug          TEXT,
+      pipeline_slug              TEXT,
+      build_id                   TEXT,
+      build_number               BIGINT,
+      build_state                TEXT,
+      step_id                    TEXT,
+      step_key                   TEXT,
+      job_id                     TEXT,
+      job_label                  TEXT,
+      job_state                  TEXT,
+      agent_id                   TEXT,
+      agent_name                 TEXT,
+      agent_queue                TEXT,
+      resource_attributes        JSONB NOT NULL DEFAULT '{}',
+      span_attributes            JSONB NOT NULL DEFAULT '{}',
+      span_events                JSONB NOT NULL DEFAULT '[]',
+      span_links                 JSONB NOT NULL DEFAULT '[]',
+      dropped_attributes_count   INTEGER NOT NULL DEFAULT 0,
+      dropped_events_count       INTEGER NOT NULL DEFAULT 0,
+      dropped_links_count        INTEGER NOT NULL DEFAULT 0,
+      received_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (trace_id, span_id)
+    )
+  `;
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_otel_spans_received
+    ON otel_spans (received_at DESC)
+  `;
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_otel_spans_build
+    ON otel_spans (organization_slug, pipeline_slug, build_number, start_time)
+  `;
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_otel_spans_build_id
+    ON otel_spans (build_id, start_time)
+    WHERE build_id IS NOT NULL
+  `;
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_otel_spans_job
+    ON otel_spans (job_id, start_time)
+    WHERE job_id IS NOT NULL
+  `;
+
+  const [stats] = await sql`
+    SELECT COUNT(*)::bigint AS spans, MAX(received_at) AS latest_received_at
+    FROM otel_spans
+  `;
+  console.log(
+    `OTel migration complete: ${stats.spans} spans in ${Date.now() - startedAt}ms ` +
+      `(latest ${stats.latest_received_at?.toISOString() ?? "none"})`,
+  );
+} finally {
+  await sql.end();
+}

--- a/src/app/api/otel/health/route.ts
+++ b/src/app/api/otel/health/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { isOtlpAuthorized, isOtlpConfigured } from "@/lib/otel-auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  if (!isOtlpConfigured()) {
+    return NextResponse.json(
+      { ok: false, error: "OTLP ingestion is not configured" },
+      { status: 503 },
+    );
+  }
+  if (!isOtlpAuthorized(request.headers)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const db = getDb();
+    const [stats] = await db<
+      Array<{
+        spans_24h: string;
+        traces_24h: string;
+        latest_received_at: Date | null;
+        latest_span_start: Date | null;
+      }>
+    >`
+      SELECT
+        COUNT(*) FILTER (WHERE received_at >= NOW() - INTERVAL '24 hours')::text
+          AS spans_24h,
+        COUNT(DISTINCT trace_id) FILTER (
+          WHERE received_at >= NOW() - INTERVAL '24 hours'
+        )::text AS traces_24h,
+        MAX(received_at) AS latest_received_at,
+        MAX(start_time) AS latest_span_start
+      FROM otel_spans
+    `;
+
+    return NextResponse.json({
+      ok: true,
+      spans_24h: Number(stats.spans_24h),
+      traces_24h: Number(stats.traces_24h),
+      latest_received_at: stats.latest_received_at?.toISOString() ?? null,
+      latest_span_start: stats.latest_span_start?.toISOString() ?? null,
+    });
+  } catch (error) {
+    console.error("OTLP health check failed:", error);
+    return NextResponse.json(
+      { ok: false, error: "OTLP storage is unavailable" },
+      { status: 503 },
+    );
+  }
+}

--- a/src/app/api/otel/v1/traces/route.ts
+++ b/src/app/api/otel/v1/traces/route.ts
@@ -1,0 +1,88 @@
+import { gunzipSync } from "node:zlib";
+import { NextRequest, NextResponse } from "next/server";
+import { isOtlpAuthorized, isOtlpConfigured } from "@/lib/otel-auth";
+import { decodeOtlpTraceRequest } from "@/lib/otel-proto";
+import { storeOtlpSpans } from "@/lib/otel-storage";
+
+export const runtime = "nodejs";
+
+const DEFAULT_MAX_REQUEST_BYTES = 4 * 1024 * 1024;
+
+function maxRequestBytes(): number {
+  const configured = Number(process.env.OTEL_MAX_REQUEST_BYTES);
+  return Number.isSafeInteger(configured) && configured > 0
+    ? configured
+    : DEFAULT_MAX_REQUEST_BYTES;
+}
+
+function protobufResponse() {
+  return new NextResponse(new Uint8Array(), {
+    status: 200,
+    headers: { "Content-Type": "application/x-protobuf" },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  if (!isOtlpConfigured()) {
+    return NextResponse.json(
+      { error: "OTLP ingestion is not configured" },
+      { status: 503 },
+    );
+  }
+  if (!isOtlpAuthorized(request.headers)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const contentType = request.headers.get("content-type")?.split(";", 1)[0];
+  if (contentType !== "application/x-protobuf") {
+    return NextResponse.json(
+      { error: "Content-Type must be application/x-protobuf" },
+      { status: 415 },
+    );
+  }
+
+  const limit = maxRequestBytes();
+  const declaredLength = Number(request.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > limit) {
+    return NextResponse.json({ error: "Payload too large" }, { status: 413 });
+  }
+
+  let spans;
+  try {
+    let payload = Buffer.from(await request.arrayBuffer());
+    if (payload.byteLength > limit) {
+      return NextResponse.json({ error: "Payload too large" }, { status: 413 });
+    }
+
+    const contentEncoding = request.headers.get("content-encoding");
+    if (contentEncoding === "gzip") {
+      payload = gunzipSync(payload, { maxOutputLength: limit });
+    } else if (contentEncoding && contentEncoding !== "identity") {
+      return NextResponse.json(
+        { error: "Unsupported Content-Encoding" },
+        { status: 415 },
+      );
+    }
+
+    spans = decodeOtlpTraceRequest(payload);
+  } catch (error) {
+    console.error("Invalid OTLP trace request:", error);
+    return NextResponse.json(
+      { error: "Invalid OTLP trace request" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await storeOtlpSpans(spans);
+    return protobufResponse();
+  } catch (error) {
+    // OTLP exporters retry 503 responses. A database or server failure is not
+    // a bad payload and must not be reported as a permanent 4xx rejection.
+    console.error("OTLP trace storage failed:", error);
+    return NextResponse.json(
+      { error: "OTLP storage is temporarily unavailable" },
+      { status: 503, headers: { "Retry-After": "5" } },
+    );
+  }
+}

--- a/src/lib/otel-auth.ts
+++ b/src/lib/otel-auth.ts
@@ -1,0 +1,19 @@
+import { timingSafeEqual } from "node:crypto";
+
+export function isOtlpConfigured(): boolean {
+  return Boolean(process.env.OTEL_INGEST_TOKEN);
+}
+
+export function isOtlpAuthorized(headers: Headers): boolean {
+  const expected = process.env.OTEL_INGEST_TOKEN;
+  const authorization = headers.get("authorization");
+  if (!expected || !authorization?.startsWith("Bearer ")) return false;
+
+  const received = authorization.slice("Bearer ".length);
+  const expectedBytes = Buffer.from(expected);
+  const receivedBytes = Buffer.from(received);
+  return (
+    expectedBytes.length === receivedBytes.length &&
+    timingSafeEqual(expectedBytes, receivedBytes)
+  );
+}

--- a/src/lib/otel-proto.ts
+++ b/src/lib/otel-proto.ts
@@ -1,0 +1,364 @@
+import { parse, type Type } from "protobufjs";
+
+export type OtlpAttributeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | OtlpAttributeValue[]
+  | { [key: string]: OtlpAttributeValue };
+
+export interface OtlpSpanEvent {
+  timeUnixNano: string;
+  name: string;
+  attributes: Record<string, OtlpAttributeValue>;
+  droppedAttributesCount: number;
+}
+
+export interface OtlpSpanLink {
+  traceId: string;
+  spanId: string;
+  traceState: string | null;
+  attributes: Record<string, OtlpAttributeValue>;
+  droppedAttributesCount: number;
+  flags: number;
+}
+
+export interface NormalizedOtlpSpan {
+  traceId: string;
+  spanId: string;
+  parentSpanId: string | null;
+  traceState: string | null;
+  flags: number;
+  name: string;
+  kind: number;
+  startTime: Date;
+  endTime: Date;
+  durationMs: number;
+  statusCode: number;
+  statusMessage: string | null;
+  scopeName: string | null;
+  scopeVersion: string | null;
+  scopeSchemaUrl: string | null;
+  resourceSchemaUrl: string | null;
+  resourceAttributes: Record<string, OtlpAttributeValue>;
+  spanAttributes: Record<string, OtlpAttributeValue>;
+  events: OtlpSpanEvent[];
+  links: OtlpSpanLink[];
+  droppedAttributesCount: number;
+  droppedEventsCount: number;
+  droppedLinksCount: number;
+}
+
+interface LongLike {
+  toString(): string;
+}
+
+interface ProtoAnyValue {
+  stringValue?: string;
+  boolValue?: boolean;
+  intValue?: number | string | LongLike;
+  doubleValue?: number;
+  arrayValue?: { values?: ProtoAnyValue[] };
+  kvlistValue?: { values?: ProtoKeyValue[] };
+  bytesValue?: Uint8Array;
+}
+
+interface ProtoKeyValue {
+  key?: string;
+  value?: ProtoAnyValue;
+}
+
+interface ProtoSpan {
+  traceId?: Uint8Array;
+  spanId?: Uint8Array;
+  traceState?: string;
+  parentSpanId?: Uint8Array;
+  flags?: number;
+  name?: string;
+  kind?: number;
+  startTimeUnixNano?: number | string | LongLike;
+  endTimeUnixNano?: number | string | LongLike;
+  attributes?: ProtoKeyValue[];
+  droppedAttributesCount?: number;
+  events?: Array<{
+    timeUnixNano?: number | string | LongLike;
+    name?: string;
+    attributes?: ProtoKeyValue[];
+    droppedAttributesCount?: number;
+  }>;
+  droppedEventsCount?: number;
+  links?: Array<{
+    traceId?: Uint8Array;
+    spanId?: Uint8Array;
+    traceState?: string;
+    attributes?: ProtoKeyValue[];
+    droppedAttributesCount?: number;
+    flags?: number;
+  }>;
+  droppedLinksCount?: number;
+  status?: { message?: string; code?: number };
+}
+
+interface ExportTraceServiceRequest {
+  resourceSpans?: Array<{
+    resource?: { attributes?: ProtoKeyValue[] };
+    scopeSpans?: Array<{
+      scope?: { name?: string; version?: string };
+      spans?: ProtoSpan[];
+      schemaUrl?: string;
+    }>;
+    schemaUrl?: string;
+  }>;
+}
+
+// This is the wire-compatible subset of the stable OpenTelemetry trace proto.
+// Protobuf message names and packages do not affect the wire format; field
+// numbers and wire types do. Keeping the schema inline avoids filesystem reads
+// from a serverless function bundle.
+const TRACE_PROTO = `
+syntax = "proto3";
+
+message ExportTraceServiceRequest {
+  repeated ResourceSpans resource_spans = 1;
+}
+
+message ResourceSpans {
+  Resource resource = 1;
+  repeated ScopeSpans scope_spans = 2;
+  string schema_url = 3;
+}
+
+message ScopeSpans {
+  InstrumentationScope scope = 1;
+  repeated Span spans = 2;
+  string schema_url = 3;
+}
+
+message Resource {
+  repeated KeyValue attributes = 1;
+  uint32 dropped_attributes_count = 2;
+}
+
+message InstrumentationScope {
+  string name = 1;
+  string version = 2;
+  repeated KeyValue attributes = 3;
+  uint32 dropped_attributes_count = 4;
+}
+
+message AnyValue {
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+    ArrayValue array_value = 5;
+    KeyValueList kvlist_value = 6;
+    bytes bytes_value = 7;
+    int32 string_value_strindex = 8;
+  }
+}
+
+message ArrayValue {
+  repeated AnyValue values = 1;
+}
+
+message KeyValueList {
+  repeated KeyValue values = 1;
+}
+
+message KeyValue {
+  string key = 1;
+  AnyValue value = 2;
+  int32 key_strindex = 3;
+}
+
+message Span {
+  bytes trace_id = 1;
+  bytes span_id = 2;
+  string trace_state = 3;
+  bytes parent_span_id = 4;
+  string name = 5;
+  int32 kind = 6;
+  fixed64 start_time_unix_nano = 7;
+  fixed64 end_time_unix_nano = 8;
+  repeated KeyValue attributes = 9;
+  uint32 dropped_attributes_count = 10;
+  repeated Event events = 11;
+  uint32 dropped_events_count = 12;
+  repeated Link links = 13;
+  uint32 dropped_links_count = 14;
+  Status status = 15;
+  fixed32 flags = 16;
+
+  message Event {
+    fixed64 time_unix_nano = 1;
+    string name = 2;
+    repeated KeyValue attributes = 3;
+    uint32 dropped_attributes_count = 4;
+  }
+
+  message Link {
+    bytes trace_id = 1;
+    bytes span_id = 2;
+    string trace_state = 3;
+    repeated KeyValue attributes = 4;
+    uint32 dropped_attributes_count = 5;
+    fixed32 flags = 6;
+  }
+}
+
+message Status {
+  string message = 2;
+  int32 code = 3;
+}
+`;
+
+let requestType: Type | undefined;
+
+function getRequestType(): Type {
+  if (!requestType) {
+    requestType = parse(TRACE_PROTO).root.lookupType("ExportTraceServiceRequest");
+  }
+  return requestType;
+}
+
+function longToBigInt(value: number | string | LongLike | undefined): bigint {
+  if (value === undefined) return BigInt(0);
+  return BigInt(typeof value === "number" ? Math.trunc(value) : value.toString());
+}
+
+function longToJsonValue(value: number | string | LongLike): number | string {
+  const parsed = longToBigInt(value);
+  if (
+    parsed <= BigInt(Number.MAX_SAFE_INTEGER) &&
+    parsed >= BigInt(Number.MIN_SAFE_INTEGER)
+  ) {
+    return Number(parsed);
+  }
+  return parsed.toString();
+}
+
+function anyValueToJson(value: ProtoAnyValue | undefined): OtlpAttributeValue {
+  if (!value) return null;
+  const has = (field: keyof ProtoAnyValue) =>
+    Object.prototype.hasOwnProperty.call(value, field);
+  if (has("stringValue")) return value.stringValue ?? "";
+  if (has("boolValue")) return value.boolValue ?? false;
+  if (has("intValue")) return longToJsonValue(value.intValue!);
+  if (has("doubleValue")) return value.doubleValue ?? 0;
+  if (has("arrayValue")) {
+    return (value.arrayValue!.values ?? []).map(anyValueToJson);
+  }
+  if (has("kvlistValue")) {
+    return keyValuesToRecord(value.kvlistValue!.values);
+  }
+  if (has("bytesValue")) {
+    return Buffer.from(value.bytesValue!).toString("base64");
+  }
+  return null;
+}
+
+function keyValuesToRecord(
+  attributes: ProtoKeyValue[] | undefined,
+): Record<string, OtlpAttributeValue> {
+  const result: Record<string, OtlpAttributeValue> = {};
+  for (const attribute of attributes ?? []) {
+    if (attribute.key) result[attribute.key] = anyValueToJson(attribute.value);
+  }
+  return result;
+}
+
+function bytesToHex(
+  value: Uint8Array | undefined,
+  expectedLength: number,
+  field: string,
+  allowEmpty = false,
+): string | null {
+  const bytes = value ?? new Uint8Array();
+  if (allowEmpty && bytes.length === 0) return null;
+  if (bytes.length !== expectedLength || bytes.every((byte) => byte === 0)) {
+    throw new Error(`Invalid OTLP ${field}`);
+  }
+  return Buffer.from(bytes).toString("hex");
+}
+
+function nanoTimestampToDate(nanoseconds: bigint, field: string): Date {
+  if (nanoseconds <= BigInt(0)) throw new Error(`Invalid OTLP ${field}`);
+  const date = new Date(Number(nanoseconds / BigInt(1_000_000)));
+  if (Number.isNaN(date.getTime())) throw new Error(`Invalid OTLP ${field}`);
+  return date;
+}
+
+export function decodeOtlpTraceRequest(
+  payload: Uint8Array,
+): NormalizedOtlpSpan[] {
+  const decoded = getRequestType().decode(payload) as unknown as ExportTraceServiceRequest;
+  const result: NormalizedOtlpSpan[] = [];
+
+  for (const resourceSpans of decoded.resourceSpans ?? []) {
+    const resourceAttributes = keyValuesToRecord(
+      resourceSpans.resource?.attributes,
+    );
+
+    for (const scopeSpans of resourceSpans.scopeSpans ?? []) {
+      for (const span of scopeSpans.spans ?? []) {
+        const startNanos = longToBigInt(span.startTimeUnixNano);
+        const endNanos = longToBigInt(span.endTimeUnixNano);
+        if (endNanos < startNanos) {
+          throw new Error("Invalid OTLP span duration");
+        }
+
+        result.push({
+          traceId: bytesToHex(span.traceId, 16, "trace_id")!,
+          spanId: bytesToHex(span.spanId, 8, "span_id")!,
+          parentSpanId: bytesToHex(
+            span.parentSpanId,
+            8,
+            "parent_span_id",
+            true,
+          ),
+          traceState: span.traceState || null,
+          flags: span.flags ?? 0,
+          name: span.name || "unknown",
+          kind: span.kind ?? 0,
+          startTime: nanoTimestampToDate(startNanos, "start_time_unix_nano"),
+          endTime: nanoTimestampToDate(endNanos, "end_time_unix_nano"),
+          durationMs: Number(endNanos - startNanos) / 1_000_000,
+          statusCode: span.status?.code ?? 0,
+          statusMessage: span.status?.message || null,
+          scopeName: scopeSpans.scope?.name || null,
+          scopeVersion: scopeSpans.scope?.version || null,
+          scopeSchemaUrl: scopeSpans.schemaUrl || null,
+          resourceSchemaUrl: resourceSpans.schemaUrl || null,
+          resourceAttributes,
+          spanAttributes: keyValuesToRecord(span.attributes),
+          events: (span.events ?? []).map((event) => ({
+            timeUnixNano: longToBigInt(event.timeUnixNano).toString(),
+            name: event.name || "unknown",
+            attributes: keyValuesToRecord(event.attributes),
+            droppedAttributesCount: event.droppedAttributesCount ?? 0,
+          })),
+          links: (span.links ?? []).map((link) => ({
+            traceId: bytesToHex(link.traceId, 16, "link.trace_id")!,
+            spanId: bytesToHex(link.spanId, 8, "link.span_id")!,
+            traceState: link.traceState || null,
+            attributes: keyValuesToRecord(link.attributes),
+            droppedAttributesCount: link.droppedAttributesCount ?? 0,
+            flags: link.flags ?? 0,
+          })),
+          droppedAttributesCount: span.droppedAttributesCount ?? 0,
+          droppedEventsCount: span.droppedEventsCount ?? 0,
+          droppedLinksCount: span.droppedLinksCount ?? 0,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+export function encodeOtlpTraceRequestForTest(value: object): Uint8Array {
+  return getRequestType().encode(getRequestType().fromObject(value)).finish();
+}

--- a/src/lib/otel-storage.ts
+++ b/src/lib/otel-storage.ts
@@ -1,0 +1,183 @@
+import type postgres from "postgres";
+import { getDb } from "@/lib/db";
+import type {
+  NormalizedOtlpSpan,
+  OtlpAttributeValue,
+} from "@/lib/otel-proto";
+
+const INSERT_BATCH_SIZE = 200;
+
+function jsonValue(value: unknown): postgres.JSONValue {
+  return value as postgres.JSONValue;
+}
+
+function mergedAttributes(span: NormalizedOtlpSpan) {
+  return { ...span.resourceAttributes, ...span.spanAttributes };
+}
+
+function stringAttribute(
+  attributes: Record<string, OtlpAttributeValue>,
+  key: string,
+): string | null {
+  const value = attributes[key];
+  if (value === undefined || value === null) return null;
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return null;
+}
+
+function numberAttribute(
+  attributes: Record<string, OtlpAttributeValue>,
+  key: string,
+): number | null {
+  const value = attributes[key];
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && /^-?\d+$/.test(value)) {
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+export async function storeOtlpSpans(spans: NormalizedOtlpSpan[]) {
+  if (spans.length === 0) return { accepted: 0 };
+
+  const db = getDb();
+  const rows = spans.map((span) => {
+    const attributes = mergedAttributes(span);
+    return {
+      trace_id: span.traceId,
+      span_id: span.spanId,
+      parent_span_id: span.parentSpanId,
+      trace_state: span.traceState,
+      trace_flags: span.flags,
+      span_name: span.name,
+      span_kind: span.kind,
+      start_time: span.startTime,
+      end_time: span.endTime,
+      duration_ms: span.durationMs,
+      status_code: span.statusCode,
+      status_message: span.statusMessage,
+      service_name: stringAttribute(attributes, "service.name"),
+      scope_name: span.scopeName,
+      scope_version: span.scopeVersion,
+      resource_schema_url: span.resourceSchemaUrl,
+      scope_schema_url: span.scopeSchemaUrl,
+      organization_slug: stringAttribute(
+        attributes,
+        "buildkite.organization.slug",
+      ),
+      pipeline_slug: stringAttribute(attributes, "buildkite.pipeline.slug"),
+      build_id: stringAttribute(attributes, "buildkite.build.id"),
+      build_number: numberAttribute(attributes, "buildkite.build.number"),
+      build_state: stringAttribute(attributes, "buildkite.build.state"),
+      step_id: stringAttribute(attributes, "buildkite.step.id"),
+      step_key: stringAttribute(attributes, "buildkite.step.key"),
+      job_id: stringAttribute(attributes, "buildkite.job.id"),
+      job_label: stringAttribute(attributes, "buildkite.job.label"),
+      job_state: stringAttribute(attributes, "buildkite.job.state"),
+      agent_id: stringAttribute(attributes, "buildkite.agent.id"),
+      agent_name: stringAttribute(attributes, "buildkite.agent.name"),
+      agent_queue:
+        stringAttribute(attributes, "buildkite.agent.queue") ??
+        stringAttribute(attributes, "buildkite.queue"),
+      resource_attributes: db.json(jsonValue(span.resourceAttributes)),
+      span_attributes: db.json(jsonValue(span.spanAttributes)),
+      span_events: db.json(jsonValue(span.events)),
+      span_links: db.json(jsonValue(span.links)),
+      dropped_attributes_count: span.droppedAttributesCount,
+      dropped_events_count: span.droppedEventsCount,
+      dropped_links_count: span.droppedLinksCount,
+    };
+  });
+
+  await db.begin(async (transaction) => {
+    const tx = transaction as unknown as typeof db;
+    for (let offset = 0; offset < rows.length; offset += INSERT_BATCH_SIZE) {
+      const batch = rows.slice(offset, offset + INSERT_BATCH_SIZE);
+      await tx`
+        INSERT INTO otel_spans ${tx(
+          batch,
+          "trace_id",
+          "span_id",
+          "parent_span_id",
+          "trace_state",
+          "trace_flags",
+          "span_name",
+          "span_kind",
+          "start_time",
+          "end_time",
+          "duration_ms",
+          "status_code",
+          "status_message",
+          "service_name",
+          "scope_name",
+          "scope_version",
+          "resource_schema_url",
+          "scope_schema_url",
+          "organization_slug",
+          "pipeline_slug",
+          "build_id",
+          "build_number",
+          "build_state",
+          "step_id",
+          "step_key",
+          "job_id",
+          "job_label",
+          "job_state",
+          "agent_id",
+          "agent_name",
+          "agent_queue",
+          "resource_attributes",
+          "span_attributes",
+          "span_events",
+          "span_links",
+          "dropped_attributes_count",
+          "dropped_events_count",
+          "dropped_links_count",
+        )}
+        ON CONFLICT (trace_id, span_id) DO UPDATE SET
+          parent_span_id = EXCLUDED.parent_span_id,
+          trace_state = EXCLUDED.trace_state,
+          trace_flags = EXCLUDED.trace_flags,
+          span_name = EXCLUDED.span_name,
+          span_kind = EXCLUDED.span_kind,
+          start_time = EXCLUDED.start_time,
+          end_time = EXCLUDED.end_time,
+          duration_ms = EXCLUDED.duration_ms,
+          status_code = EXCLUDED.status_code,
+          status_message = EXCLUDED.status_message,
+          service_name = EXCLUDED.service_name,
+          scope_name = EXCLUDED.scope_name,
+          scope_version = EXCLUDED.scope_version,
+          resource_schema_url = EXCLUDED.resource_schema_url,
+          scope_schema_url = EXCLUDED.scope_schema_url,
+          organization_slug = EXCLUDED.organization_slug,
+          pipeline_slug = EXCLUDED.pipeline_slug,
+          build_id = EXCLUDED.build_id,
+          build_number = EXCLUDED.build_number,
+          build_state = EXCLUDED.build_state,
+          step_id = EXCLUDED.step_id,
+          step_key = EXCLUDED.step_key,
+          job_id = EXCLUDED.job_id,
+          job_label = EXCLUDED.job_label,
+          job_state = EXCLUDED.job_state,
+          agent_id = EXCLUDED.agent_id,
+          agent_name = EXCLUDED.agent_name,
+          agent_queue = EXCLUDED.agent_queue,
+          resource_attributes = EXCLUDED.resource_attributes,
+          span_attributes = EXCLUDED.span_attributes,
+          span_events = EXCLUDED.span_events,
+          span_links = EXCLUDED.span_links,
+          dropped_attributes_count = EXCLUDED.dropped_attributes_count,
+          dropped_events_count = EXCLUDED.dropped_events_count,
+          dropped_links_count = EXCLUDED.dropped_links_count,
+          received_at = NOW()
+      `;
+    }
+  });
+
+  return { accepted: spans.length };
+}


### PR DESCRIPTION
## What changed

- add an authenticated OTLP/HTTP protobuf trace receiver
- normalize and idempotently store Buildkite spans in Postgres
- add database migration, private health check, and Buildkite notification-service setup tooling
- document control-plane and agent-side OTel configuration

## Why

This enriches the existing CI dashboard with detailed Buildkite timing data while keeping Databricks build and job data as the canonical roster and avoiding a separate observability dashboard.

## Validation

- targeted ESLint
- `npx tsc --noEmit`
- Node syntax checks for both setup scripts
- `npm run build -- --webpack`
- local authenticated OTLP ingestion, idempotency, and database smoke test
