### PR TITLE
Add OTel build waterfall

### DIFF
--- a/src/app/api/builds/route.ts
+++ b/src/app/api/builds/route.ts
@@ -8,6 +8,25 @@ const PAGE_SIZE = 50;
 const TTL = 30_000;
 const CDN_CACHE = { maxAge: 60, staleWhileRevalidate: 3_600 };
 
+function parseBuildkiteBuildUrl(value: unknown) {
+  if (typeof value !== "string") return null;
+  try {
+    const url = new URL(value);
+    if (url.hostname !== "buildkite.com") return null;
+    const match = url.pathname.match(
+      /^\/([^/]+)\/([^/]+)\/builds\/(\d+)\/?$/,
+    );
+    if (!match) return null;
+    return {
+      organization_slug: decodeURIComponent(match[1]),
+      pipeline_slug: decodeURIComponent(match[2]),
+      build_number: match[3],
+    };
+  } catch {
+    return null;
+  }
+}
+
 function buildJobFilterSubquery(jobGroups: string[], jobNames: string[]): string {
   const nameConditions: string[] = [];
 
@@ -77,6 +96,7 @@ export async function GET(request: NextRequest) {
       queryDatabricks(`
         SELECT
           b.id AS id,
+          b.number AS build_number,
           b.web_url,
           b.message,
           b.commit AS commit_sha,
@@ -131,13 +151,24 @@ export async function GET(request: NextRequest) {
     // dedicated endpoints so the first screen does not carry 10k+ nested jobs.
     const buildsWithMetadata = builds.map((build) => {
       const b = build as Record<string, unknown>;
+      const traceIdentity = parseBuildkiteBuildUrl(b.web_url);
       // Parse PR number from commit message if not set (e.g. main branch)
       let prNumber = b.pr_number as string | null;
       if (!prNumber && b.message) {
         const match = (b.message as string).match(/\(#(\d+)\)/);
         if (match) prNumber = match[1];
       }
-      return { ...b, pr_number: prNumber };
+      return {
+        ...b,
+        pr_number: prNumber,
+        organization_slug: traceIdentity?.organization_slug ?? null,
+        pipeline_slug: traceIdentity?.pipeline_slug ?? null,
+        build_number:
+          traceIdentity?.build_number ??
+          (b.build_number === null || b.build_number === undefined
+            ? null
+            : String(b.build_number)),
+      };
     });
 
     const counts = countResult[0] as Record<string, string> ?? { total: "0", passed: "0", failed: "0" };

--- a/src/app/api/builds/trace/route.ts
+++ b/src/app/api/builds/trace/route.ts
@@ -1,0 +1,239 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const runtime = "nodejs";
+
+const MAX_SPANS = 2_000;
+const SLUG = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,99}$/;
+
+type TraceRow = {
+  trace_id: string;
+  span_id: string;
+  parent_span_id: string | null;
+  span_name: string;
+  start_time: Date;
+  end_time: Date;
+  duration_ms: number;
+  status_code: number;
+  step_key: string | null;
+  job_id: string | null;
+  job_label: string | null;
+  job_state: string | null;
+  agent_queue: string | null;
+  step_label: string | null;
+  group_label: string | null;
+  step_outcome: string | null;
+  job_passed: string | null;
+  job_url: string | null;
+  step_url: string | null;
+  wait_ms: number | null;
+  received_at: Date;
+};
+
+type Lane = {
+  id: string;
+  parentId: string | null;
+  traceId: string;
+  kind: "job" | "step";
+  label: string;
+  group: string | null;
+  stepKey: string | null;
+  jobId: string | null;
+  queue: string | null;
+  startTime: string;
+  endTime: string;
+  durationMs: number;
+  waitMs: number;
+  status: "passed" | "failed" | "unknown";
+  url: string | null;
+  critical: boolean;
+};
+
+function laneStatus(row: TraceRow): Lane["status"] {
+  if (
+    row.status_code === 2 ||
+    row.job_passed === "false" ||
+    row.step_outcome === "failed"
+  ) {
+    return "failed";
+  }
+  if (
+    row.status_code === 1 ||
+    row.job_passed === "true" ||
+    row.step_outcome === "passed"
+  ) {
+    return "passed";
+  }
+  return "unknown";
+}
+
+function markCompletionFrontier(lanes: Lane[]) {
+  const ordered = [...lanes].sort((a, b) => {
+    const start = Date.parse(a.startTime) - Date.parse(b.startTime);
+    if (start !== 0) return start;
+    return Date.parse(b.endTime) - Date.parse(a.endTime);
+  });
+  let furthestEnd = Number.NEGATIVE_INFINITY;
+  const frontier = new Set<string>();
+  for (const lane of ordered) {
+    const end = Date.parse(lane.endTime);
+    if (end > furthestEnd + 1) {
+      frontier.add(lane.id);
+      furthestEnd = end;
+    }
+  }
+  return lanes.map((lane) => ({
+    ...lane,
+    critical: frontier.has(lane.id),
+  }));
+}
+
+function error(message: string, status: number) {
+  return NextResponse.json(
+    { error: message },
+    { status, headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const organization = request.nextUrl.searchParams.get("organization") ?? "";
+  const pipeline = request.nextUrl.searchParams.get("pipeline") ?? "";
+  const buildNumber = request.nextUrl.searchParams.get("buildNumber") ?? "";
+
+  if (!SLUG.test(organization) || !SLUG.test(pipeline)) {
+    return error("Invalid Buildkite organization or pipeline", 400);
+  }
+  if (!/^\d{1,12}$/.test(buildNumber)) {
+    return error("Invalid Buildkite build number", 400);
+  }
+
+  try {
+    const db = getDb();
+    const rows = await db<TraceRow[]>`
+      SELECT
+        trace_id,
+        span_id,
+        parent_span_id,
+        span_name,
+        start_time,
+        end_time,
+        duration_ms,
+        status_code,
+        step_key,
+        job_id,
+        job_label,
+        job_state,
+        agent_queue,
+        NULLIF(span_attributes->>'buildkite.step.label', '') AS step_label,
+        NULLIF(span_attributes->>'buildkite.step.group.label', '') AS group_label,
+        NULLIF(span_attributes->>'buildkite.step.outcome', '') AS step_outcome,
+        NULLIF(span_attributes->>'buildkite.job.passed', '') AS job_passed,
+        NULLIF(span_attributes->>'buildkite.job.web_url', '') AS job_url,
+        NULLIF(span_attributes->>'buildkite.step.web_url', '') AS step_url,
+        CASE
+          WHEN span_attributes->>'buildkite.job.wait_time_ms' ~ '^\\d+(\\.\\d+)?$'
+          THEN (span_attributes->>'buildkite.job.wait_time_ms')::double precision
+          ELSE 0
+        END AS wait_ms,
+        received_at
+      FROM otel_spans
+      WHERE organization_slug = ${organization}
+        AND pipeline_slug = ${pipeline}
+        AND build_number = ${buildNumber}::bigint
+      ORDER BY start_time ASC, duration_ms DESC
+      LIMIT ${MAX_SPANS}
+    `;
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        {
+          available: false,
+          complete: false,
+          truncated: false,
+          lanes: [],
+          summary: null,
+        },
+        { headers: { "Cache-Control": "private, max-age=5" } },
+      );
+    }
+
+    const childJobParents = new Set(
+      rows
+        .filter((row) => row.span_name === "buildkite.job")
+        .map((row) => row.parent_span_id)
+        .filter((value): value is string => Boolean(value)),
+    );
+    const displayRows = rows.filter(
+      (row) =>
+        row.span_name === "buildkite.job" ||
+        (row.span_name === "buildkite.step" &&
+          !childJobParents.has(row.span_id)),
+    );
+
+    const lanes = markCompletionFrontier(
+      displayRows.map((row) => ({
+        id: row.span_id,
+        parentId: row.parent_span_id,
+        traceId: row.trace_id,
+        kind: row.span_name === "buildkite.job" ? "job" : "step",
+        label: row.job_label ?? row.step_label ?? row.span_name,
+        group: row.group_label,
+        stepKey: row.step_key,
+        jobId: row.job_id,
+        queue: row.agent_queue,
+        startTime: row.start_time.toISOString(),
+        endTime: row.end_time.toISOString(),
+        durationMs: Number(row.duration_ms),
+        waitMs: Math.max(0, Number(row.wait_ms ?? 0)),
+        status: laneStatus(row),
+        url: row.job_url ?? row.step_url,
+        critical: false,
+      })),
+    );
+
+    const buildSpan = rows.find((row) => row.span_name === "buildkite.build");
+    const laneStarts = lanes.map(
+      (lane) => Date.parse(lane.startTime) - lane.waitMs,
+    );
+    const laneEnds = lanes.map((lane) => Date.parse(lane.endTime));
+    const observedStart = buildSpan
+      ? buildSpan.start_time.getTime()
+      : laneStarts.length > 0
+        ? Math.min(...laneStarts)
+        : Math.min(...rows.map((row) => row.start_time.getTime()));
+    const observedEnd = buildSpan
+      ? buildSpan.end_time.getTime()
+      : laneEnds.length > 0
+        ? Math.max(...laneEnds)
+        : Math.max(...rows.map((row) => row.end_time.getTime()));
+    const latestReceived = Math.max(
+      ...rows.map((row) => row.received_at.getTime()),
+    );
+
+    return NextResponse.json(
+      {
+        available: true,
+        complete: Boolean(buildSpan),
+        truncated: rows.length === MAX_SPANS,
+        lanes,
+        summary: {
+          observedStart: new Date(observedStart).toISOString(),
+          observedEnd: new Date(observedEnd).toISOString(),
+          observedDurationMs: Math.max(0, observedEnd - observedStart),
+          spanCount: rows.length,
+          laneCount: lanes.length,
+          traceCount: new Set(rows.map((row) => row.trace_id)).size,
+          queueCount: new Set(
+            lanes.map((lane) => lane.queue).filter(Boolean),
+          ).size,
+          criticalCount: lanes.filter((lane) => lane.critical).length,
+          latestReceivedAt: new Date(latestReceived).toISOString(),
+        },
+      },
+      { headers: { "Cache-Control": "private, max-age=5" } },
+    );
+  } catch (cause) {
+    console.error("Failed to load build trace:", cause);
+    return error("Failed to load build trace", 500);
+  }
+}

--- a/src/components/build-waterfall.tsx
+++ b/src/components/build-waterfall.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+
+interface WaterfallLane {
+  id: string;
+  kind: "job" | "step";
+  label: string;
+  group: string | null;
+  stepKey: string | null;
+  jobId: string | null;
+  queue: string | null;
+  startTime: string;
+  endTime: string;
+  durationMs: number;
+  waitMs: number;
+  status: "passed" | "failed" | "unknown";
+  url: string | null;
+  critical: boolean;
+}
+
+interface TraceResponse {
+  available: boolean;
+  complete: boolean;
+  truncated: boolean;
+  lanes: WaterfallLane[];
+  summary: {
+    observedStart: string;
+    observedEnd: string;
+    observedDurationMs: number;
+    spanCount: number;
+    laneCount: number;
+    traceCount: number;
+    queueCount: number;
+    criticalCount: number;
+    latestReceivedAt: string;
+  } | null;
+  error?: string;
+}
+
+interface BuildWaterfallProps {
+  organization: string;
+  pipeline: string;
+  buildNumber: string;
+}
+
+const INITIAL_LANE_LIMIT = 36;
+const TICKS = [0, 0.25, 0.5, 0.75, 1];
+
+async function fetchTrace(url: string): Promise<TraceResponse> {
+  const response = await fetch(url);
+  const body = (await response.json()) as TraceResponse;
+  if (!response.ok) {
+    throw new Error(body.error ?? "Failed to load trace");
+  }
+  return body;
+}
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  if (ms < 1_000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) {
+    const seconds = ms / 1_000;
+    return `${seconds < 10 ? seconds.toFixed(1) : Math.round(seconds)}s`;
+  }
+  const totalSeconds = Math.round(ms / 1_000);
+  const seconds = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m ${seconds}s`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${minutes}m`;
+}
+
+function formatTime(value: string): string {
+  return new Date(value).toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}
+
+function GridLines() {
+  return (
+    <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+      {TICKS.map((tick) => (
+        <span
+          key={tick}
+          className="absolute inset-y-0 w-px bg-zinc-200/70 dark:bg-zinc-800"
+          style={{ left: `${tick * 100}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function BuildWaterfall({
+  organization,
+  pipeline,
+  buildNumber,
+}: BuildWaterfallProps) {
+  const [criticalOnly, setCriticalOnly] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+  const params = new URLSearchParams({
+    organization,
+    pipeline,
+    buildNumber,
+  });
+  const { data, error, isLoading, isValidating, mutate } = useSWR<TraceResponse>(
+    `/api/builds/trace?${params.toString()}`,
+    fetchTrace,
+    {
+      keepPreviousData: true,
+      refreshInterval: (latest) => (latest?.complete ? 0 : 10_000),
+    },
+  );
+
+  const orderedLanes = useMemo(
+    () =>
+      [...(data?.lanes ?? [])].sort((a, b) => {
+        const start = Date.parse(a.startTime) - Date.parse(b.startTime);
+        if (start !== 0) return start;
+        return b.durationMs - a.durationMs;
+      }),
+    [data?.lanes],
+  );
+
+  const visibleLanes = useMemo(() => {
+    if (criticalOnly) return orderedLanes.filter((lane) => lane.critical);
+    if (showAll || orderedLanes.length <= INITIAL_LANE_LIMIT) return orderedLanes;
+    const initiallyVisible = new Set(
+      orderedLanes.slice(0, INITIAL_LANE_LIMIT).map((lane) => lane.id),
+    );
+    for (const lane of orderedLanes) {
+      if (lane.critical) initiallyVisible.add(lane.id);
+    }
+    return orderedLanes.filter((lane) => initiallyVisible.has(lane.id));
+  }, [criticalOnly, orderedLanes, showAll]);
+
+  if (isLoading && !data) {
+    return (
+      <div className="flex min-h-40 items-center justify-center border-t border-zinc-200 bg-zinc-50/70 px-6 text-sm text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900/30 dark:text-zinc-400">
+        Loading trace spans…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-40 flex-col items-center justify-center gap-3 border-t border-zinc-200 bg-zinc-50/70 px-6 text-center dark:border-zinc-800 dark:bg-zinc-900/30">
+        <p className="text-sm font-medium text-red-600 dark:text-red-400">
+          Trace data could not be loaded.
+        </p>
+        <button
+          type="button"
+          onClick={() => mutate()}
+          className="dashboard-control min-h-10 rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-200 dark:hover:bg-zinc-900"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data?.available || !data.summary || data.lanes.length === 0) {
+    return (
+      <div className="border-t border-zinc-200 bg-zinc-50/70 px-6 py-8 dark:border-zinc-800 dark:bg-zinc-900/30">
+        <p className="text-sm font-medium text-zinc-700 dark:text-zinc-200">
+          No trace spans for this build
+        </p>
+        <p className="mt-1 max-w-2xl text-xs leading-5 text-zinc-500 dark:text-zinc-400">
+          Older builds predate OTel collection. Active builds populate here as
+          spans finish; the current build roster still comes from Databricks.
+        </p>
+      </div>
+    );
+  }
+
+  const { summary } = data;
+  const timelineStart = Date.parse(summary.observedStart);
+  const timelineEnd = Date.parse(summary.observedEnd);
+  const timelineDuration = Math.max(1, timelineEnd - timelineStart);
+  const hiddenCount = Math.max(0, orderedLanes.length - visibleLanes.length);
+
+  return (
+    <section
+      aria-label={`Build ${buildNumber} waterfall`}
+      className="sticky left-0 w-[calc(100vw-2rem)] max-w-[1376px] border-t border-zinc-200 bg-zinc-50/80 sm:w-[calc(100vw-3rem)] lg:w-[calc(100vw-4rem)] dark:border-zinc-800 dark:bg-zinc-900/35"
+    >
+      <div className="flex flex-col gap-4 border-b border-zinc-200 px-5 py-4 lg:flex-row lg:items-start lg:justify-between dark:border-zinc-800">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h4 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+              Build waterfall
+            </h4>
+            <span
+              className={`rounded-full px-2 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.12em] ${
+                data.complete
+                  ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
+                  : "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+              }`}
+            >
+              {data.complete ? "Complete" : "Live"}
+            </span>
+            {isValidating && (
+              <span className="text-[11px] text-zinc-400">Checking…</span>
+            )}
+          </div>
+          <p className="mt-1 text-xs leading-5 text-zinc-500 dark:text-zinc-400">
+            Amber spans form an inferred critical path: each extended the
+            observed completion frontier. Buildkite OTel does not include
+            dependency edges.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-zinc-500 dark:text-zinc-400">
+          <span>
+            <strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">
+              {formatDuration(summary.observedDurationMs)}
+            </strong>{" "}
+            observed
+          </span>
+          <span>
+            <strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">
+              {summary.laneCount}
+            </strong>{" "}
+            jobs / steps
+          </span>
+          <span>
+            <strong className="font-mono font-semibold text-amber-700 dark:text-amber-300">
+              {summary.criticalCount}
+            </strong>{" "}
+            path spans
+          </span>
+          <span>
+            <strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">
+              {summary.queueCount}
+            </strong>{" "}
+            queues
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-3">
+        <div className="flex items-center gap-4 text-[11px] text-zinc-500 dark:text-zinc-400">
+          <span className="inline-flex items-center gap-1.5">
+            <span className="h-2 w-4 rounded-sm bg-blue-500" /> run
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <span className="h-2 w-4 rounded-sm bg-red-500" /> failed
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <span className="h-2 w-4 rounded-sm border border-amber-500 bg-amber-300 dark:bg-amber-500" />
+            critical path
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <span className="h-2 w-4 rounded-sm bg-zinc-300 dark:bg-zinc-700" /> queued
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            aria-pressed={criticalOnly}
+            onClick={() => setCriticalOnly((value) => !value)}
+            className={`dashboard-control min-h-9 rounded-md border px-3 text-xs font-medium ${
+              criticalOnly
+                ? "border-amber-400 bg-amber-50 text-amber-800 dark:border-amber-600 dark:bg-amber-950/60 dark:text-amber-200"
+                : "border-zinc-300 bg-white text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:bg-zinc-900"
+            }`}
+          >
+            Critical path only
+          </button>
+          {!criticalOnly && orderedLanes.length > INITIAL_LANE_LIMIT && (
+            <button
+              type="button"
+              onClick={() => setShowAll((value) => !value)}
+              className="dashboard-control min-h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:bg-zinc-900"
+            >
+              {showAll ? "Show less" : `Show all ${orderedLanes.length}`}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto pb-2">
+        <div className="min-w-[760px] px-5">
+          <div className="grid grid-cols-[minmax(13rem,17rem)_minmax(32rem,1fr)] gap-4 border-b border-zinc-200 pb-2 dark:border-zinc-800">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-400">
+              Job / span
+            </div>
+            <div className="relative h-5 font-mono text-[10px] text-zinc-400">
+              {TICKS.map((tick) => (
+                <span
+                  key={tick}
+                  className="absolute -translate-x-1/2 first:translate-x-0 last:-translate-x-full"
+                  style={{ left: `${tick * 100}%` }}
+                >
+                  {formatDuration(timelineDuration * tick)}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            {visibleLanes.map((lane) => {
+              const start = Date.parse(lane.startTime);
+              const end = Date.parse(lane.endTime);
+              const queueStart = Math.max(timelineStart, start - lane.waitMs);
+              const queueLeft = clampPercent(
+                ((queueStart - timelineStart) / timelineDuration) * 100,
+              );
+              const queueWidth = clampPercent(
+                ((start - queueStart) / timelineDuration) * 100,
+              );
+              const runLeft = clampPercent(
+                ((start - timelineStart) / timelineDuration) * 100,
+              );
+              const runWidth = clampPercent(
+                ((end - start) / timelineDuration) * 100,
+              );
+              const runColor = lane.critical
+                ? "border border-amber-500 bg-amber-300 shadow-[0_0_0_1px_rgb(245_158_11_/_0.12)] dark:bg-amber-500"
+                : lane.status === "failed"
+                  ? "bg-red-500 dark:bg-red-500"
+                  : "bg-blue-500 dark:bg-blue-500";
+              const detail = `${lane.label} · ${formatTime(lane.startTime)}–${formatTime(lane.endTime)} · ${formatDuration(lane.durationMs)}${lane.queue ? ` · ${lane.queue}` : ""}`;
+
+              return (
+                <div
+                  key={lane.id}
+                  className="grid min-h-11 grid-cols-[minmax(13rem,17rem)_minmax(32rem,1fr)] items-center gap-4 border-b border-zinc-200/70 last:border-0 dark:border-zinc-800/70"
+                >
+                  <div className="min-w-0 py-2">
+                    <div className="flex items-center gap-2">
+                      {lane.critical && (
+                        <span
+                          aria-label="Inferred critical path"
+                          className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
+                        />
+                      )}
+                      <span
+                        className="truncate text-xs font-medium text-zinc-800 dark:text-zinc-200"
+                        title={lane.label}
+                      >
+                        {lane.label}
+                      </span>
+                      <span className="ml-auto shrink-0 font-mono text-[10px] text-zinc-400">
+                        {formatDuration(lane.durationMs)}
+                      </span>
+                    </div>
+                    <div className="mt-0.5 flex min-w-0 items-center gap-2 pl-3.5 font-mono text-[10px] text-zinc-400">
+                      <span className="truncate">
+                        {lane.queue ?? lane.group ?? lane.kind}
+                      </span>
+                      {lane.waitMs > 0 && (
+                        <span className="shrink-0">
+                          +{formatDuration(lane.waitMs)} wait
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="relative h-7">
+                    <GridLines />
+                    {queueWidth > 0.08 && (
+                      <span
+                        aria-hidden="true"
+                        className="absolute top-2 h-3 rounded-l-sm bg-zinc-300 dark:bg-zinc-700"
+                        style={{
+                          left: `${queueLeft}%`,
+                          width: `${Math.max(queueWidth, 0.2)}%`,
+                          backgroundImage:
+                            "repeating-linear-gradient(135deg, transparent, transparent 3px, rgb(255 255 255 / 0.35) 3px, rgb(255 255 255 / 0.35) 4px)",
+                        }}
+                      />
+                    )}
+                    {lane.url ? (
+                      <a
+                        href={lane.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={detail}
+                        title={detail}
+                        className={`absolute top-1.5 h-4 min-w-1 rounded-sm transition-[filter] hover:brightness-110 ${runColor}`}
+                        style={{
+                          left: `${runLeft}%`,
+                          width: `${Math.max(runWidth, 0.25)}%`,
+                        }}
+                      />
+                    ) : (
+                      <span
+                        role="img"
+                        aria-label={detail}
+                        title={detail}
+                        className={`absolute top-1.5 h-4 min-w-1 rounded-sm ${runColor}`}
+                        style={{
+                          left: `${runLeft}%`,
+                          width: `${Math.max(runWidth, 0.25)}%`,
+                        }}
+                      />
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {hiddenCount > 0 && !criticalOnly && (
+            <button
+              type="button"
+              onClick={() => setShowAll(true)}
+              className="dashboard-control my-2 min-h-10 w-full rounded-md text-xs font-medium text-zinc-500 hover:bg-zinc-100 hover:text-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-800/60 dark:hover:text-zinc-200"
+            >
+              Show {hiddenCount} more spans
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-2 border-t border-zinc-200 px-5 py-2.5 font-mono text-[10px] text-zinc-400 dark:border-zinc-800">
+        <span>
+          {formatTime(summary.observedStart)} → {formatTime(summary.observedEnd)}
+        </span>
+        <span>
+          Last span received {formatTime(summary.latestReceivedAt)}
+          {data.truncated ? " · first 2,000 spans" : ""}
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/src/components/builds-table.tsx
+++ b/src/components/builds-table.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { Fragment, useState, useCallback, useMemo } from "react";
 import useSWR from "swr";
+import { BuildWaterfall } from "@/components/build-waterfall";
 import type { GroupStatus } from "@/lib/test-groups";
 import { isOptionalJob, isSoftFailJob } from "@/lib/optional-jobs";
 
 export interface Build {
   id: string;
+  build_number: string | null;
+  organization_slug: string | null;
+  pipeline_slug: string | null;
   web_url: string;
   message: string;
   commit_sha: string;
@@ -199,6 +203,7 @@ export function BuildsTable({
   selectedJobs,
 }: BuildsTableProps) {
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const [expandedBuildId, setExpandedBuildId] = useState<string | null>(null);
   const buildIds = useMemo(
     () => builds.map((build) => build.id),
     [builds],
@@ -370,28 +375,75 @@ export function BuildsTable({
                   return [g.group, { ...g, jobs }];
                 })
               );
+              const canShowTrace = Boolean(
+                build.organization_slug &&
+                  build.pipeline_slug &&
+                  build.build_number,
+              );
+              const isTraceExpanded = expandedBuildId === build.id;
 
               return (
-                <tr
-                  key={build.id}
-                  className="border-b border-zinc-100 last:border-0 dark:border-zinc-800/50"
-                >
-                  <td className="sticky left-0 z-10 whitespace-nowrap bg-white px-4 py-2 dark:bg-zinc-950">
-                    {build.web_url ? (
-                      <a
-                        href={build.web_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-zinc-500 hover:text-zinc-900 hover:underline dark:text-zinc-400 dark:hover:text-zinc-100"
-                      >
-                        {build.created_at ? formatTime(build.created_at) : "—"}
-                      </a>
-                    ) : (
-                      <span className="text-zinc-500 dark:text-zinc-400">
-                        {build.created_at ? formatTime(build.created_at) : "—"}
-                      </span>
-                    )}
-                  </td>
+                <Fragment key={build.id}>
+                  <tr
+                    className={`border-b border-zinc-100 dark:border-zinc-800/50 ${
+                      isTraceExpanded ? "bg-zinc-50 dark:bg-zinc-900/30" : ""
+                    }`}
+                  >
+                    <td
+                      className={`sticky left-0 z-10 whitespace-nowrap px-4 py-2 ${
+                        isTraceExpanded
+                          ? "bg-zinc-50 dark:bg-zinc-900"
+                          : "bg-white dark:bg-zinc-950"
+                      }`}
+                    >
+                      <div className="flex items-center gap-1.5">
+                        {canShowTrace ? (
+                          <button
+                            type="button"
+                            aria-label={`${isTraceExpanded ? "Hide" : "Show"} waterfall for build ${build.build_number}`}
+                            aria-expanded={isTraceExpanded}
+                            aria-controls={`build-trace-${build.id}`}
+                            onClick={() =>
+                              setExpandedBuildId((current) =>
+                                current === build.id ? null : build.id,
+                              )
+                            }
+                            className="dashboard-control inline-flex h-7 w-7 shrink-0 items-center justify-center rounded text-zinc-400 hover:bg-zinc-100 hover:text-zinc-800 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                          >
+                            <svg
+                              viewBox="0 0 16 16"
+                              aria-hidden="true"
+                              className={`h-3.5 w-3.5 transition-transform motion-reduce:transition-none ${isTraceExpanded ? "rotate-90" : ""}`}
+                            >
+                              <path
+                                d="m6 3.5 4.5 4.5L6 12.5"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth="1.5"
+                              />
+                            </svg>
+                          </button>
+                        ) : (
+                          <span aria-hidden="true" className="h-7 w-7" />
+                        )}
+                        {build.web_url ? (
+                          <a
+                            href={build.web_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-zinc-500 hover:text-zinc-900 hover:underline dark:text-zinc-400 dark:hover:text-zinc-100"
+                          >
+                            {build.created_at ? formatTime(build.created_at) : "—"}
+                          </a>
+                        ) : (
+                          <span className="text-zinc-500 dark:text-zinc-400">
+                            {build.created_at ? formatTime(build.created_at) : "—"}
+                          </span>
+                        )}
+                      </div>
+                    </td>
                   <td className="px-4 py-2 font-mono text-xs">
                     {build.commit_sha ? (
                       <a
@@ -449,7 +501,7 @@ export function BuildsTable({
                   <td className="max-w-[16rem] truncate px-4 py-2 text-zinc-600 dark:text-zinc-400">
                     {build.message ?? "—"}
                   </td>
-                  {columns.map((col, i) => {
+                    {columns.map((col, i) => {
                     const key =
                       col.type === "job"
                         ? `${col.group}::${col.jobName}`
@@ -523,8 +575,23 @@ export function BuildsTable({
                         borderClass={borderR}
                       />
                     );
-                  })}
-                </tr>
+                    })}
+                  </tr>
+                  {isTraceExpanded && canShowTrace && (
+                    <tr id={`build-trace-${build.id}`}>
+                      <td
+                        colSpan={FIXED_COLS + columns.length}
+                        className="p-0"
+                      >
+                        <BuildWaterfall
+                          organization={build.organization_slug!}
+                          pipeline={build.pipeline_slug!}
+                          buildNumber={build.build_number!}
+                        />
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
               );
             })}
             {builds.length === 0 && (


### PR DESCRIPTION
## What changed

- add a lazy per-build trace API backed by the indexed OTel span table
- add an expandable build waterfall to Recent Builds
- visualize execution, queue wait, failure state, and an inferred critical path
- preserve live trace data while active builds refresh and show explicit loading, error, and pre-OTel empty states

## Why

The dashboard now receives Buildkite traces, but the timing data was not visible alongside the canonical Databricks build roster. This makes the first trace-derived diagnostic available without introducing another dashboard.

The critical path is presented as an inference: amber spans are those that extended the observed completion frontier. Buildkite OTel does not expose dependency edges.

## Validation

- targeted ESLint
- `npx tsc --noEmit`
- `git diff --check`
- `npm run build -- --webpack`
- live API checks for current, invalid, and pre-OTel builds
- browser QA in light mode, dark mode, and a 390px viewport
- critical-path filtering and explicit empty-state interaction checks
