### PR TITLE
Improve OTel timeline discoverability

### DIFF
--- a/src/app/api/builds/groups/route.ts
+++ b/src/app/api/builds/groups/route.ts
@@ -37,6 +37,7 @@ export async function GET(request: NextRequest) {
           groupsByBuild: {},
           jobNames: [],
           jobsByBuild: {},
+          startedJobCountsByBuild: {},
           jobOptions: [],
         },
         CDN_CACHE,
@@ -53,7 +54,8 @@ export async function GET(request: NextRequest) {
         j.build_id,
         j.name,
         j.state,
-        j.web_url
+        j.web_url,
+        j.started_at
       FROM vllm_data_warehouse.buildkite.build_job AS j
       WHERE j.build_id IN (${idList})
         AND j._fivetran_deleted = false
@@ -65,15 +67,23 @@ export async function GET(request: NextRequest) {
       string,
       { name: string; state: string; web_url?: string }[]
     >();
+    const startedJobCountsByBuild = Object.fromEntries(
+      buildIds.map((buildId) => [buildId, 0]),
+    ) as Record<string, number>;
     for (const job of jobs) {
-      const row = job as Record<string, string>;
-      const buildJobs = jobsByBuild.get(row.build_id) ?? [];
+      const row = job as Record<string, string | null>;
+      const buildId = row.build_id;
+      if (!buildId || !row.name || !row.state) continue;
+      if (row.started_at) {
+        startedJobCountsByBuild[buildId] += 1;
+      }
+      const buildJobs = jobsByBuild.get(buildId) ?? [];
       buildJobs.push({
         name: row.name,
         state: row.state,
-        web_url: row.web_url,
+        web_url: row.web_url ?? undefined,
       });
-      jobsByBuild.set(row.build_id, buildJobs);
+      jobsByBuild.set(buildId, buildJobs);
     }
 
     const groupedByBuild = new Map<string, GroupStatus[]>();
@@ -121,6 +131,7 @@ export async function GET(request: NextRequest) {
       groupsByBuild,
       jobNames,
       jobsByBuild: compactJobsByBuild,
+      startedJobCountsByBuild,
       jobOptions: [...jobToGroup.entries()]
         .map(([name, group]) => ({ name, group }))
         .sort((a, b) => a.name.localeCompare(b.name)),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,6 +54,7 @@ interface BuildGroupsResponse {
     string,
     Record<string, Array<[nameIndex: number, state: string]>>
   >;
+  startedJobCountsByBuild: Record<string, number>;
   jobOptions: Array<{ name: string; group: string }>;
   error?: string;
 }
@@ -278,6 +279,7 @@ export default function BuildsPage() {
         builds={builds}
         jobNames={groupData?.jobNames ?? []}
         jobsByBuild={groupData?.jobsByBuild ?? {}}
+        startedJobCountsByBuild={groupData?.startedJobCountsByBuild ?? {}}
         showBranch={!branch}
         hideSoftFail={hideSoftFail}
         hideOptional={hideOptional}

--- a/src/components/build-waterfall.tsx
+++ b/src/components/build-waterfall.tsx
@@ -43,6 +43,8 @@ interface BuildWaterfallProps {
   organization: string;
   pipeline: string;
   buildNumber: string;
+  buildUrl: string;
+  startedJobCount?: number;
 }
 
 const INITIAL_LANE_LIMIT = 36;
@@ -103,6 +105,8 @@ export function BuildWaterfall({
   organization,
   pipeline,
   buildNumber,
+  buildUrl,
+  startedJobCount,
 }: BuildWaterfallProps) {
   const [criticalOnly, setCriticalOnly] = useState(false);
   const [showAll, setShowAll] = useState(false);
@@ -186,6 +190,23 @@ export function BuildWaterfall({
   const timelineEnd = Date.parse(summary.observedEnd);
   const timelineDuration = Math.max(1, timelineEnd - timelineStart);
   const hiddenCount = Math.max(0, orderedLanes.length - visibleLanes.length);
+  const hasCoverage =
+    typeof startedJobCount === "number" && startedJobCount > 0;
+  const coverageTotal = hasCoverage
+    ? Math.max(startedJobCount, summary.laneCount)
+    : null;
+  const isPartial =
+    data.complete && coverageTotal !== null && summary.laneCount < coverageTotal;
+  const traceState = !data.complete
+    ? "Live"
+    : isPartial
+      ? "Partial"
+      : "Complete";
+  const traceStateColor = !data.complete
+    ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
+    : isPartial
+      ? "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+      : "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300";
 
   return (
     <section
@@ -193,55 +214,63 @@ export function BuildWaterfall({
       className="sticky left-0 w-[calc(100vw-2rem)] max-w-[1376px] border-t border-zinc-200 bg-zinc-50/80 sm:w-[calc(100vw-3rem)] lg:w-[calc(100vw-4rem)] dark:border-zinc-800 dark:bg-zinc-900/35"
     >
       <div className="flex flex-col gap-4 border-b border-zinc-200 px-5 py-4 lg:flex-row lg:items-start lg:justify-between dark:border-zinc-800">
-        <div>
+        <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             <h4 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-              Build waterfall
+              Build #{buildNumber} timeline
             </h4>
             <span
-              className={`rounded-full px-2 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.12em] ${
-                data.complete
-                  ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
-                  : "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
-              }`}
+              className={`rounded-full px-2 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.12em] ${traceStateColor}`}
             >
-              {data.complete ? "Complete" : "Live"}
+              {traceState}
             </span>
             {isValidating && (
               <span className="text-[11px] text-zinc-400">Checking…</span>
             )}
           </div>
           <p className="mt-1 text-xs leading-5 text-zinc-500 dark:text-zinc-400">
-            Amber spans form an inferred critical path: each extended the
-            observed completion frontier. Buildkite OTel does not include
-            dependency edges.
+            Amber marks jobs most likely to determine when the build finished.
+            This is inferred from timing because Buildkite OTel does not include
+            dependency links.
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-zinc-500 dark:text-zinc-400">
-          <span>
-            <strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">
-              {formatDuration(summary.observedDurationMs)}
-            </strong>{" "}
-            observed
-          </span>
-          <span>
-            <strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">
-              {summary.laneCount}
-            </strong>{" "}
-            jobs / steps
-          </span>
-          <span>
-            <strong className="font-mono font-semibold text-amber-700 dark:text-amber-300">
-              {summary.criticalCount}
-            </strong>{" "}
-            path spans
-          </span>
-          <span>
-            <strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">
-              {summary.queueCount}
-            </strong>{" "}
-            queues
-          </span>
+        <div className="flex flex-col items-start gap-3 lg:items-end">
+          <a
+            href={buildUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="dashboard-control inline-flex min-h-9 items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 text-xs font-semibold text-blue-600 hover:border-blue-300 hover:bg-blue-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-blue-400 dark:hover:border-blue-800 dark:hover:bg-blue-950/50"
+          >
+            Open Buildkite #{buildNumber}
+            <span aria-hidden="true">↗</span>
+          </a>
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-zinc-500 dark:text-zinc-400">
+            <span>
+              <strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">
+                {formatDuration(summary.observedDurationMs)}
+              </strong>{" "}
+              observed
+            </span>
+            <span>
+              <strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">
+                {summary.laneCount}
+                {coverageTotal !== null ? ` of ${coverageTotal}` : ""}
+              </strong>{" "}
+              jobs traced
+            </span>
+            <span>
+              <strong className="font-mono font-semibold text-amber-700 dark:text-amber-300">
+                {summary.criticalCount}
+              </strong>{" "}
+              build-limiting
+            </span>
+            <span>
+              <strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">
+                {summary.queueCount}
+              </strong>{" "}
+              queues
+            </span>
+          </div>
         </div>
       </div>
 
@@ -255,7 +284,7 @@ export function BuildWaterfall({
           </span>
           <span className="inline-flex items-center gap-1.5">
             <span className="h-2 w-4 rounded-sm border border-amber-500 bg-amber-300 dark:bg-amber-500" />
-            critical path
+            build-limiting
           </span>
           <span className="inline-flex items-center gap-1.5">
             <span className="h-2 w-4 rounded-sm bg-zinc-300 dark:bg-zinc-700" /> queued
@@ -272,7 +301,7 @@ export function BuildWaterfall({
                 : "border-zinc-300 bg-white text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:bg-zinc-900"
             }`}
           >
-            Critical path only
+            {criticalOnly ? "Show all jobs" : "Show build-limiting jobs"}
           </button>
           {!criticalOnly && orderedLanes.length > INITIAL_LANE_LIMIT && (
             <button
@@ -338,7 +367,7 @@ export function BuildWaterfall({
                     <div className="flex items-center gap-2">
                       {lane.critical && (
                         <span
-                          aria-label="Inferred critical path"
+                          aria-label="Inferred build-limiting job"
                           className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
                         />
                       )}

--- a/src/components/builds-table.tsx
+++ b/src/components/builds-table.tsx
@@ -183,6 +183,7 @@ interface BuildsTableProps {
   builds: Build[];
   jobNames: string[];
   jobsByBuild: CompactJobsByBuild;
+  startedJobCountsByBuild: Record<string, number>;
   showBranch?: boolean;
   hideSoftFail?: boolean;
   hideOptional?: boolean;
@@ -196,6 +197,7 @@ export function BuildsTable({
   builds,
   jobNames,
   jobsByBuild,
+  startedJobCountsByBuild,
   showBranch,
   hideSoftFail,
   hideOptional,
@@ -291,7 +293,7 @@ export function BuildsTable({
         <table className="text-sm" style={{ borderCollapse: "separate", borderSpacing: 0 }}>
           <thead>
             <tr className="border-b border-zinc-200 dark:border-zinc-800">
-              <th className="sticky left-0 z-10 bg-white px-4 pb-2 text-left align-bottom font-semibold text-zinc-500 dark:bg-zinc-950 dark:text-zinc-400">Started</th>
+              <th className="sticky left-0 z-10 bg-white px-4 pb-2 text-left align-bottom font-semibold text-zinc-500 dark:bg-zinc-950 dark:text-zinc-400">Build</th>
               <th className="px-4 pb-2 text-left align-bottom font-semibold text-zinc-500 dark:text-zinc-400">Commit</th>
               {showBranch && <th className="px-4 pb-2 text-left align-bottom font-semibold text-zinc-500 dark:text-zinc-400">Branch</th>}
               <th className="px-4 pb-2 text-left align-bottom font-semibold text-zinc-500 dark:text-zinc-400">PR</th>
@@ -381,26 +383,27 @@ export function BuildsTable({
                   build.build_number,
               );
               const isTraceExpanded = expandedBuildId === build.id;
+              const startedJobCount = startedJobCountsByBuild[build.id];
 
               return (
                 <Fragment key={build.id}>
                   <tr
-                    className={`border-b border-zinc-100 dark:border-zinc-800/50 ${
+                    className={`group border-b border-zinc-100 transition-colors dark:border-zinc-800/50 ${
                       isTraceExpanded ? "bg-zinc-50 dark:bg-zinc-900/30" : ""
-                    }`}
+                    } ${isTraceExpanded ? "" : "hover:bg-zinc-50/80 dark:hover:bg-zinc-900/20"}`}
                   >
                     <td
                       className={`sticky left-0 z-10 whitespace-nowrap px-4 py-2 ${
                         isTraceExpanded
                           ? "bg-zinc-50 dark:bg-zinc-900"
-                          : "bg-white dark:bg-zinc-950"
+                          : "bg-white group-hover:bg-zinc-50 dark:bg-zinc-950 dark:group-hover:bg-zinc-900"
                       }`}
                     >
-                      <div className="flex items-center gap-1.5">
+                      <div className="flex items-center gap-2.5">
                         {canShowTrace ? (
                           <button
                             type="button"
-                            aria-label={`${isTraceExpanded ? "Hide" : "Show"} waterfall for build ${build.build_number}`}
+                            aria-label={`${isTraceExpanded ? "Hide" : "Show"} timeline for build ${build.build_number}`}
                             aria-expanded={isTraceExpanded}
                             aria-controls={`build-trace-${build.id}`}
                             onClick={() =>
@@ -408,8 +411,25 @@ export function BuildsTable({
                                 current === build.id ? null : build.id,
                               )
                             }
-                            className="dashboard-control inline-flex h-7 w-7 shrink-0 items-center justify-center rounded text-zinc-400 hover:bg-zinc-100 hover:text-zinc-800 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                            className={`dashboard-control inline-flex min-h-8 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium transition-colors ${
+                              isTraceExpanded
+                                ? "border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950/60 dark:text-blue-300"
+                                : "border-zinc-300 bg-white text-zinc-700 hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:border-blue-800 dark:hover:bg-blue-950/50 dark:hover:text-blue-300"
+                            }`}
                           >
+                            <svg
+                              viewBox="0 0 16 16"
+                              aria-hidden="true"
+                              className="h-3.5 w-3.5"
+                            >
+                              <path
+                                d="M2.5 4.25h3v7.5h-3zm4-2h3v9.5h-3zm4 4h3v5.5h-3z"
+                                fill="currentColor"
+                              />
+                            </svg>
+                            <span>
+                              {isTraceExpanded ? "Hide timeline" : "View timeline"}
+                            </span>
                             <svg
                               viewBox="0 0 16 16"
                               aria-hidden="true"
@@ -426,22 +446,28 @@ export function BuildsTable({
                             </svg>
                           </button>
                         ) : (
-                          <span aria-hidden="true" className="h-7 w-7" />
+                          <span
+                            className="inline-flex min-h-8 items-center rounded-md border border-zinc-200 px-2.5 text-xs text-zinc-400 dark:border-zinc-800 dark:text-zinc-600"
+                            title="Timeline unavailable"
+                          >
+                            No timeline
+                          </span>
                         )}
-                        {build.web_url ? (
+                        <span className="text-zinc-500 dark:text-zinc-400">
+                          {build.created_at ? formatTime(build.created_at) : "—"}
+                        </span>
+                        {build.web_url && build.build_number ? (
                           <a
                             href={build.web_url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-zinc-500 hover:text-zinc-900 hover:underline dark:text-zinc-400 dark:hover:text-zinc-100"
+                            aria-label={`Open Buildkite build ${build.build_number}`}
+                            className="inline-flex items-center gap-1 font-medium text-blue-600 hover:underline dark:text-blue-400"
                           >
-                            {build.created_at ? formatTime(build.created_at) : "—"}
+                            Buildkite #{build.build_number}
+                            <span aria-hidden="true">↗</span>
                           </a>
-                        ) : (
-                          <span className="text-zinc-500 dark:text-zinc-400">
-                            {build.created_at ? formatTime(build.created_at) : "—"}
-                          </span>
-                        )}
+                        ) : null}
                       </div>
                     </td>
                   <td className="px-4 py-2 font-mono text-xs">
@@ -587,6 +613,8 @@ export function BuildsTable({
                           organization={build.organization_slug!}
                           pipeline={build.pipeline_slug!}
                           buildNumber={build.build_number!}
+                          buildUrl={build.web_url}
+                          startedJobCount={startedJobCount}
                         />
                       </td>
                     </tr>


### PR DESCRIPTION
## What changed

- replace the unlabeled build-row chevron with an explicit **View timeline** control
- add a visible **Buildkite #…** link in each build row and the expanded timeline header
- compare traced lanes with the canonical count of started Buildkite jobs
- show **Partial**, **Live**, or **Complete** without conflating a finished trace with complete job coverage
- replace critical-path jargon with **build-limiting jobs** and action-oriented filter copy

## Why

The waterfall was difficult to discover, Buildkite navigation was hidden behind the start time and status, and a completed root span could misleadingly imply that every job was traced.

For build #83883, the updated UI correctly reports **Partial · 2 of 11 jobs traced**.

## Validation

- focused ESLint on all four changed files
- `npx tsc --noEmit`
- `git diff --check`
- `npm run build -- --webpack`
- local browser verification against live dashboard data:
  - explicit row controls and links are visible
  - build #83883 reports 2 of 11 jobs traced
  - build-limiting filter toggles correctly
  - no browser console errors

Repository-wide ESLint still reports the pre-existing `prefer-const` issue in `src/app/api/alerts/queue/route.ts:166`; this PR does not touch that route.