### PR TITLE
Show command and pytest spans in build timelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ Open http://localhost:3000.
 | `BUILDKITE_API_TOKEN` | Buildkite personal API token; needs `read_suites` for Test Engine, GraphQL API access and `write_builds` for queue promotion, and notification-service scopes only when running the OTel setup script |
 | `BUILDKITE_ORGANIZATION`, `BUILDKITE_TEST_SUITE` | Test Engine organization and suite slug (defaults: `vllm`, `ci-1`) |
 | `BUILDKITE_QUEUE_OPERATOR_TOKEN` | Required to enable queue-job promotion; authorized operators enter it for the current browser tab |
-| `OTEL_INGEST_TOKEN` | Required Bearer token for the OTLP/HTTP trace receiver |
+| `OTEL_INGEST_TOKEN` | Shared Bearer token used by Buildkite's OTel notification service |
 | `OTEL_MAX_REQUEST_BYTES` | Optional OTLP request limit; defaults to 4 MiB |
 | `OTEL_ENDPOINT` | Buildkite notification-service base URL; defaults operationally to `https://ci.vllm.ai/api/otel` |
+| `OTEL_BUILDKITE_OIDC_AUDIENCE`, `OTEL_BUILDKITE_OIDC_ORGANIZATION`, `OTEL_BUILDKITE_OIDC_PIPELINE`, `OTEL_BUILDKITE_OIDC_BRANCH` | Optional restrictions for short-lived Buildkite job tokens; defaults to the production vLLM main pipeline |
 | `SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID` | Slack bot for queue-depth alerts (`chat:write`, `reactions:write`) |
 | `CRON_SECRET` | Optional shared secret required by Vercel cron handlers |
 
@@ -95,20 +96,23 @@ job history without introducing another dashboard.
    ```
 
 The Vercel receiver accepts OTLP/HTTP protobuf with optional gzip compression;
-it is not a gRPC collector. To add agent-side checkout, hook, plugin, command,
-and artifact spans, Buildkite agent v3.101 or newer can be configured with:
+it is not a gRPC collector. Buildkite agent v3.100 and newer propagates its
+trace context to job processes, and the vLLM helper continues `TRACEPARENT`
+when it is present. The agent's own span exporter is OTLP/gRPC-only, so adding
+agent-internal checkout, hook, plugin, and artifact spans would still require a
+standard OpenTelemetry Collector in front of this HTTP endpoint.
 
-```bash
-BUILDKITE_TRACING_BACKEND=opentelemetry
-BUILDKITE_TRACING_PROPAGATE_TRACEPARENT=true
-OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-OTEL_EXPORTER_OTLP_ENDPOINT=https://ci.vllm.ai/api/otel
-OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer $OTEL_INGEST_TOKEN"
-OTEL_TRACES_SAMPLER=always_on
-```
+Detailed job timing does not distribute `OTEL_INGEST_TOKEN` to test code. An
+opted-in trusted main-branch job requests a five-minute Buildkite OIDC token for
+the dashboard audience when it uploads a batch. The receiver verifies the
+Buildkite signature and requires the token's organization, pipeline, branch,
+build, and job identity to match every span. Pull-request jobs and AMD mirrors
+are excluded from the initial pilot.
 
-For older agents that only export OTLP/gRPC, put a standard OpenTelemetry
-Collector in front of this HTTP endpoint or upgrade the agents first.
+The vLLM CI helper creates a span for each generated YAML command. When the
+command invokes pytest, its lightweight pytest plugin sends one child span per
+test node ID. The build timeline groups those spans as job → command → test;
+telemetry errors are warnings and never change the test command's exit status.
 
 ## Deployment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
+        "jose": "^6.2.8",
         "js-yaml": "^4.1.1",
         "next": "16.1.7",
         "plotly.js-basic-dist-min": "^3.4.0",
@@ -6503,6 +6504,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
+    "jose": "^6.2.8",
     "js-yaml": "^4.1.1",
     "next": "16.1.7",
     "plotly.js-basic-dist-min": "^3.4.0",

--- a/src/app/api/builds/trace/route.ts
+++ b/src/app/api/builds/trace/route.ts
@@ -3,7 +3,7 @@ import { getDb } from "@/lib/db";
 
 export const runtime = "nodejs";
 
-const MAX_SPANS = 2_000;
+const MAX_SPANS = 5_000;
 const SLUG = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,99}$/;
 
 type TraceRow = {
@@ -27,14 +27,21 @@ type TraceRow = {
   job_url: string | null;
   step_url: string | null;
   wait_ms: number | null;
+  ci_kind: string | null;
+  command_index: number | null;
+  command_label: string | null;
+  test_nodeid: string | null;
+  test_outcome: string | null;
   received_at: Date;
 };
+
+type LaneKind = "job" | "step" | "command" | "test";
 
 type Lane = {
   id: string;
   parentId: string | null;
   traceId: string;
-  kind: "job" | "step";
+  kind: LaneKind;
   label: string;
   group: string | null;
   stepKey: string | null;
@@ -44,23 +51,27 @@ type Lane = {
   endTime: string;
   durationMs: number;
   waitMs: number;
-  status: "passed" | "failed" | "unknown";
+  status: "passed" | "failed" | "skipped" | "unknown";
+  outcome: string | null;
   url: string | null;
   critical: boolean;
 };
 
 function laneStatus(row: TraceRow): Lane["status"] {
+  if (row.test_outcome === "skipped") return "skipped";
   if (
     row.status_code === 2 ||
     row.job_passed === "false" ||
-    row.step_outcome === "failed"
+    row.step_outcome === "failed" ||
+    row.test_outcome === "failed"
   ) {
     return "failed";
   }
   if (
     row.status_code === 1 ||
     row.job_passed === "true" ||
-    row.step_outcome === "passed"
+    row.step_outcome === "passed" ||
+    row.test_outcome === "passed"
   ) {
     return "passed";
   }
@@ -93,6 +104,40 @@ function error(message: string, status: number) {
     { error: message },
     { status, headers: { "Cache-Control": "no-store" } },
   );
+}
+
+function jobLane(row: TraceRow, id = row.span_id): Lane {
+  return {
+    id,
+    parentId: row.parent_span_id,
+    traceId: row.trace_id,
+    kind: row.span_name === "buildkite.step" ? "step" : "job",
+    label: row.job_label ?? row.step_label ?? row.span_name,
+    group: row.group_label,
+    stepKey: row.step_key,
+    jobId: row.job_id,
+    queue: row.agent_queue,
+    startTime: row.start_time.toISOString(),
+    endTime: row.end_time.toISOString(),
+    durationMs: Number(row.duration_ms),
+    waitMs: Math.max(0, Number(row.wait_ms ?? 0)),
+    status: laneStatus(row),
+    outcome: row.job_state ?? row.step_outcome,
+    url: row.job_url ?? row.step_url,
+    critical: false,
+  };
+}
+
+function detailKind(row: TraceRow): "command" | "test" | null {
+  if (row.ci_kind === "command") return "command";
+  if (row.ci_kind === "test") return "test";
+  return null;
+}
+
+function detailLabel(row: TraceRow, kind: "command" | "test"): string {
+  if (kind === "test") return row.test_nodeid ?? row.span_name;
+  const prefix = row.command_index ? `${row.command_index}. ` : "";
+  return `${prefix}${row.command_label ?? row.span_name}`;
 }
 
 export async function GET(request: NextRequest) {
@@ -131,10 +176,19 @@ export async function GET(request: NextRequest) {
         NULLIF(span_attributes->>'buildkite.job.web_url', '') AS job_url,
         NULLIF(span_attributes->>'buildkite.step.web_url', '') AS step_url,
         CASE
-          WHEN span_attributes->>'buildkite.job.wait_time_ms' ~ '^\\d+(\\.\\d+)?$'
+          WHEN span_attributes->>'buildkite.job.wait_time_ms' ~ '^\d+(\.\d+)?$'
           THEN (span_attributes->>'buildkite.job.wait_time_ms')::double precision
           ELSE 0
         END AS wait_ms,
+        NULLIF(span_attributes->>'ci.span.kind', '') AS ci_kind,
+        CASE
+          WHEN span_attributes->>'ci.command.index' ~ '^\d+$'
+          THEN (span_attributes->>'ci.command.index')::integer
+          ELSE NULL
+        END AS command_index,
+        NULLIF(span_attributes->>'ci.command.label', '') AS command_label,
+        NULLIF(span_attributes->>'test.nodeid', '') AS test_nodeid,
+        NULLIF(span_attributes->>'test.outcome', '') AS test_outcome,
         received_at
       FROM otel_spans
       WHERE organization_slug = ${organization}
@@ -163,20 +217,69 @@ export async function GET(request: NextRequest) {
         .map((row) => row.parent_span_id)
         .filter((value): value is string => Boolean(value)),
     );
-    const displayRows = rows.filter(
+    const controlRows = rows.filter(
       (row) =>
         row.span_name === "buildkite.job" ||
         (row.span_name === "buildkite.step" &&
           !childJobParents.has(row.span_id)),
     );
+    const details = rows.filter((row) => detailKind(row) !== null);
 
-    const lanes = markCompletionFrontier(
-      displayRows.map((row) => ({
+    const baseJobLanes = controlRows.map((row) => jobLane(row));
+    const jobLaneByJobId = new Map(
+      baseJobLanes
+        .filter((lane) => lane.jobId)
+        .map((lane) => [lane.jobId as string, lane]),
+    );
+
+    const detailRowsByJobId = new Map<string, TraceRow[]>();
+    for (const row of details) {
+      if (!row.job_id) continue;
+      const jobRows = detailRowsByJobId.get(row.job_id) ?? [];
+      jobRows.push(row);
+      detailRowsByJobId.set(row.job_id, jobRows);
+    }
+    for (const [jobId, jobRows] of detailRowsByJobId) {
+      if (jobLaneByJobId.has(jobId)) continue;
+      const first = jobRows[0];
+      const start = Math.min(...jobRows.map((row) => row.start_time.getTime()));
+      const end = Math.max(...jobRows.map((row) => row.end_time.getTime()));
+      const synthetic = jobLane(first, `job:${jobId}`);
+      synthetic.parentId = null;
+      synthetic.startTime = new Date(start).toISOString();
+      synthetic.endTime = new Date(end).toISOString();
+      synthetic.durationMs = Math.max(0, end - start);
+      synthetic.waitMs = 0;
+      synthetic.status = jobRows.some((row) => laneStatus(row) === "failed")
+        ? "failed"
+        : "unknown";
+      baseJobLanes.push(synthetic);
+      jobLaneByJobId.set(jobId, synthetic);
+    }
+
+    const jobLanes = markCompletionFrontier(baseJobLanes);
+    const commandIds = new Set(
+      details
+        .filter((row) => detailKind(row) === "command")
+        .map((row) => row.span_id),
+    );
+    const detailLanes = details.map((row): Lane => {
+      const kind = detailKind(row) as "command" | "test";
+      const jobParent = row.job_id
+        ? (jobLaneByJobId.get(row.job_id)?.id ?? null)
+        : null;
+      const parentId =
+        kind === "test" &&
+        row.parent_span_id &&
+        commandIds.has(row.parent_span_id)
+          ? row.parent_span_id
+          : jobParent;
+      return {
         id: row.span_id,
-        parentId: row.parent_span_id,
+        parentId,
         traceId: row.trace_id,
-        kind: row.span_name === "buildkite.job" ? "job" : "step",
-        label: row.job_label ?? row.step_label ?? row.span_name,
+        kind,
+        label: detailLabel(row, kind),
         group: row.group_label,
         stepKey: row.step_key,
         jobId: row.job_id,
@@ -184,18 +287,20 @@ export async function GET(request: NextRequest) {
         startTime: row.start_time.toISOString(),
         endTime: row.end_time.toISOString(),
         durationMs: Number(row.duration_ms),
-        waitMs: Math.max(0, Number(row.wait_ms ?? 0)),
+        waitMs: 0,
         status: laneStatus(row),
-        url: row.job_url ?? row.step_url,
+        outcome: kind === "test" ? row.test_outcome : null,
+        url: null,
         critical: false,
-      })),
-    );
+      };
+    });
+    const lanes = [...jobLanes, ...detailLanes];
 
     const buildSpan = rows.find((row) => row.span_name === "buildkite.build");
-    const laneStarts = lanes.map(
+    const laneStarts = jobLanes.map(
       (lane) => Date.parse(lane.startTime) - lane.waitMs,
     );
-    const laneEnds = lanes.map((lane) => Date.parse(lane.endTime));
+    const laneEnds = jobLanes.map((lane) => Date.parse(lane.endTime));
     const observedStart = buildSpan
       ? buildSpan.start_time.getTime()
       : laneStarts.length > 0
@@ -209,6 +314,10 @@ export async function GET(request: NextRequest) {
     const latestReceived = Math.max(
       ...rows.map((row) => row.received_at.getTime()),
     );
+    const commandCount = detailLanes.filter(
+      (lane) => lane.kind === "command",
+    ).length;
+    const testCount = detailLanes.filter((lane) => lane.kind === "test").length;
 
     return NextResponse.json(
       {
@@ -221,12 +330,14 @@ export async function GET(request: NextRequest) {
           observedEnd: new Date(observedEnd).toISOString(),
           observedDurationMs: Math.max(0, observedEnd - observedStart),
           spanCount: rows.length,
-          laneCount: lanes.length,
+          laneCount: jobLanes.length,
+          commandCount,
+          testCount,
           traceCount: new Set(rows.map((row) => row.trace_id)).size,
           queueCount: new Set(
-            lanes.map((lane) => lane.queue).filter(Boolean),
+            jobLanes.map((lane) => lane.queue).filter(Boolean),
           ).size,
-          criticalCount: lanes.filter((lane) => lane.critical).length,
+          criticalCount: jobLanes.filter((lane) => lane.critical).length,
           latestReceivedAt: new Date(latestReceived).toISOString(),
         },
       },

--- a/src/app/api/otel/health/route.ts
+++ b/src/app/api/otel/health/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
-import { isOtlpAuthorized, isOtlpConfigured } from "@/lib/otel-auth";
+import { authorizeOtlpRequest, isOtlpConfigured } from "@/lib/otel-auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -12,7 +12,8 @@ export async function GET(request: NextRequest) {
       { status: 503 },
     );
   }
-  if (!isOtlpAuthorized(request.headers)) {
+  const principal = await authorizeOtlpRequest(request.headers);
+  if (principal?.kind !== "shared-token") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/src/app/api/otel/v1/traces/route.ts
+++ b/src/app/api/otel/v1/traces/route.ts
@@ -1,6 +1,10 @@
 import { gunzipSync } from "node:zlib";
 import { NextRequest, NextResponse } from "next/server";
-import { isOtlpAuthorized, isOtlpConfigured } from "@/lib/otel-auth";
+import {
+  authorizeOtlpRequest,
+  isOtlpConfigured,
+  spansMatchPrincipal,
+} from "@/lib/otel-auth";
 import { decodeOtlpTraceRequest } from "@/lib/otel-proto";
 import { storeOtlpSpans } from "@/lib/otel-storage";
 
@@ -29,7 +33,8 @@ export async function POST(request: NextRequest) {
       { status: 503 },
     );
   }
-  if (!isOtlpAuthorized(request.headers)) {
+  const principal = await authorizeOtlpRequest(request.headers);
+  if (!principal) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -65,6 +70,12 @@ export async function POST(request: NextRequest) {
     }
 
     spans = decodeOtlpTraceRequest(payload);
+    if (!spansMatchPrincipal(spans, principal)) {
+      return NextResponse.json(
+        { error: "Span identity does not match OIDC claims" },
+        { status: 403 },
+      );
+    }
   } catch (error) {
     console.error("Invalid OTLP trace request:", error);
     return NextResponse.json(

--- a/src/components/build-waterfall.tsx
+++ b/src/components/build-waterfall.tsx
@@ -3,9 +3,12 @@
 import { useMemo, useState } from "react";
 import useSWR from "swr";
 
+type LaneKind = "job" | "step" | "command" | "test";
+
 interface WaterfallLane {
   id: string;
-  kind: "job" | "step";
+  parentId: string | null;
+  kind: LaneKind;
   label: string;
   group: string | null;
   stepKey: string | null;
@@ -15,7 +18,8 @@ interface WaterfallLane {
   endTime: string;
   durationMs: number;
   waitMs: number;
-  status: "passed" | "failed" | "unknown";
+  status: "passed" | "failed" | "skipped" | "unknown";
+  outcome: string | null;
   url: string | null;
   critical: boolean;
 }
@@ -31,6 +35,8 @@ interface TraceResponse {
     observedDurationMs: number;
     spanCount: number;
     laneCount: number;
+    commandCount: number;
+    testCount: number;
     traceCount: number;
     queueCount: number;
     criticalCount: number;
@@ -47,15 +53,13 @@ interface BuildWaterfallProps {
   startedJobCount?: number;
 }
 
-const INITIAL_LANE_LIMIT = 36;
+const INITIAL_JOB_LIMIT = 36;
 const TICKS = [0, 0.25, 0.5, 0.75, 1];
 
 async function fetchTrace(url: string): Promise<TraceResponse> {
   const response = await fetch(url);
   const body = (await response.json()) as TraceResponse;
-  if (!response.ok) {
-    throw new Error(body.error ?? "Failed to load trace");
-  }
+  if (!response.ok) throw new Error(body.error ?? "Failed to load trace");
   return body;
 }
 
@@ -101,6 +105,23 @@ function GridLines() {
   );
 }
 
+function laneDepth(lane: WaterfallLane): number {
+  if (lane.kind === "test") return 2;
+  if (lane.kind === "command") return 1;
+  return 0;
+}
+
+function laneColor(lane: WaterfallLane): string {
+  if (lane.critical) {
+    return "border border-amber-500 bg-amber-300 shadow-[0_0_0_1px_rgb(245_158_11_/_0.12)] dark:bg-amber-500";
+  }
+  if (lane.status === "failed") return "bg-red-500 dark:bg-red-500";
+  if (lane.status === "skipped") return "bg-zinc-300 dark:bg-zinc-600";
+  if (lane.kind === "test") return "bg-emerald-500 dark:bg-emerald-500";
+  if (lane.kind === "command") return "bg-cyan-500 dark:bg-cyan-500";
+  return "bg-blue-500 dark:bg-blue-500";
+}
+
 export function BuildWaterfall({
   organization,
   pipeline,
@@ -110,11 +131,8 @@ export function BuildWaterfall({
 }: BuildWaterfallProps) {
   const [criticalOnly, setCriticalOnly] = useState(false);
   const [showAll, setShowAll] = useState(false);
-  const params = new URLSearchParams({
-    organization,
-    pipeline,
-    buildNumber,
-  });
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const params = new URLSearchParams({ organization, pipeline, buildNumber });
   const { data, error, isLoading, isValidating, mutate } = useSWR<TraceResponse>(
     `/api/builds/trace?${params.toString()}`,
     fetchTrace,
@@ -124,27 +142,84 @@ export function BuildWaterfall({
     },
   );
 
-  const orderedLanes = useMemo(
-    () =>
-      [...(data?.lanes ?? [])].sort((a, b) => {
+  const { jobLanes, childrenByParent } = useMemo(() => {
+    const lanes = data?.lanes ?? [];
+    const roots = lanes
+      .filter((lane) => lane.kind === "job" || lane.kind === "step")
+      .sort((a, b) => {
         const start = Date.parse(a.startTime) - Date.parse(b.startTime);
-        if (start !== 0) return start;
-        return b.durationMs - a.durationMs;
-      }),
-    [data?.lanes],
-  );
+        return start !== 0 ? start : b.durationMs - a.durationMs;
+      });
+    const children = new Map<string, WaterfallLane[]>();
+    for (const lane of lanes) {
+      if (!lane.parentId || lane.kind === "job" || lane.kind === "step") continue;
+      const siblings = children.get(lane.parentId) ?? [];
+      siblings.push(lane);
+      children.set(lane.parentId, siblings);
+    }
+    for (const siblings of children.values()) {
+      siblings.sort((a, b) => {
+        const index = a.kind === "command" && b.kind === "command"
+          ? Number(a.label.split(".", 1)[0]) - Number(b.label.split(".", 1)[0])
+          : 0;
+        if (Number.isFinite(index) && index !== 0) return index;
+        return Date.parse(a.startTime) - Date.parse(b.startTime);
+      });
+    }
+    return { jobLanes: roots, childrenByParent: children };
+  }, [data?.lanes]);
 
-  const visibleLanes = useMemo(() => {
-    if (criticalOnly) return orderedLanes.filter((lane) => lane.critical);
-    if (showAll || orderedLanes.length <= INITIAL_LANE_LIMIT) return orderedLanes;
+  const visibleJobs = useMemo(() => {
+    const filtered = criticalOnly
+      ? jobLanes.filter((lane) => lane.critical)
+      : jobLanes;
+    if (showAll || filtered.length <= INITIAL_JOB_LIMIT) return filtered;
     const initiallyVisible = new Set(
-      orderedLanes.slice(0, INITIAL_LANE_LIMIT).map((lane) => lane.id),
+      filtered.slice(0, INITIAL_JOB_LIMIT).map((lane) => lane.id),
     );
-    for (const lane of orderedLanes) {
+    for (const lane of filtered) {
       if (lane.critical) initiallyVisible.add(lane.id);
     }
-    return orderedLanes.filter((lane) => initiallyVisible.has(lane.id));
-  }, [criticalOnly, orderedLanes, showAll]);
+    return filtered.filter((lane) => initiallyVisible.has(lane.id));
+  }, [criticalOnly, jobLanes, showAll]);
+
+  const visibleLanes = useMemo(() => {
+    const flattened: WaterfallLane[] = [];
+    for (const job of visibleJobs) {
+      flattened.push(job);
+      if (!expanded.has(job.id)) continue;
+      for (const command of childrenByParent.get(job.id) ?? []) {
+        flattened.push(command);
+        if (!expanded.has(command.id)) continue;
+        flattened.push(...(childrenByParent.get(command.id) ?? []));
+      }
+    }
+    return flattened;
+  }, [childrenByParent, expanded, visibleJobs]);
+
+  function toggleExpanded(id: string) {
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleAllJobs() {
+    const expandableJobs = jobLanes
+      .filter((lane) => (childrenByParent.get(lane.id)?.length ?? 0) > 0)
+      .map((lane) => lane.id);
+    const allExpanded = expandableJobs.every((id) => expanded.has(id));
+    setExpanded((current) => {
+      const next = new Set(current);
+      for (const id of expandableJobs) {
+        if (allExpanded) next.delete(id);
+        else next.add(id);
+      }
+      return next;
+    });
+  }
 
   if (isLoading && !data) {
     return (
@@ -171,7 +246,7 @@ export function BuildWaterfall({
     );
   }
 
-  if (!data?.available || !data.summary || data.lanes.length === 0) {
+  if (!data?.available || !data.summary || jobLanes.length === 0) {
     return (
       <div className="border-t border-zinc-200 bg-zinc-50/70 px-6 py-8 dark:border-zinc-800 dark:bg-zinc-900/30">
         <p className="text-sm font-medium text-zinc-700 dark:text-zinc-200">
@@ -189,24 +264,24 @@ export function BuildWaterfall({
   const timelineStart = Date.parse(summary.observedStart);
   const timelineEnd = Date.parse(summary.observedEnd);
   const timelineDuration = Math.max(1, timelineEnd - timelineStart);
-  const hiddenCount = Math.max(0, orderedLanes.length - visibleLanes.length);
-  const hasCoverage =
-    typeof startedJobCount === "number" && startedJobCount > 0;
+  const hiddenCount = Math.max(0, jobLanes.length - visibleJobs.length);
+  const hasCoverage = typeof startedJobCount === "number" && startedJobCount > 0;
   const coverageTotal = hasCoverage
     ? Math.max(startedJobCount, summary.laneCount)
     : null;
   const isPartial =
     data.complete && coverageTotal !== null && summary.laneCount < coverageTotal;
-  const traceState = !data.complete
-    ? "Live"
-    : isPartial
-      ? "Partial"
-      : "Complete";
+  const traceState = !data.complete ? "Live" : isPartial ? "Partial" : "Complete";
   const traceStateColor = !data.complete
     ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300"
     : isPartial
       ? "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300"
       : "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300";
+  const expandableJobs = jobLanes.filter(
+    (lane) => (childrenByParent.get(lane.id)?.length ?? 0) > 0,
+  );
+  const allJobsExpanded =
+    expandableJobs.length > 0 && expandableJobs.every((lane) => expanded.has(lane.id));
 
   return (
     <section
@@ -219,19 +294,14 @@ export function BuildWaterfall({
             <h4 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
               Build #{buildNumber} timeline
             </h4>
-            <span
-              className={`rounded-full px-2 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.12em] ${traceStateColor}`}
-            >
+            <span className={`rounded-full px-2 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.12em] ${traceStateColor}`}>
               {traceState}
             </span>
-            {isValidating && (
-              <span className="text-[11px] text-zinc-400">Checking…</span>
-            )}
+            {isValidating && <span className="text-[11px] text-zinc-400">Checking…</span>}
           </div>
           <p className="mt-1 text-xs leading-5 text-zinc-500 dark:text-zinc-400">
-            Amber marks jobs most likely to determine when the build finished.
-            This is inferred from timing because Buildkite OTel does not include
-            dependency links.
+            Select a traced job to see its commands. Select a pytest command to
+            see every test. Amber jobs are inferred build-limiting work.
           </p>
         </div>
         <div className="flex flex-col items-start gap-3 lg:items-end">
@@ -241,75 +311,43 @@ export function BuildWaterfall({
             rel="noopener noreferrer"
             className="dashboard-control inline-flex min-h-9 items-center gap-1.5 rounded-md border border-zinc-300 bg-white px-3 text-xs font-semibold text-blue-600 hover:border-blue-300 hover:bg-blue-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-blue-400 dark:hover:border-blue-800 dark:hover:bg-blue-950/50"
           >
-            Open Buildkite #{buildNumber}
-            <span aria-hidden="true">↗</span>
+            Open Buildkite #{buildNumber}<span aria-hidden="true">↗</span>
           </a>
           <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-zinc-500 dark:text-zinc-400">
-            <span>
-              <strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">
-                {formatDuration(summary.observedDurationMs)}
-              </strong>{" "}
-              observed
-            </span>
-            <span>
-              <strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">
-                {summary.laneCount}
-                {coverageTotal !== null ? ` of ${coverageTotal}` : ""}
-              </strong>{" "}
-              jobs traced
-            </span>
-            <span>
-              <strong className="font-mono font-semibold text-amber-700 dark:text-amber-300">
-                {summary.criticalCount}
-              </strong>{" "}
-              build-limiting
-            </span>
-            <span>
-              <strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">
-                {summary.queueCount}
-              </strong>{" "}
-              queues
-            </span>
+            <span><strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">{formatDuration(summary.observedDurationMs)}</strong> observed</span>
+            <span><strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">{summary.laneCount}{coverageTotal !== null ? ` of ${coverageTotal}` : ""}</strong> jobs traced</span>
+            {summary.commandCount > 0 && <span><strong className="font-mono font-semibold text-cyan-700 dark:text-cyan-300">{summary.commandCount}</strong> commands</span>}
+            {summary.testCount > 0 && <span><strong className="font-mono font-semibold text-emerald-700 dark:text-emerald-300">{summary.testCount}</strong> tests</span>}
+            <span><strong className="font-mono font-semibold text-amber-700 dark:text-amber-300">{summary.criticalCount}</strong> build-limiting</span>
           </div>
         </div>
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-3">
-        <div className="flex items-center gap-4 text-[11px] text-zinc-500 dark:text-zinc-400">
-          <span className="inline-flex items-center gap-1.5">
-            <span className="h-2 w-4 rounded-sm bg-blue-500" /> run
-          </span>
-          <span className="inline-flex items-center gap-1.5">
-            <span className="h-2 w-4 rounded-sm bg-red-500" /> failed
-          </span>
-          <span className="inline-flex items-center gap-1.5">
-            <span className="h-2 w-4 rounded-sm border border-amber-500 bg-amber-300 dark:bg-amber-500" />
-            build-limiting
-          </span>
-          <span className="inline-flex items-center gap-1.5">
-            <span className="h-2 w-4 rounded-sm bg-zinc-300 dark:bg-zinc-700" /> queued
-          </span>
+        <div className="flex flex-wrap items-center gap-4 text-[11px] text-zinc-500 dark:text-zinc-400">
+          <span className="inline-flex items-center gap-1.5"><span className="h-2 w-4 rounded-sm bg-blue-500" /> job</span>
+          {summary.commandCount > 0 && <span className="inline-flex items-center gap-1.5"><span className="h-2 w-4 rounded-sm bg-cyan-500" /> command</span>}
+          {summary.testCount > 0 && <span className="inline-flex items-center gap-1.5"><span className="h-2 w-4 rounded-sm bg-emerald-500" /> test</span>}
+          <span className="inline-flex items-center gap-1.5"><span className="h-2 w-4 rounded-sm bg-red-500" /> failed</span>
+          <span className="inline-flex items-center gap-1.5"><span className="h-2 w-4 rounded-sm bg-zinc-300 dark:bg-zinc-700" /> queued / skipped</span>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          {expandableJobs.length > 0 && (
+            <button type="button" onClick={toggleAllJobs} className="dashboard-control min-h-9 rounded-md border border-cyan-300 bg-cyan-50 px-3 text-xs font-medium text-cyan-800 hover:bg-cyan-100 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-200 dark:hover:bg-cyan-950/70">
+              {allJobsExpanded ? "Collapse commands" : `Show commands (${summary.commandCount})`}
+            </button>
+          )}
           <button
             type="button"
             aria-pressed={criticalOnly}
             onClick={() => setCriticalOnly((value) => !value)}
-            className={`dashboard-control min-h-9 rounded-md border px-3 text-xs font-medium ${
-              criticalOnly
-                ? "border-amber-400 bg-amber-50 text-amber-800 dark:border-amber-600 dark:bg-amber-950/60 dark:text-amber-200"
-                : "border-zinc-300 bg-white text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:bg-zinc-900"
-            }`}
+            className={`dashboard-control min-h-9 rounded-md border px-3 text-xs font-medium ${criticalOnly ? "border-amber-400 bg-amber-50 text-amber-800 dark:border-amber-600 dark:bg-amber-950/60 dark:text-amber-200" : "border-zinc-300 bg-white text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:bg-zinc-900"}`}
           >
             {criticalOnly ? "Show all jobs" : "Show build-limiting jobs"}
           </button>
-          {!criticalOnly && orderedLanes.length > INITIAL_LANE_LIMIT && (
-            <button
-              type="button"
-              onClick={() => setShowAll((value) => !value)}
-              className="dashboard-control min-h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:bg-zinc-900"
-            >
-              {showAll ? "Show less" : `Show all ${orderedLanes.length}`}
+          {!criticalOnly && jobLanes.length > INITIAL_JOB_LIMIT && (
+            <button type="button" onClick={() => setShowAll((value) => !value)} className="dashboard-control min-h-9 rounded-md border border-zinc-300 bg-white px-3 text-xs font-medium text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-300 dark:hover:bg-zinc-900">
+              {showAll ? "Show less" : `Show all ${jobLanes.length} jobs`}
             </button>
           )}
         </div>
@@ -317,17 +355,11 @@ export function BuildWaterfall({
 
       <div className="overflow-x-auto pb-2">
         <div className="min-w-[760px] px-5">
-          <div className="grid grid-cols-[minmax(13rem,17rem)_minmax(32rem,1fr)] gap-4 border-b border-zinc-200 pb-2 dark:border-zinc-800">
-            <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-400">
-              Job / span
-            </div>
+          <div className="grid grid-cols-[minmax(16rem,21rem)_minmax(32rem,1fr)] gap-4 border-b border-zinc-200 pb-2 dark:border-zinc-800">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-400">Job / command / test</div>
             <div className="relative h-5 font-mono text-[10px] text-zinc-400">
               {TICKS.map((tick) => (
-                <span
-                  key={tick}
-                  className="absolute -translate-x-1/2 first:translate-x-0 last:-translate-x-full"
-                  style={{ left: `${tick * 100}%` }}
-                >
+                <span key={tick} className="absolute -translate-x-1/2 first:translate-x-0 last:-translate-x-full" style={{ left: `${tick * 100}%` }}>
                   {formatDuration(timelineDuration * tick)}
                 </span>
               ))}
@@ -339,97 +371,47 @@ export function BuildWaterfall({
               const start = Date.parse(lane.startTime);
               const end = Date.parse(lane.endTime);
               const queueStart = Math.max(timelineStart, start - lane.waitMs);
-              const queueLeft = clampPercent(
-                ((queueStart - timelineStart) / timelineDuration) * 100,
-              );
-              const queueWidth = clampPercent(
-                ((start - queueStart) / timelineDuration) * 100,
-              );
-              const runLeft = clampPercent(
-                ((start - timelineStart) / timelineDuration) * 100,
-              );
-              const runWidth = clampPercent(
-                ((end - start) / timelineDuration) * 100,
-              );
-              const runColor = lane.critical
-                ? "border border-amber-500 bg-amber-300 shadow-[0_0_0_1px_rgb(245_158_11_/_0.12)] dark:bg-amber-500"
-                : lane.status === "failed"
-                  ? "bg-red-500 dark:bg-red-500"
-                  : "bg-blue-500 dark:bg-blue-500";
-              const detail = `${lane.label} · ${formatTime(lane.startTime)}–${formatTime(lane.endTime)} · ${formatDuration(lane.durationMs)}${lane.queue ? ` · ${lane.queue}` : ""}`;
+              const queueLeft = clampPercent(((queueStart - timelineStart) / timelineDuration) * 100);
+              const queueWidth = clampPercent(((start - queueStart) / timelineDuration) * 100);
+              const runLeft = clampPercent(((start - timelineStart) / timelineDuration) * 100);
+              const runWidth = clampPercent(((end - start) / timelineDuration) * 100);
+              const children = childrenByParent.get(lane.id) ?? [];
+              const isExpandable = children.length > 0;
+              const depth = laneDepth(lane);
+              const detail = `${lane.label} · ${formatTime(lane.startTime)}–${formatTime(lane.endTime)} · ${formatDuration(lane.durationMs)}${lane.outcome ? ` · ${lane.outcome}` : ""}`;
+              const rowTone = depth === 0 ? "" : depth === 1 ? "bg-cyan-50/35 dark:bg-cyan-950/10" : "bg-emerald-50/30 dark:bg-emerald-950/10";
 
               return (
-                <div
-                  key={lane.id}
-                  className="grid min-h-11 grid-cols-[minmax(13rem,17rem)_minmax(32rem,1fr)] items-center gap-4 border-b border-zinc-200/70 last:border-0 dark:border-zinc-800/70"
-                >
-                  <div className="min-w-0 py-2">
-                    <div className="flex items-center gap-2">
-                      {lane.critical && (
-                        <span
-                          aria-label="Inferred build-limiting job"
-                          className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
-                        />
-                      )}
-                      <span
-                        className="truncate text-xs font-medium text-zinc-800 dark:text-zinc-200"
-                        title={lane.label}
-                      >
-                        {lane.label}
-                      </span>
-                      <span className="ml-auto shrink-0 font-mono text-[10px] text-zinc-400">
-                        {formatDuration(lane.durationMs)}
-                      </span>
+                <div key={lane.id} className={`grid min-h-10 grid-cols-[minmax(16rem,21rem)_minmax(32rem,1fr)] items-center gap-4 border-b border-zinc-200/70 last:border-0 dark:border-zinc-800/70 ${rowTone}`}>
+                  <div className="relative min-w-0 py-1.5" style={{ paddingLeft: `${depth * 18}px` }}>
+                    {depth > 0 && <span aria-hidden="true" className={`absolute inset-y-0 w-px ${depth === 1 ? "left-2 bg-cyan-200 dark:bg-cyan-900" : "left-6 bg-emerald-200 dark:bg-emerald-900"}`} />}
+                    <div className="flex items-center gap-1.5">
+                      {isExpandable ? (
+                        <button type="button" onClick={() => toggleExpanded(lane.id)} aria-expanded={expanded.has(lane.id)} aria-label={`${expanded.has(lane.id) ? "Collapse" : "Expand"} ${lane.label}`} className="dashboard-control flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-500 hover:bg-zinc-200/70 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-100">
+                          <span aria-hidden="true" className={`transition-transform ${expanded.has(lane.id) ? "rotate-90" : ""}`}>›</span>
+                        </button>
+                      ) : <span className="w-6 shrink-0" />}
+                      {lane.critical && <span aria-label="Inferred build-limiting job" className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" />}
+                      <span className={`truncate text-xs text-zinc-800 dark:text-zinc-200 ${depth === 0 ? "font-medium" : "font-mono text-[11px]"}`} title={lane.label}>{lane.label}</span>
+                      {isExpandable && <span className="shrink-0 rounded bg-zinc-200/70 px-1.5 py-0.5 font-mono text-[9px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">{children.length}</span>}
+                      <span className="ml-auto shrink-0 font-mono text-[10px] text-zinc-400">{formatDuration(lane.durationMs)}</span>
                     </div>
-                    <div className="mt-0.5 flex min-w-0 items-center gap-2 pl-3.5 font-mono text-[10px] text-zinc-400">
-                      <span className="truncate">
-                        {lane.queue ?? lane.group ?? lane.kind}
-                      </span>
-                      {lane.waitMs > 0 && (
-                        <span className="shrink-0">
-                          +{formatDuration(lane.waitMs)} wait
-                        </span>
-                      )}
-                    </div>
+                    {depth === 0 && (
+                      <div className="mt-0.5 flex min-w-0 items-center gap-2 pl-7 font-mono text-[10px] text-zinc-400">
+                        <span className="truncate">{lane.queue ?? lane.group ?? lane.kind}</span>
+                        {lane.waitMs > 0 && <span className="shrink-0">+{formatDuration(lane.waitMs)} wait</span>}
+                      </div>
+                    )}
                   </div>
                   <div className="relative h-7">
                     <GridLines />
-                    {queueWidth > 0.08 && (
-                      <span
-                        aria-hidden="true"
-                        className="absolute top-2 h-3 rounded-l-sm bg-zinc-300 dark:bg-zinc-700"
-                        style={{
-                          left: `${queueLeft}%`,
-                          width: `${Math.max(queueWidth, 0.2)}%`,
-                          backgroundImage:
-                            "repeating-linear-gradient(135deg, transparent, transparent 3px, rgb(255 255 255 / 0.35) 3px, rgb(255 255 255 / 0.35) 4px)",
-                        }}
-                      />
+                    {queueWidth > 0.08 && depth === 0 && (
+                      <span aria-hidden="true" className="absolute top-2 h-3 rounded-l-sm bg-zinc-300 dark:bg-zinc-700" style={{ left: `${queueLeft}%`, width: `${Math.max(queueWidth, 0.2)}%`, backgroundImage: "repeating-linear-gradient(135deg, transparent, transparent 3px, rgb(255 255 255 / 0.35) 3px, rgb(255 255 255 / 0.35) 4px)" }} />
                     )}
                     {lane.url ? (
-                      <a
-                        href={lane.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={detail}
-                        title={detail}
-                        className={`absolute top-1.5 h-4 min-w-1 rounded-sm transition-[filter] hover:brightness-110 ${runColor}`}
-                        style={{
-                          left: `${runLeft}%`,
-                          width: `${Math.max(runWidth, 0.25)}%`,
-                        }}
-                      />
+                      <a href={lane.url} target="_blank" rel="noopener noreferrer" aria-label={detail} title={detail} className={`absolute top-1.5 h-4 min-w-1 rounded-sm transition-[filter] hover:brightness-110 ${laneColor(lane)}`} style={{ left: `${runLeft}%`, width: `${Math.max(runWidth, 0.25)}%` }} />
                     ) : (
-                      <span
-                        role="img"
-                        aria-label={detail}
-                        title={detail}
-                        className={`absolute top-1.5 h-4 min-w-1 rounded-sm ${runColor}`}
-                        style={{
-                          left: `${runLeft}%`,
-                          width: `${Math.max(runWidth, 0.25)}%`,
-                        }}
-                      />
+                      <span role="img" aria-label={detail} title={detail} className={`absolute top-1.5 h-4 min-w-1 rounded-sm ${laneColor(lane)}`} style={{ left: `${runLeft}%`, width: `${Math.max(runWidth, 0.25)}%` }} />
                     )}
                   </div>
                 </div>
@@ -438,25 +420,16 @@ export function BuildWaterfall({
           </div>
 
           {hiddenCount > 0 && !criticalOnly && (
-            <button
-              type="button"
-              onClick={() => setShowAll(true)}
-              className="dashboard-control my-2 min-h-10 w-full rounded-md text-xs font-medium text-zinc-500 hover:bg-zinc-100 hover:text-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-800/60 dark:hover:text-zinc-200"
-            >
-              Show {hiddenCount} more spans
+            <button type="button" onClick={() => setShowAll(true)} className="dashboard-control my-2 min-h-10 w-full rounded-md text-xs font-medium text-zinc-500 hover:bg-zinc-100 hover:text-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-800/60 dark:hover:text-zinc-200">
+              Show {hiddenCount} more jobs
             </button>
           )}
         </div>
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-2 border-t border-zinc-200 px-5 py-2.5 font-mono text-[10px] text-zinc-400 dark:border-zinc-800">
-        <span>
-          {formatTime(summary.observedStart)} → {formatTime(summary.observedEnd)}
-        </span>
-        <span>
-          Last span received {formatTime(summary.latestReceivedAt)}
-          {data.truncated ? " · first 2,000 spans" : ""}
-        </span>
+        <span>{formatTime(summary.observedStart)} → {formatTime(summary.observedEnd)}</span>
+        <span>Last span received {formatTime(summary.latestReceivedAt)}{data.truncated ? " · first 5,000 spans" : ""}</span>
       </div>
     </section>
   );

--- a/src/lib/otel-auth.ts
+++ b/src/lib/otel-auth.ts
@@ -1,19 +1,147 @@
 import { timingSafeEqual } from "node:crypto";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import type { NormalizedOtlpSpan, OtlpAttributeValue } from "@/lib/otel-proto";
 
-export function isOtlpConfigured(): boolean {
-  return Boolean(process.env.OTEL_INGEST_TOKEN);
-}
+const BUILDKITE_ISSUER = "https://agent.buildkite.com";
+const BUILDKITE_JWKS = createRemoteJWKSet(
+  new URL("https://agent.buildkite.com/.well-known/jwks"),
+);
+const DEFAULT_OIDC_AUDIENCE = "https://ci.vllm.ai/api/otel";
+const DEFAULT_ORGANIZATION = "vllm";
+const DEFAULT_PIPELINE = "ci";
+const DEFAULT_BRANCH = "main";
 
-export function isOtlpAuthorized(headers: Headers): boolean {
+export type OtlpPrincipal =
+  | { kind: "shared-token" }
+  | {
+      kind: "buildkite-oidc";
+      organization: string;
+      pipeline: string;
+      buildNumber: number;
+      buildId: string;
+      jobId: string;
+      branch: string;
+    };
+
+function sharedTokenMatches(received: string): boolean {
   const expected = process.env.OTEL_INGEST_TOKEN;
-  const authorization = headers.get("authorization");
-  if (!expected || !authorization?.startsWith("Bearer ")) return false;
+  if (!expected) return false;
 
-  const received = authorization.slice("Bearer ".length);
   const expectedBytes = Buffer.from(expected);
   const receivedBytes = Buffer.from(received);
   return (
     expectedBytes.length === receivedBytes.length &&
     timingSafeEqual(expectedBytes, receivedBytes)
   );
+}
+
+function stringClaim(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Buildkite OIDC token is missing ${name}`);
+  }
+  return value;
+}
+
+function numberClaim(value: unknown, name: string): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`Buildkite OIDC token has invalid ${name}`);
+  }
+  return parsed;
+}
+
+export function isOtlpConfigured(): boolean {
+  return Boolean(process.env.OTEL_INGEST_TOKEN) ||
+    process.env.OTEL_BUILDKITE_OIDC_DISABLED !== "true";
+}
+
+export async function authorizeOtlpRequest(
+  headers: Headers,
+): Promise<OtlpPrincipal | null> {
+  const authorization = headers.get("authorization");
+  if (!authorization?.startsWith("Bearer ")) return null;
+
+  const received = authorization.slice("Bearer ".length);
+  if (sharedTokenMatches(received)) return { kind: "shared-token" };
+  if (process.env.OTEL_BUILDKITE_OIDC_DISABLED === "true") return null;
+
+  try {
+    const { payload } = await jwtVerify(received, BUILDKITE_JWKS, {
+      issuer: BUILDKITE_ISSUER,
+      audience:
+        process.env.OTEL_BUILDKITE_OIDC_AUDIENCE ?? DEFAULT_OIDC_AUDIENCE,
+      clockTolerance: 10,
+    });
+    const organization = stringClaim(
+      payload.organization_slug,
+      "organization_slug",
+    );
+    const pipeline = stringClaim(payload.pipeline_slug, "pipeline_slug");
+    const branch = stringClaim(payload.build_branch, "build_branch");
+    if (
+      organization !==
+        (process.env.OTEL_BUILDKITE_OIDC_ORGANIZATION ?? DEFAULT_ORGANIZATION) ||
+      pipeline !==
+        (process.env.OTEL_BUILDKITE_OIDC_PIPELINE ?? DEFAULT_PIPELINE) ||
+      branch !== (process.env.OTEL_BUILDKITE_OIDC_BRANCH ?? DEFAULT_BRANCH)
+    ) {
+      return null;
+    }
+
+    return {
+      kind: "buildkite-oidc",
+      organization,
+      pipeline,
+      branch,
+      buildNumber: numberClaim(payload.build_number, "build_number"),
+      buildId: stringClaim(payload.build_id, "build_id"),
+      jobId: stringClaim(payload.job_id, "job_id"),
+    };
+  } catch (error) {
+    console.warn("Buildkite OIDC verification failed:", error);
+    return null;
+  }
+}
+
+function primitiveAttribute(
+  attributes: Record<string, OtlpAttributeValue>,
+  key: string,
+): string | null {
+  const value = attributes[key];
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return String(value);
+  }
+  return null;
+}
+
+export function spansMatchPrincipal(
+  spans: NormalizedOtlpSpan[],
+  principal: OtlpPrincipal,
+): boolean {
+  if (principal.kind === "shared-token") return true;
+  if (spans.length === 0) return false;
+
+  return spans.every((span) => {
+    const attributes = {
+      ...span.resourceAttributes,
+      ...span.spanAttributes,
+    };
+    return (
+      primitiveAttribute(attributes, "buildkite.organization.slug") ===
+        principal.organization &&
+      primitiveAttribute(attributes, "buildkite.pipeline.slug") ===
+        principal.pipeline &&
+      primitiveAttribute(attributes, "buildkite.build.number") ===
+        String(principal.buildNumber) &&
+      primitiveAttribute(attributes, "buildkite.build.id") ===
+        principal.buildId &&
+      primitiveAttribute(attributes, "buildkite.job.id") === principal.jobId &&
+      primitiveAttribute(attributes, "buildkite.build.branch") ===
+        principal.branch
+    );
+  });
 }


### PR DESCRIPTION
## What changed

- Accept short-lived Buildkite OIDC tokens for job-emitted OTLP spans while retaining the shared token used by the Buildkite notification service.
- Verify organization, pipeline, branch, build, and job identity against every uploaded span.
- Associate command and pytest test spans with their Buildkite job in the trace API.
- Add expandable job → command → test rows to the existing build timeline, with counts, durations, outcomes, and a shared time axis.
- Document the OIDC upload path and the initial trusted-main pilot.

## Why

Buildkite's control-plane spans stop at the job boundary. The dashboard needs a secure ingestion path and nested UI to show how long each generated CI command and each pytest test takes without adding another dashboard.

## Validation

- `npx tsc --noEmit`
- focused ESLint on all changed TypeScript/TSX files
- `npm run build`
- local browser verification against current trace data
- cross-language OTLP payload decode check with the vLLM exporter