### PR TITLE
Accept scoped Buildkite OIDC for OTLP ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Open http://localhost:3000.
 | `BUILDKITE_API_TOKEN` | Buildkite personal API token; needs `read_suites` for Test Engine, GraphQL API access and `write_builds` for queue promotion, and notification-service scopes only when running the OTel setup script |
 | `BUILDKITE_ORGANIZATION`, `BUILDKITE_TEST_SUITE` | Test Engine organization and suite slug (defaults: `vllm`, `ci-1`) |
 | `BUILDKITE_QUEUE_OPERATOR_TOKEN` | Required to enable queue-job promotion; authorized operators enter it for the current browser tab |
-| `OTEL_INGEST_TOKEN` | Required Bearer token for the OTLP/HTTP trace receiver |
+| `OTEL_INGEST_TOKEN` | Bearer token used by Buildkite's native OTel notification service; the receiver also accepts scoped Buildkite OIDC tokens |
 | `OTEL_MAX_REQUEST_BYTES` | Optional OTLP request limit; defaults to 4 MiB |
 | `OTEL_ENDPOINT` | Buildkite notification-service base URL; defaults operationally to `https://ci.vllm.ai/api/otel` |
 | `SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID` | Slack bot for queue-depth alerts (`chat:write`, `reactions:write`) |
@@ -95,8 +95,13 @@ job history without introducing another dashboard.
    ```
 
 The Vercel receiver accepts OTLP/HTTP protobuf with optional gzip compression;
-it is not a gRPC collector. To add agent-side checkout, hook, plugin, command,
-and artifact spans, Buildkite agent v3.101 or newer can be configured with:
+it is not a gRPC collector. It accepts the static ingest token above and
+short-lived Buildkite OIDC tokens for the `vllm/ci` pipeline. OIDC uploads are
+restricted to `main` builds or API-triggered `khluu/otel` treatment builds, so
+pull-request jobs cannot mint credentials accepted by the receiver.
+
+To add agent-side checkout, hook, plugin, command, and artifact spans,
+Buildkite agent v3.101 or newer can be configured with:
 
 ```bash
 BUILDKITE_TRACING_BACKEND=opentelemetry

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
+        "jose": "^6.2.9",
         "js-yaml": "^4.1.1",
         "next": "16.1.7",
         "plotly.js-basic-dist-min": "^3.4.0",
@@ -6503,6 +6504,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
+    "jose": "^6.2.9",
     "js-yaml": "^4.1.1",
     "next": "16.1.7",
     "plotly.js-basic-dist-min": "^3.4.0",

--- a/src/app/api/otel/health/route.ts
+++ b/src/app/api/otel/health/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
       { status: 503 },
     );
   }
-  if (!isOtlpAuthorized(request.headers)) {
+  if (!(await isOtlpAuthorized(request.headers))) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/src/app/api/otel/v1/traces/route.ts
+++ b/src/app/api/otel/v1/traces/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest) {
       { status: 503 },
     );
   }
-  if (!isOtlpAuthorized(request.headers)) {
+  if (!(await isOtlpAuthorized(request.headers))) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/src/lib/otel-auth.ts
+++ b/src/lib/otel-auth.ts
@@ -1,19 +1,67 @@
 import { timingSafeEqual } from "node:crypto";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const BUILDKITE_ISSUER = "https://agent.buildkite.com";
+const BUILDKITE_JWKS = createRemoteJWKSet(
+  new URL(`${BUILDKITE_ISSUER}/.well-known/jwks`),
+  {
+    timeoutDuration: 1_500,
+    cooldownDuration: 30_000,
+    cacheMaxAge: 10 * 60_000,
+  },
+);
+const BUILDKITE_AUDIENCE = "https://ci.vllm.ai/api/otel";
+const BUILDKITE_ORGANIZATION = "vllm";
+const BUILDKITE_PIPELINE = "ci";
+const BUILDKITE_TREATMENT_BRANCH = "khluu/otel";
+const JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 export function isOtlpConfigured(): boolean {
-  return Boolean(process.env.OTEL_INGEST_TOKEN);
+  return true;
 }
 
-export function isOtlpAuthorized(headers: Headers): boolean {
+function isStaticTokenAuthorized(token: string): boolean {
   const expected = process.env.OTEL_INGEST_TOKEN;
-  const authorization = headers.get("authorization");
-  if (!expected || !authorization?.startsWith("Bearer ")) return false;
+  if (!expected) return false;
 
-  const received = authorization.slice("Bearer ".length);
   const expectedBytes = Buffer.from(expected);
-  const receivedBytes = Buffer.from(received);
+  const receivedBytes = Buffer.from(token);
   return (
     expectedBytes.length === receivedBytes.length &&
     timingSafeEqual(expectedBytes, receivedBytes)
   );
+}
+
+async function isBuildkiteTokenAuthorized(token: string): Promise<boolean> {
+  try {
+    const { payload } = await jwtVerify(token, BUILDKITE_JWKS, {
+      issuer: BUILDKITE_ISSUER,
+      audience: BUILDKITE_AUDIENCE,
+      algorithms: ["RS256"],
+      maxTokenAge: "6m",
+      clockTolerance: 5,
+    });
+    const trustedBranch = payload.build_branch === "main";
+    const trustedTreatment =
+      payload.build_source === "api" &&
+      payload.build_branch === BUILDKITE_TREATMENT_BRANCH;
+    return (
+      payload.organization_slug === BUILDKITE_ORGANIZATION &&
+      payload.pipeline_slug === BUILDKITE_PIPELINE &&
+      typeof payload.job_id === "string" &&
+      JOB_ID.test(payload.job_id) &&
+      (trustedBranch || trustedTreatment)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function isOtlpAuthorized(headers: Headers): Promise<boolean> {
+  const authorization = headers.get("authorization");
+  if (!authorization?.startsWith("Bearer ")) return false;
+
+  const token = authorization.slice("Bearer ".length);
+  if (isStaticTokenAuthorized(token)) return true;
+  return isBuildkiteTokenAuthorized(token);
 }


### PR DESCRIPTION
## Summary
- keep static bearer auth for Buildkite native OTel notifications
- accept short-lived Buildkite OIDC tokens using the official issuer and JWKS
- scope OIDC uploads to the vllm/ci pipeline on main or API-triggered khluu/otel treatment builds
- reject ordinary pull-request/webhook builds

## Validation
- npx eslint src/lib/otel-auth.ts src/app/api/otel/v1/traces/route.ts src/app/api/otel/health/route.ts
- npm run build
- git diff --check