### PR TITLE
Allow scoped OTel treatment builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Open http://localhost:3000.
 | `OTEL_INGEST_TOKEN` | Shared Bearer token used by Buildkite's OTel notification service |
 | `OTEL_MAX_REQUEST_BYTES` | Optional OTLP request limit; defaults to 4 MiB |
 | `OTEL_ENDPOINT` | Buildkite notification-service base URL; defaults operationally to `https://ci.vllm.ai/api/otel` |
-| `OTEL_BUILDKITE_OIDC_AUDIENCE`, `OTEL_BUILDKITE_OIDC_ORGANIZATION`, `OTEL_BUILDKITE_OIDC_PIPELINE`, `OTEL_BUILDKITE_OIDC_BRANCH` | Optional restrictions for short-lived Buildkite job tokens; defaults to the production vLLM main pipeline |
+| `OTEL_BUILDKITE_OIDC_AUDIENCE`, `OTEL_BUILDKITE_OIDC_ORGANIZATION`, `OTEL_BUILDKITE_OIDC_PIPELINE`, `OTEL_BUILDKITE_OIDC_BRANCH`, `OTEL_BUILDKITE_OIDC_TREATMENT_BRANCH` | Optional restrictions for short-lived Buildkite job tokens; defaults to the production vLLM main pipeline plus API-triggered `khluu/otel` treatment builds |
 | `SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID` | Slack bot for queue-depth alerts (`chat:write`, `reactions:write`) |
 | `CRON_SECRET` | Optional shared secret required by Vercel cron handlers |
 
@@ -106,8 +106,9 @@ Detailed job timing does not distribute `OTEL_INGEST_TOKEN` to test code. An
 opted-in trusted main-branch job requests a five-minute Buildkite OIDC token for
 the dashboard audience when it uploads a batch. The receiver verifies the
 Buildkite signature and requires the token's organization, pipeline, branch,
-build, and job identity to match every span. Pull-request jobs and AMD mirrors
-are excluded from the initial pilot.
+build, and job identity to match every span. The receiver accepts normal
+`main` jobs and API-triggered `khluu/otel` treatment jobs; pull-request jobs and
+AMD mirrors are excluded from the initial pilot.
 
 The vLLM CI helper creates a span for each generated YAML command. When the
 command invokes pytest, its lightweight pytest plugin sends one child span per

--- a/src/lib/otel-auth.ts
+++ b/src/lib/otel-auth.ts
@@ -10,6 +10,7 @@ const DEFAULT_OIDC_AUDIENCE = "https://ci.vllm.ai/api/otel";
 const DEFAULT_ORGANIZATION = "vllm";
 const DEFAULT_PIPELINE = "ci";
 const DEFAULT_BRANCH = "main";
+const DEFAULT_TREATMENT_BRANCH = "khluu/otel";
 
 export type OtlpPrincipal =
   | { kind: "shared-token" }
@@ -78,12 +79,20 @@ export async function authorizeOtlpRequest(
     );
     const pipeline = stringClaim(payload.pipeline_slug, "pipeline_slug");
     const branch = stringClaim(payload.build_branch, "build_branch");
+    const expectedBranch =
+      process.env.OTEL_BUILDKITE_OIDC_BRANCH ?? DEFAULT_BRANCH;
+    const treatmentBranch =
+      process.env.OTEL_BUILDKITE_OIDC_TREATMENT_BRANCH ??
+      DEFAULT_TREATMENT_BRANCH;
+    const trustedBranch = branch === expectedBranch;
+    const trustedTreatment =
+      branch === treatmentBranch && payload.build_source === "api";
     if (
       organization !==
         (process.env.OTEL_BUILDKITE_OIDC_ORGANIZATION ?? DEFAULT_ORGANIZATION) ||
       pipeline !==
         (process.env.OTEL_BUILDKITE_OIDC_PIPELINE ?? DEFAULT_PIPELINE) ||
-      branch !== (process.env.OTEL_BUILDKITE_OIDC_BRANCH ?? DEFAULT_BRANCH)
+      (!trustedBranch && !trustedTreatment)
     ) {
       return null;
     }


### PR DESCRIPTION
## Summary
- preserve the existing build/job-bound Buildkite OIDC receiver
- continue accepting normal vllm/ci main jobs
- additionally accept only API-triggered khluu/otel treatment builds
- continue rejecting ordinary pull-request/webhook branches

## Validation
- npx eslint src/lib/otel-auth.ts
- npm run build
- git diff --check