### PR TITLE
Use Buildkite OIDC claims that are actually issued

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ Detailed job timing does not distribute `OTEL_INGEST_TOKEN` to test code. An
 opted-in trusted main-branch job requests a five-minute Buildkite OIDC token for
 the dashboard audience when it uploads a batch. The receiver verifies the
 Buildkite signature and requires the token's organization, pipeline, branch,
-build, and job identity to match every span. The receiver accepts normal
-`main` jobs and API-triggered `khluu/otel` treatment jobs; pull-request jobs and
-AMD mirrors are excluded from the initial pilot.
+build number, and globally unique job ID to match every span. The receiver
+accepts normal `main` jobs and API-triggered `khluu/otel` treatment jobs;
+pull-request jobs and AMD mirrors are excluded from the initial pilot.
 
 The vLLM CI helper creates a span for each generated YAML command. When the
 command invokes pytest, its lightweight pytest plugin sends one child span per

--- a/src/lib/otel-auth.ts
+++ b/src/lib/otel-auth.ts
@@ -19,7 +19,6 @@ export type OtlpPrincipal =
       organization: string;
       pipeline: string;
       buildNumber: number;
-      buildId: string;
       jobId: string;
       branch: string;
     };
@@ -103,7 +102,6 @@ export async function authorizeOtlpRequest(
       pipeline,
       branch,
       buildNumber: numberClaim(payload.build_number, "build_number"),
-      buildId: stringClaim(payload.build_id, "build_id"),
       jobId: stringClaim(payload.job_id, "job_id"),
     };
   } catch (error) {
@@ -146,8 +144,6 @@ export function spansMatchPrincipal(
         principal.pipeline &&
       primitiveAttribute(attributes, "buildkite.build.number") ===
         String(principal.buildNumber) &&
-      primitiveAttribute(attributes, "buildkite.build.id") ===
-        principal.buildId &&
       primitiveAttribute(attributes, "buildkite.job.id") === principal.jobId &&
       primitiveAttribute(attributes, "buildkite.build.branch") ===
         principal.branch


### PR DESCRIPTION
## Summary
- stop requiring a build_id claim that Buildkite job OIDC tokens do not issue
- retain identity binding through organization, pipeline, branch, build number, and globally unique job ID
- continue requiring every uploaded span to match the verified token identity

## Production evidence
Buildkite treatment #84268 minted a correctly scoped token, but Vercel logged: `Buildkite OIDC token is missing build_id`.

## Validation
- npx eslint src/lib/otel-auth.ts
- npm run build
- git diff --check