### PR TITLE
Load complete job traces on demand

### DIFF
--- a/src/app/api/builds/trace/route.ts
+++ b/src/app/api/builds/trace/route.ts
@@ -3,9 +3,11 @@ import { getDb } from "@/lib/db";
 
 export const runtime = "nodejs";
 
-const MAX_SPANS = 5_000;
+const MAX_BUILD_SPANS = 5_000;
+const JOB_DETAIL_PAGE_SIZE = 2_000;
 const COMPLETION_CLOCK_SKEW_MS = 30_000;
 const SLUG = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,99}$/;
+const JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 type TraceRow = {
   trace_id: string;
@@ -56,6 +58,12 @@ type Lane = {
   outcome: string | null;
   url: string | null;
   critical: boolean;
+  childCount: number;
+};
+
+type DetailCountRow = {
+  parent_span_id: string;
+  child_count: number;
 };
 
 function laneStatus(row: TraceRow): Lane["status"] {
@@ -126,6 +134,7 @@ function jobLane(row: TraceRow, id = row.span_id): Lane {
     outcome: row.job_state ?? row.step_outcome,
     url: row.job_url ?? row.step_url,
     critical: false,
+    childCount: 0,
   };
 }
 
@@ -145,6 +154,8 @@ export async function GET(request: NextRequest) {
   const organization = request.nextUrl.searchParams.get("organization") ?? "";
   const pipeline = request.nextUrl.searchParams.get("pipeline") ?? "";
   const buildNumber = request.nextUrl.searchParams.get("buildNumber") ?? "";
+  const jobId = request.nextUrl.searchParams.get("jobId");
+  const pageValue = request.nextUrl.searchParams.get("page") ?? "0";
 
   if (!SLUG.test(organization) || !SLUG.test(pipeline)) {
     return error("Invalid Buildkite organization or pipeline", 400);
@@ -152,10 +163,23 @@ export async function GET(request: NextRequest) {
   if (!/^\d{1,12}$/.test(buildNumber)) {
     return error("Invalid Buildkite build number", 400);
   }
+  if (jobId !== null && !JOB_ID.test(jobId)) {
+    return error("Invalid Buildkite job ID", 400);
+  }
+  if (
+    !/^\d{1,4}$/.test(pageValue) ||
+    (jobId === null && pageValue !== "0")
+  ) {
+    return error("Invalid trace page", 400);
+  }
 
   try {
     const db = getDb();
-    const rows = await db<TraceRow[]>`
+    const page = Number(pageValue);
+    const pageSize = jobId === null ? MAX_BUILD_SPANS : JOB_DETAIL_PAGE_SIZE;
+    const requestedJobId = jobId ?? null;
+    const offset = page * pageSize;
+    const fetchedRows = await db<TraceRow[]>`
       SELECT
         trace_id,
         span_id,
@@ -195,9 +219,25 @@ export async function GET(request: NextRequest) {
       WHERE organization_slug = ${organization}
         AND pipeline_slug = ${pipeline}
         AND build_number = ${buildNumber}::bigint
-      ORDER BY start_time ASC, duration_ms DESC
-      LIMIT ${MAX_SPANS}
+        AND (
+          (
+            ${requestedJobId}::text IS NULL
+            AND (
+              span_name IN ('buildkite.build', 'buildkite.job', 'buildkite.step')
+              OR span_attributes->>'ci.span.kind' = 'command'
+            )
+          )
+          OR (
+            ${requestedJobId}::text IS NOT NULL
+            AND job_id = ${requestedJobId}
+          )
+        )
+      ORDER BY start_time ASC, duration_ms DESC, span_id ASC
+      LIMIT ${pageSize + 1}
+      OFFSET ${offset}
     `;
+    const hasMore = fetchedRows.length > pageSize;
+    const rows = hasMore ? fetchedRows.slice(0, pageSize) : fetchedRows;
 
     if (rows.length === 0) {
       return NextResponse.json(
@@ -205,12 +245,30 @@ export async function GET(request: NextRequest) {
           available: false,
           complete: false,
           truncated: false,
+          nextPage: null,
           lanes: [],
           summary: null,
         },
         { headers: { "Cache-Control": "private, max-age=5" } },
       );
     }
+
+    const detailCounts = await db<DetailCountRow[]>`
+      SELECT
+        parent_span_id,
+        COUNT(*)::integer AS child_count
+      FROM otel_spans
+      WHERE organization_slug = ${organization}
+        AND pipeline_slug = ${pipeline}
+        AND build_number = ${buildNumber}::bigint
+        AND span_attributes->>'ci.span.kind' = 'test'
+        AND parent_span_id IS NOT NULL
+        AND (${requestedJobId}::text IS NULL OR job_id = ${requestedJobId})
+      GROUP BY parent_span_id
+    `;
+    const childCountByParent = new Map(
+      detailCounts.map((row) => [row.parent_span_id, Number(row.child_count)]),
+    );
 
     const childJobParents = new Set(
       rows
@@ -259,20 +317,13 @@ export async function GET(request: NextRequest) {
     }
 
     const jobLanes = markCompletionFrontier(baseJobLanes);
-    const commandIds = new Set(
-      details
-        .filter((row) => detailKind(row) === "command")
-        .map((row) => row.span_id),
-    );
     const detailLanes = details.map((row): Lane => {
       const kind = detailKind(row) as "command" | "test";
       const jobParent = row.job_id
         ? (jobLaneByJobId.get(row.job_id)?.id ?? null)
         : null;
       const parentId =
-        kind === "test" &&
-        row.parent_span_id &&
-        commandIds.has(row.parent_span_id)
+        kind === "test" && row.parent_span_id
           ? row.parent_span_id
           : jobParent;
       return {
@@ -293,6 +344,9 @@ export async function GET(request: NextRequest) {
         outcome: kind === "test" ? row.test_outcome : null,
         url: null,
         critical: false,
+        childCount: kind === "command"
+          ? (childCountByParent.get(row.span_id) ?? 0)
+          : 0,
       };
     });
     const lanes = [...jobLanes, ...detailLanes];
@@ -332,19 +386,22 @@ export async function GET(request: NextRequest) {
     const commandCount = detailLanes.filter(
       (lane) => lane.kind === "command",
     ).length;
-    const testCount = detailLanes.filter((lane) => lane.kind === "test").length;
+    const testCount = jobId === null
+      ? [...childCountByParent.values()].reduce((sum, count) => sum + count, 0)
+      : detailLanes.filter((lane) => lane.kind === "test").length;
 
     return NextResponse.json(
       {
         available: true,
         complete,
-        truncated: rows.length === MAX_SPANS,
+        truncated: hasMore,
+        nextPage: hasMore ? page + 1 : null,
         lanes,
         summary: {
           observedStart: new Date(observedStart).toISOString(),
           observedEnd: new Date(observedEnd).toISOString(),
           observedDurationMs: Math.max(0, observedEnd - observedStart),
-          spanCount: rows.length,
+          spanCount: jobId === null ? rows.length + testCount : rows.length,
           laneCount: jobLanes.length,
           commandCount,
           testCount,

--- a/src/components/build-waterfall.tsx
+++ b/src/components/build-waterfall.tsx
@@ -22,12 +22,14 @@ interface WaterfallLane {
   outcome: string | null;
   url: string | null;
   critical: boolean;
+  childCount: number;
 }
 
 interface TraceResponse {
   available: boolean;
   complete: boolean;
   truncated: boolean;
+  nextPage: number | null;
   lanes: WaterfallLane[];
   summary: {
     observedStart: string;
@@ -132,6 +134,11 @@ export function BuildWaterfall({
   const [criticalOnly, setCriticalOnly] = useState(false);
   const [showAll, setShowAll] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [jobDetails, setJobDetails] = useState<Record<string, WaterfallLane[]>>(
+    {},
+  );
+  const [loadingJobs, setLoadingJobs] = useState<Set<string>>(() => new Set());
+  const [detailErrors, setDetailErrors] = useState<Set<string>>(() => new Set());
   const params = new URLSearchParams({ organization, pipeline, buildNumber });
   const { data, error, isLoading, isValidating, mutate } = useSWR<TraceResponse>(
     `/api/builds/trace?${params.toString()}`,
@@ -143,7 +150,17 @@ export function BuildWaterfall({
   );
 
   const { jobLanes, childrenByParent } = useMemo(() => {
-    const lanes = data?.lanes ?? [];
+    const detailedJobIds = new Set(Object.keys(jobDetails));
+    const lanes = [
+      ...(data?.lanes ?? []).filter(
+        (lane) =>
+          !lane.jobId ||
+          !detailedJobIds.has(lane.jobId) ||
+          lane.kind === "job" ||
+          lane.kind === "step",
+      ),
+      ...Object.values(jobDetails).flat(),
+    ];
     const roots = lanes
       .filter((lane) => lane.kind === "job" || lane.kind === "step")
       .sort((a, b) => {
@@ -167,7 +184,7 @@ export function BuildWaterfall({
       });
     }
     return { jobLanes: roots, childrenByParent: children };
-  }, [data?.lanes]);
+  }, [data?.lanes, jobDetails]);
 
   const visibleJobs = useMemo(() => {
     const filtered = criticalOnly
@@ -197,11 +214,65 @@ export function BuildWaterfall({
     return flattened;
   }, [childrenByParent, expanded, visibleJobs]);
 
-  function toggleExpanded(id: string) {
+  async function loadJobDetails(jobId: string, jobParentId: string | null) {
+    if (jobDetails[jobId] || loadingJobs.has(jobId)) return;
+
+    setLoadingJobs((current) => new Set(current).add(jobId));
+    setDetailErrors((current) => {
+      const next = new Set(current);
+      next.delete(jobId);
+      return next;
+    });
+
+    try {
+      const lanes = new Map<string, WaterfallLane>();
+      let page: number | null = 0;
+      while (page !== null) {
+        const detailParams = new URLSearchParams({
+          organization,
+          pipeline,
+          buildNumber,
+          jobId,
+          page: String(page),
+        });
+        const response = await fetchTrace(
+          `/api/builds/trace?${detailParams.toString()}`,
+        );
+        for (const lane of response.lanes) {
+          if (lane.kind === "command" || lane.kind === "test") {
+            lanes.set(
+              lane.id,
+              lane.kind === "command" && jobParentId
+                ? { ...lane, parentId: jobParentId }
+                : lane,
+            );
+          }
+        }
+        page = response.nextPage;
+      }
+      setJobDetails((current) => ({
+        ...current,
+        [jobId]: [...lanes.values()],
+      }));
+    } catch {
+      setDetailErrors((current) => new Set(current).add(jobId));
+    } finally {
+      setLoadingJobs((current) => {
+        const next = new Set(current);
+        next.delete(jobId);
+        return next;
+      });
+    }
+  }
+
+  function toggleExpanded(lane: WaterfallLane) {
+    if (lane.kind === "command" && lane.jobId && lane.childCount > 0) {
+      void loadJobDetails(lane.jobId, lane.parentId);
+    }
     setExpanded((current) => {
       const next = new Set(current);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (next.has(lane.id)) next.delete(lane.id);
+      else next.add(lane.id);
       return next;
     });
   }
@@ -376,7 +447,20 @@ export function BuildWaterfall({
               const runLeft = clampPercent(((start - timelineStart) / timelineDuration) * 100);
               const runWidth = clampPercent(((end - start) / timelineDuration) * 100);
               const children = childrenByParent.get(lane.id) ?? [];
-              const isExpandable = children.length > 0;
+              const displayedChildCount = lane.kind === "command"
+                ? Math.max(lane.childCount, children.length)
+                : children.length;
+              const isExpandable = displayedChildCount > 0;
+              const isLoadingDetails = Boolean(
+                lane.kind === "command" &&
+                lane.jobId &&
+                loadingJobs.has(lane.jobId),
+              );
+              const hasDetailError = Boolean(
+                lane.kind === "command" &&
+                lane.jobId &&
+                detailErrors.has(lane.jobId),
+              );
               const depth = laneDepth(lane);
               const detail = `${lane.label} · ${formatTime(lane.startTime)}–${formatTime(lane.endTime)} · ${formatDuration(lane.durationMs)}${lane.outcome ? ` · ${lane.outcome}` : ""}`;
               const rowTone = depth === 0 ? "" : depth === 1 ? "bg-cyan-50/35 dark:bg-cyan-950/10" : "bg-emerald-50/30 dark:bg-emerald-950/10";
@@ -387,13 +471,15 @@ export function BuildWaterfall({
                     {depth > 0 && <span aria-hidden="true" className={`absolute inset-y-0 w-px ${depth === 1 ? "left-2 bg-cyan-200 dark:bg-cyan-900" : "left-6 bg-emerald-200 dark:bg-emerald-900"}`} />}
                     <div className="flex items-center gap-1.5">
                       {isExpandable ? (
-                        <button type="button" onClick={() => toggleExpanded(lane.id)} aria-expanded={expanded.has(lane.id)} aria-label={`${expanded.has(lane.id) ? "Collapse" : "Expand"} ${lane.label}`} className="dashboard-control flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-500 hover:bg-zinc-200/70 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-100">
+                        <button type="button" onClick={() => toggleExpanded(lane)} aria-expanded={expanded.has(lane.id)} aria-label={`${expanded.has(lane.id) ? "Collapse" : "Expand"} ${lane.label}`} className="dashboard-control flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-500 hover:bg-zinc-200/70 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-100">
                           <span aria-hidden="true" className={`transition-transform ${expanded.has(lane.id) ? "rotate-90" : ""}`}>›</span>
                         </button>
                       ) : <span className="w-6 shrink-0" />}
                       {lane.critical && <span aria-label="Inferred build-limiting job" className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" />}
                       <span className={`truncate text-xs text-zinc-800 dark:text-zinc-200 ${depth === 0 ? "font-medium" : "font-mono text-[11px]"}`} title={lane.label}>{lane.label}</span>
-                      {isExpandable && <span className="shrink-0 rounded bg-zinc-200/70 px-1.5 py-0.5 font-mono text-[9px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">{children.length}</span>}
+                      {isExpandable && <span className="shrink-0 rounded bg-zinc-200/70 px-1.5 py-0.5 font-mono text-[9px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">{displayedChildCount}</span>}
+                      {isLoadingDetails && <span className="shrink-0 text-[9px] text-cyan-600 dark:text-cyan-400">loading tests…</span>}
+                      {hasDetailError && <span className="shrink-0 text-[9px] text-red-600 dark:text-red-400">test trace load failed; select again to retry</span>}
                       <span className="ml-auto shrink-0 font-mono text-[10px] text-zinc-400">{formatDuration(lane.durationMs)}</span>
                     </div>
                     {depth === 0 && (


### PR DESCRIPTION
## Summary

- keep the initial build trace response bounded to build, job, step, and command spans
- return exact aggregate pytest child counts for command rows
- load all command and pytest spans for an expanded job through stable pagination
- show loading and retry states while job details are fetched

## Root cause

The build trace endpoint globally sorted every span in a build and returned only the first 5,000. Busy builds can contain tens of thousands of pytest spans across parallel jobs, so later jobs were represented by their Buildkite job and command spans but only a partial set of tests.

For build #84274, `Basic Models Tests (Other)` collected 421 tests, but the dashboard received only 7 test spans.

## Validation

- `npm test`
- `npm exec -- eslint src/app/api/builds/trace/route.ts src/components/build-waterfall.tsx`
- `npm run build`
- validated the local API against production trace data for build #84274: the affected command reports and loads all 421 tests
- validated pagination against a 5,987-test job across four pages
