### PR TITLE
Add queue job prioritization

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -14,7 +14,8 @@ DATABASE_URL=postgres://user:pass@host:5432/dbname
 # Buildkite Agent Metrics API (required for agent metrics polling)
 BUILDKITE_AGENT_TOKEN=your-agent-registration-token
 
-# Buildkite API (scope requirements depend on the enabled dashboard features)
+# Buildkite API (requires read_suites for Test Engine and GraphQL API access
+# plus write_builds to enable queue-job promotion)
 BUILDKITE_API_TOKEN=your-personal-api-token
 BUILDKITE_ORGANIZATION=vllm
 BUILDKITE_TEST_SUITE=ci-1
@@ -27,6 +28,10 @@ OTEL_MAX_REQUEST_BYTES=4194304
 # Base URL used by `npm run configure:buildkite-otel`. Buildkite appends
 # /v1/traces automatically.
 OTEL_ENDPOINT=https://ci.vllm.ai/api/otel
+
+# Required to enable the queue UI's promotion action. Give this only to
+# authorized operators; it is kept in browser memory for the current tab.
+BUILDKITE_QUEUE_OPERATOR_TOKEN=choose-a-long-random-operator-token
 
 # GPU reporting auth (must match GPU_REPORT_SECRET on the node-side script)
 GPU_REPORT_SECRET=your-gpu-report-secret

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Open http://localhost:3000.
 | `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, `DATABRICKS_WAREHOUSE_ID` | Databricks SQL Warehouse access |
 | `DATABASE_URL` | Postgres connection string for agent/queue samples |
 | `BUILDKITE_AGENT_TOKEN` | Buildkite agent registration token (for the Agent Metrics API) |
-| `BUILDKITE_API_TOKEN` | Buildkite personal API token; needs `read_suites` for Test Engine and notification-service scopes only when running the OTel setup script |
+| `BUILDKITE_API_TOKEN` | Buildkite personal API token; needs `read_suites` for Test Engine, GraphQL API access and `write_builds` for queue promotion, and notification-service scopes only when running the OTel setup script |
 | `BUILDKITE_ORGANIZATION`, `BUILDKITE_TEST_SUITE` | Test Engine organization and suite slug (defaults: `vllm`, `ci-1`) |
+| `BUILDKITE_QUEUE_OPERATOR_TOKEN` | Required to enable queue-job promotion; authorized operators enter it for the current browser tab |
 | `OTEL_INGEST_TOKEN` | Required Bearer token for the OTLP/HTTP trace receiver |
 | `OTEL_MAX_REQUEST_BYTES` | Optional OTLP request limit; defaults to 4 MiB |
 | `OTEL_ENDPOINT` | Buildkite notification-service base URL; defaults operationally to `https://ci.vllm.ai/api/otel` |

--- a/src/app/api/queue/jobs/reprioritize/route.ts
+++ b/src/app/api/queue/jobs/reprioritize/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { BuildkiteQueueError, reprioritizeQueueJob } from "@/lib/buildkite-queue-jobs";
+
+export const dynamic = "force-dynamic";
+
+function hasOperatorAccess(request: NextRequest): boolean {
+  const expectedToken = process.env.BUILDKITE_QUEUE_OPERATOR_TOKEN;
+  const suppliedToken = request.headers.get("x-queue-operator-token");
+  return Boolean(expectedToken && suppliedToken && suppliedToken === expectedToken);
+}
+
+export async function POST(request: NextRequest) {
+  if (!hasOperatorAccess(request)) {
+    return NextResponse.json(
+      {
+        error: "Promotion requires the configured queue operator token.",
+        code: "QUEUE_OPERATOR_UNAUTHORIZED",
+      },
+      { status: 401, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  let body: { queue?: unknown; jobUuid?: unknown };
+  try {
+    body = (await request.json()) as { queue?: unknown; jobUuid?: unknown };
+  } catch {
+    return NextResponse.json(
+      { error: "The promotion request must be valid JSON.", code: "INVALID_REQUEST" },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  if (typeof body.queue !== "string" || typeof body.jobUuid !== "string") {
+    return NextResponse.json(
+      { error: "A queue and job UUID are required.", code: "INVALID_REQUEST" },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  try {
+    const result = await reprioritizeQueueJob(body.queue, body.jobUuid);
+    return NextResponse.json(
+      { priority: result.priority },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    if (error instanceof BuildkiteQueueError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error.status, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    console.error("Failed to reprioritize queue job:", error);
+    return NextResponse.json(
+      { error: "This job could not be promoted.", code: "QUEUE_REPRIORITIZE_UNAVAILABLE" },
+      { status: 502, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/src/app/api/queue/jobs/route.ts
+++ b/src/app/api/queue/jobs/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { BuildkiteQueueError, getQueueJobs } from "@/lib/buildkite-queue-jobs";
+
+export const dynamic = "force-dynamic";
+
+function responseError(error: unknown) {
+  if (error instanceof BuildkiteQueueError) {
+    return NextResponse.json(
+      { error: error.message, code: error.code },
+      { status: error.status, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  console.error("Failed to fetch current queue jobs:", error);
+  return NextResponse.json(
+    { error: "Current queue jobs could not be loaded.", code: "QUEUE_JOBS_UNAVAILABLE" },
+    { status: 502, headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const queue = request.nextUrl.searchParams.get("queue") ?? "";
+
+  try {
+    const jobs = await getQueueJobs(queue);
+    return NextResponse.json(
+      { jobs, operatorAccessRequired: Boolean(process.env.BUILDKITE_QUEUE_OPERATOR_TOKEN) },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    return responseError(error);
+  }
+}

--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import { StatCard } from "@/components/stat-card";
 import { SearchableSelect } from "@/components/searchable-select";
 import { QueueOverviewChart } from "@/components/queue-overview-chart";
+import { QueueWaitingJobs } from "@/components/queue-waiting-jobs";
 import { effectiveWaiting } from "@/lib/queue-plugins";
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -261,6 +262,8 @@ export default function QueuePage() {
           );
         })()}
       </div>
+
+      {queue && <QueueWaitingJobs queue={queue} />}
 
       {/* Queue Overview Chart */}
       <div className="rounded-lg border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950">

--- a/src/components/queue-waiting-jobs.tsx
+++ b/src/components/queue-waiting-jobs.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+
+interface QueueJob {
+  uuid: string;
+  label: string | null;
+  url: string;
+  scheduledAt: string;
+  priority: number;
+}
+
+interface QueueJobsResponse {
+  jobs: QueueJob[];
+  operatorAccessRequired: boolean;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  const body = (await response.json()) as T & { error?: string };
+
+  if (!response.ok || body.error) {
+    throw new Error(body.error ?? `Request failed with status ${response.status}`);
+  }
+
+  return body;
+}
+
+function formatScheduledAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+export function QueueWaitingJobs({ queue }: { queue: string }) {
+  const [operatorToken, setOperatorToken] = useState("");
+  const [showAccess, setShowAccess] = useState(false);
+  const [pendingJobUuid, setPendingJobUuid] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const url = queue ? `/api/queue/jobs?queue=${encodeURIComponent(queue)}` : null;
+  const { data, error, isLoading, isValidating, mutate } = useSWR<QueueJobsResponse>(
+    url,
+    fetchJson,
+    { refreshInterval: 30_000, keepPreviousData: true },
+  );
+
+  async function promote(job: QueueJob) {
+    if (!operatorToken) {
+      setShowAccess(true);
+      setNotice("Enter the queue operator token to enable promotions.");
+      return;
+    }
+
+    const name = job.label || "this job";
+    if (!window.confirm(`Move ${name} to the front of ${queue}? Its priority will be calculated from the current queue.`)) {
+      return;
+    }
+
+    setPendingJobUuid(job.uuid);
+    setNotice(null);
+    try {
+      const response = await fetch("/api/queue/jobs/reprioritize", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Queue-Operator-Token": operatorToken,
+        },
+        body: JSON.stringify({ queue, jobUuid: job.uuid }),
+      });
+      const body = (await response.json()) as { priority?: number; error?: string };
+      if (!response.ok || body.error || body.priority === undefined) {
+        if (response.status === 401) setOperatorToken("");
+        throw new Error(body.error ?? "This job could not be promoted.");
+      }
+
+      setNotice(`${job.label || "Job"} moved to the front at priority ${body.priority}.`);
+      await mutate();
+    } catch (promotionError) {
+      setNotice(promotionError instanceof Error ? promotionError.message : "This job could not be promoted.");
+    } finally {
+      setPendingJobUuid(null);
+    }
+  }
+
+  const canPromote = Boolean(data?.operatorAccessRequired && operatorToken);
+  const showTable = Boolean(data && (data.jobs.length > 0 || isValidating || error));
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="border-b border-zinc-200 px-5 py-4 dark:border-zinc-800">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="text-base font-semibold tracking-tight">Waiting jobs</h2>
+              {data && (
+                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold tabular-nums text-amber-800 dark:bg-amber-950/60 dark:text-amber-300">
+                  {data.jobs.length}
+                </span>
+              )}
+            </div>
+            <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+              {queue} · priority first, then earliest scheduled
+            </p>
+          </div>
+          <div className="flex min-h-5 items-center text-xs" role="status" aria-live="polite">
+            {isValidating && data && !error && (
+              <span className="flex items-center gap-2 text-blue-600 dark:text-blue-400">
+                <span
+                  className="h-3 w-3 animate-spin rounded-full border-2 border-blue-200 border-t-blue-600 motion-reduce:animate-none dark:border-blue-900 dark:border-t-blue-400"
+                  aria-hidden="true"
+                />
+                Updating queue
+              </span>
+            )}
+            {error && data && (
+              <span className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+                Refresh paused — showing saved jobs
+                <button
+                  type="button"
+                  onClick={() => void mutate()}
+                  className="font-medium underline underline-offset-2"
+                >
+                  Retry
+                </button>
+              </span>
+            )}
+          </div>
+        </div>
+
+        {data?.operatorAccessRequired ? (
+          <div className="mt-4 border-t border-zinc-100 pt-3 dark:border-zinc-800/80">
+            <button
+              type="button"
+              onClick={() => setShowAccess((open) => !open)}
+              aria-expanded={showAccess}
+              className="dashboard-control text-xs font-medium text-zinc-600 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-zinc-100"
+            >
+              {operatorToken ? "Operator access enabled for this tab" : "Unlock promotion actions"}
+            </button>
+            {showAccess && (
+              <label className="mt-2 flex max-w-md flex-col gap-1.5 text-xs text-zinc-500 dark:text-zinc-400 sm:flex-row sm:items-center">
+                <span className="shrink-0">Operator token</span>
+                <input
+                  type="password"
+                  value={operatorToken}
+                  onChange={(event) => setOperatorToken(event.target.value)}
+                  autoComplete="off"
+                  className="min-h-10 min-w-0 flex-1 rounded-md border border-zinc-200 bg-zinc-50 px-3 text-sm text-zinc-900 shadow-sm outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-500/15 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+                />
+              </label>
+            )}
+          </div>
+        ) : data ? (
+          <p className="mt-3 text-xs text-amber-700 dark:text-amber-300">
+            Promotion is disabled until BUILDKITE_QUEUE_OPERATOR_TOKEN is configured on the dashboard.
+          </p>
+        ) : null}
+
+        {notice && (
+          <p className="mt-3 text-sm text-zinc-700 dark:text-zinc-300" role="status">
+            {notice}
+          </p>
+        )}
+      </div>
+
+      {isLoading && !data && (
+        <div className="flex min-h-36 items-center justify-center px-5 text-sm text-zinc-500 dark:text-zinc-400">
+          Loading waiting jobs…
+        </div>
+      )}
+
+      {error && !data && (
+        <div className="flex min-h-36 flex-col items-center justify-center gap-3 px-5 text-center text-sm text-zinc-500 dark:text-zinc-400">
+          <p>Waiting jobs couldn&apos;t be loaded.</p>
+          <button
+            type="button"
+            onClick={() => void mutate()}
+            className="dashboard-control rounded-md border border-zinc-300 px-3 py-1.5 font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {data && data.jobs.length === 0 && !isValidating && !error && (
+        <div className="flex min-h-36 items-center justify-center px-5 text-center text-sm text-zinc-500 dark:text-zinc-400">
+          No command jobs are waiting in {queue}.
+        </div>
+      )}
+
+      {showTable && data && (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[720px] text-sm">
+            <thead>
+              <tr className="border-b border-zinc-200 text-left text-xs uppercase tracking-[0.08em] text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+                <th className="w-16 px-5 py-3 font-medium">Order</th>
+                <th className="px-5 py-3 font-medium">Job</th>
+                <th className="px-5 py-3 font-medium">Priority</th>
+                <th className="px-5 py-3 font-medium">Scheduled</th>
+                <th className="px-5 py-3 text-right font-medium">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.jobs.map((job, index) => {
+                const isPending = pendingJobUuid === job.uuid;
+                const isFirst = index === 0;
+                return (
+                  <tr
+                    key={job.uuid}
+                    className={`border-b border-zinc-100 last:border-0 dark:border-zinc-800/50 ${isFirst ? "bg-amber-50/55 dark:bg-amber-950/15" : ""}`}
+                  >
+                    <td className="px-5 py-3 font-mono text-xs tabular-nums text-zinc-500 dark:text-zinc-400">
+                      {String(index + 1).padStart(2, "0")}
+                    </td>
+                    <td className="max-w-md px-5 py-3">
+                      <a
+                        href={job.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block truncate font-medium text-blue-700 hover:underline dark:text-blue-400"
+                        title={job.label || job.uuid}
+                      >
+                        {job.label || "Unnamed command job"}
+                      </a>
+                      <span className="mt-0.5 block font-mono text-[11px] text-zinc-400 dark:text-zinc-500">
+                        {job.uuid}
+                      </span>
+                    </td>
+                    <td className="px-5 py-3">
+                      <span className={`inline-flex rounded-full px-2 py-0.5 font-mono text-xs tabular-nums ${isFirst ? "bg-amber-100 text-amber-900 dark:bg-amber-900/60 dark:text-amber-200" : "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"}`}>
+                        {job.priority}
+                      </span>
+                    </td>
+                    <td className="whitespace-nowrap px-5 py-3 text-zinc-600 dark:text-zinc-400">
+                      {formatScheduledAt(job.scheduledAt)}
+                    </td>
+                    <td className="px-5 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => void promote(job)}
+                        disabled={!canPromote || isPending}
+                        title={
+                          !data.operatorAccessRequired
+                            ? "Promotion is not configured on this dashboard"
+                            : !operatorToken
+                              ? "Unlock promotion actions first"
+                              : undefined
+                        }
+                        className="dashboard-control min-h-10 rounded-md border border-amber-300 bg-amber-50 px-3 text-xs font-semibold text-amber-900 hover:border-amber-400 hover:bg-amber-100 disabled:cursor-not-allowed disabled:border-zinc-200 disabled:bg-zinc-100 disabled:text-zinc-400 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200 dark:hover:bg-amber-950/70 dark:disabled:border-zinc-800 dark:disabled:bg-zinc-900 dark:disabled:text-zinc-600"
+                      >
+                        {isPending ? "Moving…" : "Move to front"}
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {data && data.jobs.length > 0 && (
+        <p className="border-t border-zinc-100 px-5 py-3 text-xs text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+          Buildkite breaks identical priority and scheduled-time ties by pipeline upload order; that final tie-breaker is not exposed in this view.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/lib/buildkite-queue-jobs.ts
+++ b/src/lib/buildkite-queue-jobs.ts
@@ -1,0 +1,239 @@
+const GRAPHQL_ENDPOINT = "https://graphql.buildkite.com/v1";
+const REST_ENDPOINT = "https://api.buildkite.com/v2";
+const JOBS_PAGE_SIZE = 100;
+
+export interface QueueJob {
+  uuid: string;
+  label: string | null;
+  url: string;
+  scheduledAt: string;
+  priority: number;
+}
+
+interface GraphQLResponse {
+  data?: {
+    organization?: {
+      jobs: {
+        pageInfo: {
+          hasNextPage: boolean;
+          endCursor: string | null;
+        };
+        edges: Array<{
+          node: {
+            uuid?: string;
+            label?: string | null;
+            url?: string;
+            scheduledAt?: string;
+            priority?: { number?: number };
+          };
+        }>;
+      };
+    } | null;
+  };
+  errors?: Array<{ message: string }>;
+}
+
+export class BuildkiteQueueError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code: string,
+  ) {
+    super(message);
+  }
+}
+
+function getToken(): string {
+  const token = process.env.BUILDKITE_API_TOKEN;
+  if (!token) {
+    throw new BuildkiteQueueError(
+      "Queue jobs need a Buildkite API token with GraphQL API access.",
+      503,
+      "BUILDKITE_NOT_CONFIGURED",
+    );
+  }
+  return token;
+}
+
+function organization(): string {
+  return process.env.BUILDKITE_ORGANIZATION || "vllm";
+}
+
+function queueRule(queue: string): string {
+  if (!queue || queue.length > 255) {
+    throw new BuildkiteQueueError("A valid queue is required.", 400, "INVALID_QUEUE");
+  }
+  return `queue=${queue}`;
+}
+
+async function graphqlQueueJobs(queue: string): Promise<QueueJob[]> {
+  const token = getToken();
+  const jobs: QueueJob[] = [];
+  let after: string | null = null;
+
+  do {
+    const response = await fetch(GRAPHQL_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: `
+          query QueueJobs($organization: String!, $agentQueryRules: [String!], $first: Int!, $after: String) {
+            organization(slug: $organization) {
+              jobs(
+                first: $first
+                after: $after
+                type: COMMAND
+                state: SCHEDULED
+                agentQueryRules: $agentQueryRules
+              ) {
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+                edges {
+                  node {
+                    ... on JobTypeCommand {
+                      uuid
+                      label
+                      url
+                      scheduledAt
+                      priority { number }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `,
+        variables: {
+          organization: organization(),
+          agentQueryRules: [queueRule(queue)],
+          first: JOBS_PAGE_SIZE,
+          after,
+        },
+      }),
+      cache: "no-store",
+    });
+
+    let result: GraphQLResponse;
+    try {
+      result = (await response.json()) as GraphQLResponse;
+    } catch {
+      throw new BuildkiteQueueError(
+        "Buildkite returned an invalid queue-jobs response.",
+        502,
+        "BUILDKITE_INVALID_RESPONSE",
+      );
+    }
+
+    if (!response.ok || result.errors?.length) {
+      const detail = result.errors?.map((error) => error.message).join(" ");
+      const message =
+        response.status === 401
+          ? "The configured Buildkite API token is no longer valid."
+          : response.status === 403 || response.status === 404
+            ? "The Buildkite token needs GraphQL API access and read access to this organization."
+            : detail || "Buildkite could not load the queue jobs.";
+      throw new BuildkiteQueueError(
+        message,
+        response.status >= 500 ? 502 : response.status || 502,
+        "BUILDKITE_REQUEST_FAILED",
+      );
+    }
+
+    const connection = result.data?.organization?.jobs;
+    if (!connection) {
+      throw new BuildkiteQueueError(
+        "Buildkite did not return jobs for the configured organization.",
+        502,
+        "BUILDKITE_INVALID_RESPONSE",
+      );
+    }
+
+    for (const { node } of connection.edges) {
+      if (!node.uuid || !node.url || !node.scheduledAt) continue;
+      jobs.push({
+        uuid: node.uuid,
+        label: node.label ?? null,
+        url: node.url,
+        scheduledAt: node.scheduledAt,
+        priority: node.priority?.number ?? 0,
+      });
+    }
+
+    after = connection.pageInfo.hasNextPage ? connection.pageInfo.endCursor : null;
+  } while (after);
+
+  return jobs.sort((a, b) => {
+    if (a.priority !== b.priority) return b.priority - a.priority;
+    const scheduledDifference = new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime();
+    if (scheduledDifference !== 0) return scheduledDifference;
+    return a.uuid.localeCompare(b.uuid);
+  });
+}
+
+export async function getQueueJobs(queue: string): Promise<QueueJob[]> {
+  return graphqlQueueJobs(queue);
+}
+
+export async function reprioritizeQueueJob(queue: string, jobUuid: string): Promise<{ priority: number }> {
+  if (!/^[0-9a-f-]{36}$/i.test(jobUuid)) {
+    throw new BuildkiteQueueError("A valid job UUID is required.", 400, "INVALID_JOB");
+  }
+
+  const jobs = await graphqlQueueJobs(queue);
+  const job = jobs.find((candidate) => candidate.uuid === jobUuid);
+  if (!job) {
+    throw new BuildkiteQueueError(
+      "This job is no longer scheduled in the selected queue. Refresh the list and try again.",
+      409,
+      "JOB_NOT_SCHEDULED",
+    );
+  }
+
+  const highestPriority = Math.max(...jobs.map((candidate) => candidate.priority));
+  if (highestPriority >= 2_147_483_647) {
+    throw new BuildkiteQueueError(
+      "The queue's current priority is too high to promote another job.",
+      409,
+      "PRIORITY_LIMIT_REACHED",
+    );
+  }
+  const priority = highestPriority + 1;
+
+  const response = await fetch(
+    `${REST_ENDPOINT}/organizations/${encodeURIComponent(organization())}/jobs/${encodeURIComponent(jobUuid)}/reprioritize`,
+    {
+      method: "PUT",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${getToken()}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ priority }),
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    const detail = await response.text();
+    const message =
+      response.status === 401
+        ? "The configured Buildkite API token is no longer valid."
+        : response.status === 403 || response.status === 404
+          ? "The Buildkite token needs write_builds access to reprioritize jobs."
+          : "Buildkite could not reprioritize this job.";
+    console.error(`Buildkite job reprioritize failed: ${response.status} ${detail}`);
+    throw new BuildkiteQueueError(
+      message,
+      response.status >= 500 ? 502 : response.status,
+      "BUILDKITE_REPRIORITIZE_FAILED",
+    );
+  }
+
+  return { priority };
+}


### PR DESCRIPTION
## Summary

- show every scheduled command job for the selected Buildkite queue, ordered by priority and scheduled time
- let authorized operators move a scheduled job to the front without choosing a priority manually
- add explicit loading, retained-data, error, and empty states for the live queue view

## Safety

The server reloads the queue and verifies the job is still scheduled in that queue before setting its priority to the current maximum plus one. Promotion additionally requires the dashboard operator token.

## Validation

- `npm run lint`
- `git diff --check`
- `npm run build -- --webpack`

