### PR TITLE
Unify live waiting job count

### DIFF
--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -5,7 +5,7 @@ import useSWR from "swr";
 import { StatCard } from "@/components/stat-card";
 import { SearchableSelect } from "@/components/searchable-select";
 import { QueueOverviewChart } from "@/components/queue-overview-chart";
-import { QueueWaitingJobs } from "@/components/queue-waiting-jobs";
+import { QueueWaitingJobs, useQueueWaitingJobs } from "@/components/queue-waiting-jobs";
 import { effectiveWaiting } from "@/lib/queue-plugins";
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -104,6 +104,7 @@ export default function QueuePage() {
     refreshInterval: 60 * 1000,
     keepPreviousData: true,
   });
+  const queueJobsQuery = useQueueWaitingJobs(queue);
 
   const historyMatchesQueue = metricsData?.query.queue === (queue || null);
   const historyMatchesSelection =
@@ -183,8 +184,15 @@ export default function QueuePage() {
   const totalAgents = filtered.reduce((s, q) => s + q.agents_total, 0);
   const busyAgents = filtered.reduce((s, q) => s + q.agents_busy, 0);
   const idleAgents = filtered.reduce((s, q) => s + q.agents_idle, 0);
-  const waitingJobs = filtered.reduce((s, q) => s + effectiveWaiting(q.queue, q.jobs_scheduled, q.jobs_waiting), 0);
   const runningJobs = filtered.reduce((s, q) => s + q.jobs_running, 0);
+  const liveWaitingJobs = queueJobsQuery.data?.jobs.length;
+  const liveWaitingJobsDetail = !queue
+    ? "Select a queue"
+    : queueJobsQuery.error
+      ? "Live count unavailable"
+      : liveWaitingJobs === undefined
+        ? "Loading live queue"
+        : "Live command jobs";
 
   return (
     <div className="space-y-6">
@@ -225,8 +233,9 @@ export default function QueuePage() {
         />
         <StatCard
           label="Waiting Jobs"
-          value={waitingJobs}
-          color={waitingJobs > 0 ? "yellow" : "default"}
+          value={liveWaitingJobs ?? "—"}
+          detail={liveWaitingJobsDetail}
+          color={liveWaitingJobs && liveWaitingJobs > 0 ? "yellow" : "default"}
         />
         <StatCard
           label="Running Jobs"
@@ -314,7 +323,7 @@ export default function QueuePage() {
         </div>
       </div>
 
-      {queue && <QueueWaitingJobs queue={queue} />}
+      {queue && <QueueWaitingJobs queue={queue} query={queueJobsQuery} />}
 
       {/* Queue Summary Table */}
       <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">

--- a/src/components/queue-waiting-jobs.tsx
+++ b/src/components/queue-waiting-jobs.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import useSWR from "swr";
 
-interface QueueJob {
+export interface QueueJob {
   uuid: string;
   label: string | null;
   url: string;
@@ -11,7 +11,7 @@ interface QueueJob {
   priority: number;
 }
 
-interface QueueJobsResponse {
+export interface QueueJobsResponse {
   jobs: QueueJob[];
   operatorAccessRequired: boolean;
 }
@@ -39,18 +39,27 @@ function formatScheduledAt(value: string): string {
   });
 }
 
-export function QueueWaitingJobs({ queue }: { queue: string }) {
+export function useQueueWaitingJobs(queue: string) {
+  const url = queue ? `/api/queue/jobs?queue=${encodeURIComponent(queue)}` : null;
+  return useSWR<QueueJobsResponse>(url, fetchJson, {
+    refreshInterval: 30_000,
+    keepPreviousData: true,
+  });
+}
+
+export function QueueWaitingJobs({
+  queue,
+  query,
+}: {
+  queue: string;
+  query: ReturnType<typeof useQueueWaitingJobs>;
+}) {
   const [operatorToken, setOperatorToken] = useState("");
   const [showAccess, setShowAccess] = useState(false);
   const [pendingJobUuid, setPendingJobUuid] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
-  const url = queue ? `/api/queue/jobs?queue=${encodeURIComponent(queue)}` : null;
-  const { data, error, isLoading, isValidating, mutate } = useSWR<QueueJobsResponse>(
-    url,
-    fetchJson,
-    { refreshInterval: 30_000, keepPreviousData: true },
-  );
+  const { data, error, isLoading, isValidating, mutate } = query;
 
   async function promote(job: QueueJob) {
     if (!operatorToken) {

--- a/src/lib/buildkite-queue-jobs.ts
+++ b/src/lib/buildkite-queue-jobs.ts
@@ -33,6 +33,32 @@ interface GraphQLResponse {
   errors?: Array<{ message: string }>;
 }
 
+interface ClusterQueuesGraphQLResponse {
+  data?: {
+    organization?: {
+      clusters: {
+        pageInfo: {
+          hasNextPage: boolean;
+          endCursor: string | null;
+        };
+        edges: Array<{
+          node: {
+            queues: {
+              edges: Array<{
+                node: {
+                  id: string;
+                  key: string;
+                };
+              }>;
+            };
+          };
+        }>;
+      };
+    } | null;
+  };
+  errors?: Array<{ message: string }>;
+}
+
 export class BuildkiteQueueError extends Error {
   constructor(
     message: string,
@@ -66,8 +92,104 @@ function queueRule(queue: string): string {
   return `queue=${queue}`;
 }
 
+function requestError(response: Response, errors?: Array<{ message: string }>): BuildkiteQueueError {
+  const detail = errors?.map((error) => error.message).join(" ");
+  const message =
+    response.status === 401
+      ? "The configured Buildkite API token is no longer valid."
+      : response.status === 403 || response.status === 404
+        ? "The Buildkite token needs GraphQL API access and read access to this organization."
+        : detail || "Buildkite could not load the queue jobs.";
+  return new BuildkiteQueueError(
+    message,
+    response.status >= 500 ? 502 : response.status || 502,
+    "BUILDKITE_REQUEST_FAILED",
+  );
+}
+
+async function getClusterQueueId(queue: string): Promise<string | null> {
+  const token = getToken();
+  let after: string | null = null;
+
+  do {
+    const response = await fetch(GRAPHQL_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: `
+          query ClusterQueues($organization: ID!, $first: Int!, $after: String) {
+            organization(slug: $organization) {
+              clusters(first: $first, after: $after) {
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+                edges {
+                  node {
+                    queues(first: $first) {
+                      edges {
+                        node {
+                          id
+                          key
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `,
+        variables: {
+          organization: organization(),
+          first: JOBS_PAGE_SIZE,
+          after,
+        },
+      }),
+      cache: "no-store",
+    });
+
+    let result: ClusterQueuesGraphQLResponse;
+    try {
+      result = (await response.json()) as ClusterQueuesGraphQLResponse;
+    } catch {
+      throw new BuildkiteQueueError(
+        "Buildkite returned an invalid cluster-queues response.",
+        502,
+        "BUILDKITE_INVALID_RESPONSE",
+      );
+    }
+
+    if (!response.ok || result.errors?.length) throw requestError(response, result.errors);
+
+    const clusters = result.data?.organization?.clusters;
+    if (!clusters) {
+      throw new BuildkiteQueueError(
+        "Buildkite did not return clusters for the configured organization.",
+        502,
+        "BUILDKITE_INVALID_RESPONSE",
+      );
+    }
+
+    for (const { node: cluster } of clusters.edges) {
+      const clusterQueue = cluster.queues.edges.find(({ node }) => node.key === queue)?.node;
+      if (clusterQueue) return clusterQueue.id;
+    }
+
+    after = clusters.pageInfo.hasNextPage ? clusters.pageInfo.endCursor : null;
+  } while (after);
+
+  return null;
+}
+
 async function graphqlQueueJobs(queue: string): Promise<QueueJob[]> {
   const token = getToken();
+  const agentQueryRule = queueRule(queue);
+  const clusterQueueId = await getClusterQueueId(queue);
   const jobs: QueueJob[] = [];
   let after: string | null = null;
 
@@ -81,14 +203,15 @@ async function graphqlQueueJobs(queue: string): Promise<QueueJob[]> {
       },
       body: JSON.stringify({
         query: `
-          query QueueJobs($organization: ID!, $agentQueryRules: [String!], $first: Int!, $after: String) {
+          query QueueJobs($organization: ID!, $agentQueryRules: [String!], $clusterQueue: [ID!], $first: Int!, $after: String) {
             organization(slug: $organization) {
               jobs(
                 first: $first
                 after: $after
-                type: COMMAND
-                state: SCHEDULED
+                type: [COMMAND]
+                state: [SCHEDULED]
                 agentQueryRules: $agentQueryRules
+                clusterQueue: $clusterQueue
               ) {
                 pageInfo {
                   hasNextPage
@@ -111,7 +234,8 @@ async function graphqlQueueJobs(queue: string): Promise<QueueJob[]> {
         `,
         variables: {
           organization: organization(),
-          agentQueryRules: [queueRule(queue)],
+          agentQueryRules: clusterQueueId ? null : [agentQueryRule],
+          clusterQueue: clusterQueueId ? [clusterQueueId] : null,
           first: JOBS_PAGE_SIZE,
           after,
         },
@@ -130,20 +254,7 @@ async function graphqlQueueJobs(queue: string): Promise<QueueJob[]> {
       );
     }
 
-    if (!response.ok || result.errors?.length) {
-      const detail = result.errors?.map((error) => error.message).join(" ");
-      const message =
-        response.status === 401
-          ? "The configured Buildkite API token is no longer valid."
-          : response.status === 403 || response.status === 404
-            ? "The Buildkite token needs GraphQL API access and read access to this organization."
-            : detail || "Buildkite could not load the queue jobs.";
-      throw new BuildkiteQueueError(
-        message,
-        response.status >= 500 ? 502 : response.status || 502,
-        "BUILDKITE_REQUEST_FAILED",
-      );
-    }
+    if (!response.ok || result.errors?.length) throw requestError(response, result.errors);
 
     const connection = result.data?.organization?.jobs;
     if (!connection) {


### PR DESCRIPTION
## Summary
- resolve selected modern Buildkite cluster queues to their GraphQL IDs
- query scheduled command jobs with `clusterQueue`, retaining the legacy agent-rule fallback
- make the Waiting Jobs card and list consume the same live result

## Why
The previous query used only the legacy `queue=<key>` agent rule. That returns zero for modern cluster queues even when Buildkite reports queued work. For `mithril-h100-pool`, Buildkite's cluster-queue metrics endpoint reported 114 waiting jobs at 2026-08-14T21:36:00Z.

## Validation
- `npx eslint src/lib/buildkite-queue-jobs.ts`
- `npx tsc --noEmit`
- `npm run build -- --webpack`
- DCO and Vercel preview checks passed

The preview endpoint is protected by Vercel SSO, so its API cannot be called anonymously from this machine.