### PR TITLE
Fix queue jobs GraphQL variable type

### DIFF
--- a/src/lib/buildkite-queue-jobs.ts
+++ b/src/lib/buildkite-queue-jobs.ts
@@ -81,7 +81,7 @@ async function graphqlQueueJobs(queue: string): Promise<QueueJob[]> {
       },
       body: JSON.stringify({
         query: `
-          query QueueJobs($organization: String!, $agentQueryRules: [String!], $first: Int!, $after: String) {
+          query QueueJobs($organization: ID!, $agentQueryRules: [String!], $first: Int!, $after: String) {
             organization(slug: $organization) {
               jobs(
                 first: $first


### PR DESCRIPTION
Corrects the queue-jobs GraphQL organization slug variable from String to ID, matching Buildkite's schema.