### PR TITLE
Report reserved Buildkite queue jobs

### DIFF
--- a/src/app/api/queue/jobs/route.ts
+++ b/src/app/api/queue/jobs/route.ts
@@ -22,9 +22,13 @@ export async function GET(request: NextRequest) {
   const queue = request.nextUrl.searchParams.get("queue") ?? "";
 
   try {
-    const jobs = await getQueueJobs(queue);
+    const { jobs, waitingCount } = await getQueueJobs(queue);
     return NextResponse.json(
-      { jobs, operatorAccessRequired: Boolean(process.env.BUILDKITE_QUEUE_OPERATOR_TOKEN) },
+      {
+        jobs,
+        waitingCount,
+        operatorAccessRequired: Boolean(process.env.BUILDKITE_QUEUE_OPERATOR_TOKEN),
+      },
       { headers: { "Cache-Control": "no-store" } },
     );
   } catch (error) {

--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -185,14 +185,18 @@ export default function QueuePage() {
   const busyAgents = filtered.reduce((s, q) => s + q.agents_busy, 0);
   const idleAgents = filtered.reduce((s, q) => s + q.agents_idle, 0);
   const runningJobs = filtered.reduce((s, q) => s + q.jobs_running, 0);
-  const liveWaitingJobs = queueJobsQuery.data?.jobs.length;
+  const liveWaitingJobs = queueJobsQuery.data
+    ? (queueJobsQuery.data.waitingCount ?? queueJobsQuery.data.jobs.length)
+    : undefined;
   const liveWaitingJobsDetail = !queue
     ? "Select a queue"
     : queueJobsQuery.error
       ? "Live count unavailable"
       : liveWaitingJobs === undefined
         ? "Loading live queue"
-        : "Live command jobs";
+        : queueJobsQuery.data?.waitingCount != null
+          ? "Buildkite queue metric"
+          : "Live command jobs";
 
   return (
     <div className="space-y-6">

--- a/src/components/queue-waiting-jobs.tsx
+++ b/src/components/queue-waiting-jobs.tsx
@@ -13,6 +13,7 @@ export interface QueueJob {
 
 export interface QueueJobsResponse {
   jobs: QueueJob[];
+  waitingCount: number | null;
   operatorAccessRequired: boolean;
 }
 
@@ -101,6 +102,8 @@ export function QueueWaitingJobs({
 
   const canPromote = Boolean(data?.operatorAccessRequired && operatorToken);
   const showTable = Boolean(data && (data.jobs.length > 0 || isValidating || error));
+  const reportedWaitingCount = data?.waitingCount ?? data?.jobs.length;
+  const hasReservedJobs = Boolean(data && data.waitingCount !== null && data.waitingCount > data.jobs.length);
 
   return (
     <section className="overflow-hidden rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
@@ -111,7 +114,7 @@ export function QueueWaitingJobs({
               <h2 className="text-base font-semibold tracking-tight">Waiting jobs</h2>
               {data && (
                 <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold tabular-nums text-amber-800 dark:bg-amber-950/60 dark:text-amber-300">
-                  {data.jobs.length}
+                  {reportedWaitingCount}
                 </span>
               )}
             </div>
@@ -144,7 +147,7 @@ export function QueueWaitingJobs({
           </div>
         </div>
 
-        {data?.operatorAccessRequired ? (
+        {data?.operatorAccessRequired && data.jobs.length > 0 ? (
           <div className="mt-4 border-t border-zinc-100 pt-3 dark:border-zinc-800/80">
             <button
               type="button"
@@ -167,7 +170,7 @@ export function QueueWaitingJobs({
               </label>
             )}
           </div>
-        ) : data ? (
+        ) : data && !hasReservedJobs ? (
           <p className="mt-3 text-xs text-amber-700 dark:text-amber-300">
             Promotion is disabled until BUILDKITE_QUEUE_OPERATOR_TOKEN is configured on the dashboard.
           </p>
@@ -201,7 +204,9 @@ export function QueueWaitingJobs({
 
       {data && data.jobs.length === 0 && !isValidating && !error && (
         <div className="flex min-h-36 items-center justify-center px-5 text-center text-sm text-zinc-500 dark:text-zinc-400">
-          No command jobs are waiting in {queue}.
+          {hasReservedJobs
+            ? `Buildkite reports ${reportedWaitingCount} waiting jobs in ${queue}, but its Agent Stack has reserved them. The public API does not expose their individual details or priority.`
+            : `No command jobs are waiting in ${queue}.`}
         </div>
       )}
 

--- a/src/lib/buildkite-queue-jobs.ts
+++ b/src/lib/buildkite-queue-jobs.ts
@@ -81,6 +81,22 @@ interface ClusterQueuePageGraphQLResponse {
   errors?: Array<{ message: string }>;
 }
 
+interface ClusterQueueMetricGraphQLResponse {
+  data?: {
+    node?: {
+      metrics?: {
+        waitingJobsCount?: number;
+      } | null;
+    } | null;
+  };
+  errors?: Array<{ message: string }>;
+}
+
+export interface QueueJobsResult {
+  jobs: QueueJob[];
+  waitingCount: number | null;
+}
+
 export class BuildkiteQueueError extends Error {
   constructor(
     message: string,
@@ -290,6 +306,50 @@ async function getClusterQueue(queue: string): Promise<ClusterQueueTarget | null
   return null;
 }
 
+async function getClusterQueueWaitingCount(queue: string): Promise<number | null> {
+  const token = getToken();
+  const clusterQueue = await getClusterQueue(queue);
+  if (!clusterQueue) return null;
+
+  const response = await fetch(GRAPHQL_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: `
+        query ClusterQueueMetric($queue: ID!) {
+          node(id: $queue) {
+            ... on ClusterQueue {
+              metrics {
+                waitingJobsCount
+              }
+            }
+          }
+        }
+      `,
+      variables: { queue: clusterQueue.queueId },
+    }),
+    cache: "no-store",
+  });
+
+  let result: ClusterQueueMetricGraphQLResponse;
+  try {
+    result = (await response.json()) as ClusterQueueMetricGraphQLResponse;
+  } catch {
+    throw new BuildkiteQueueError(
+      "Buildkite returned an invalid cluster-queue metric response.",
+      502,
+      "BUILDKITE_INVALID_RESPONSE",
+    );
+  }
+
+  if (!response.ok || result.errors?.length) throw requestError(response, result.errors);
+  return result.data?.node?.metrics?.waitingJobsCount ?? null;
+}
+
 async function graphqlQueueJobs(queue: string): Promise<QueueJob[]> {
   const token = getToken();
   const agentQueryRule = queueRule(queue);
@@ -393,8 +453,12 @@ async function graphqlQueueJobs(queue: string): Promise<QueueJob[]> {
   });
 }
 
-export async function getQueueJobs(queue: string): Promise<QueueJob[]> {
-  return graphqlQueueJobs(queue);
+export async function getQueueJobs(queue: string): Promise<QueueJobsResult> {
+  const [jobs, waitingCount] = await Promise.all([
+    graphqlQueueJobs(queue),
+    getClusterQueueWaitingCount(queue),
+  ]);
+  return { jobs, waitingCount };
 }
 
 export async function reprioritizeQueueJob(queue: string, jobUuid: string): Promise<{ priority: number }> {


### PR DESCRIPTION
## Summary
- use the selected ClusterQueue's live `waitingJobsCount` metric for the Waiting Jobs card and list badge
- explain when the Agent Stack has reserved those jobs and Buildkite no longer exposes their individual details or priority
- avoid offering promotion controls for non-enumerable reserved jobs

## Why
For `mithril-h100-pool`, Buildkite reports 99 waiting jobs in its ClusterQueue metric, while both the GraphQL job query and Agent Stack scheduled-jobs endpoint return no rows because the controller already reserved them. Reporting zero was inaccurate.

## Validation
- `npx eslint src/lib/buildkite-queue-jobs.ts src/app/api/queue/jobs/route.ts src/components/queue-waiting-jobs.tsx src/app/queue/page.tsx`
- `npx tsc --noEmit`
- `npm run build -- --webpack`