### PR TITLE
Show Docker build stages in CI timeline

### DIFF
--- a/src/app/api/builds/trace/route.ts
+++ b/src/app/api/builds/trace/route.ts
@@ -35,10 +35,20 @@ type TraceRow = {
   command_label: string | null;
   test_nodeid: string | null;
   test_outcome: string | null;
+  docker_stage: string | null;
+  docker_step_index: number | null;
+  docker_step_label: string | null;
   received_at: Date;
 };
 
-type LaneKind = "job" | "step" | "command" | "test";
+type LaneKind =
+  | "job"
+  | "step"
+  | "command"
+  | "test"
+  | "docker-stage"
+  | "docker-instruction"
+  | "docker-internal";
 
 type Lane = {
   id: string;
@@ -63,6 +73,7 @@ type Lane = {
 
 type DetailCountRow = {
   parent_span_id: string;
+  ci_kind: string;
   child_count: number;
 };
 
@@ -138,14 +149,28 @@ function jobLane(row: TraceRow, id = row.span_id): Lane {
   };
 }
 
-function detailKind(row: TraceRow): "command" | "test" | null {
-  if (row.ci_kind === "command") return "command";
-  if (row.ci_kind === "test") return "test";
+type DetailKind = Exclude<LaneKind, "job" | "step">;
+
+function detailKind(row: TraceRow): DetailKind | null {
+  if (
+    row.ci_kind === "command" ||
+    row.ci_kind === "test" ||
+    row.ci_kind === "docker-stage" ||
+    row.ci_kind === "docker-instruction" ||
+    row.ci_kind === "docker-internal"
+  ) {
+    return row.ci_kind;
+  }
   return null;
 }
 
-function detailLabel(row: TraceRow, kind: "command" | "test"): string {
+function detailLabel(row: TraceRow, kind: DetailKind): string {
   if (kind === "test") return row.test_nodeid ?? row.span_name;
+  if (kind === "docker-stage") return row.docker_stage ?? row.span_name;
+  if (kind === "docker-instruction" || kind === "docker-internal") {
+    const prefix = row.docker_step_index ? `${row.docker_step_index}. ` : "";
+    return `${prefix}${row.docker_step_label ?? row.span_name}`;
+  }
   const prefix = row.command_index ? `${row.command_index}. ` : "";
   return `${prefix}${row.command_label ?? row.span_name}`;
 }
@@ -214,6 +239,13 @@ export async function GET(request: NextRequest) {
         NULLIF(span_attributes->>'ci.command.label', '') AS command_label,
         NULLIF(span_attributes->>'test.nodeid', '') AS test_nodeid,
         NULLIF(span_attributes->>'test.outcome', '') AS test_outcome,
+        NULLIF(span_attributes->>'docker.stage', '') AS docker_stage,
+        CASE
+          WHEN span_attributes->>'docker.step.index' ~ '^\d+$'
+          THEN (span_attributes->>'docker.step.index')::integer
+          ELSE NULL
+        END AS docker_step_index,
+        NULLIF(span_attributes->>'docker.step.label', '') AS docker_step_label,
         received_at
       FROM otel_spans
       WHERE organization_slug = ${organization}
@@ -224,7 +256,9 @@ export async function GET(request: NextRequest) {
             ${requestedJobId}::text IS NULL
             AND (
               span_name IN ('buildkite.build', 'buildkite.job', 'buildkite.step')
-              OR span_attributes->>'ci.span.kind' = 'command'
+              OR span_attributes->>'ci.span.kind' IN (
+                'command', 'docker-stage', 'docker-internal'
+              )
             )
           )
           OR (
@@ -256,19 +290,25 @@ export async function GET(request: NextRequest) {
     const detailCounts = await db<DetailCountRow[]>`
       SELECT
         parent_span_id,
+        span_attributes->>'ci.span.kind' AS ci_kind,
         COUNT(*)::integer AS child_count
       FROM otel_spans
       WHERE organization_slug = ${organization}
         AND pipeline_slug = ${pipeline}
         AND build_number = ${buildNumber}::bigint
-        AND span_attributes->>'ci.span.kind' = 'test'
+        AND span_attributes->>'ci.span.kind' IN ('test', 'docker-instruction')
         AND parent_span_id IS NOT NULL
         AND (${requestedJobId}::text IS NULL OR job_id = ${requestedJobId})
-      GROUP BY parent_span_id
+      GROUP BY parent_span_id, span_attributes->>'ci.span.kind'
     `;
-    const childCountByParent = new Map(
-      detailCounts.map((row) => [row.parent_span_id, Number(row.child_count)]),
-    );
+    const childCountByParent = new Map<string, number>();
+    for (const row of detailCounts) {
+      childCountByParent.set(
+        row.parent_span_id,
+        (childCountByParent.get(row.parent_span_id) ?? 0) +
+          Number(row.child_count),
+      );
+    }
 
     const childJobParents = new Set(
       rows
@@ -283,6 +323,7 @@ export async function GET(request: NextRequest) {
           !childJobParents.has(row.span_id)),
     );
     const details = rows.filter((row) => detailKind(row) !== null);
+    const detailSpanIds = new Set(details.map((row) => row.span_id));
 
     const baseJobLanes = controlRows.map((row) => jobLane(row));
     const jobLaneByJobId = new Map(
@@ -318,12 +359,12 @@ export async function GET(request: NextRequest) {
 
     const jobLanes = markCompletionFrontier(baseJobLanes);
     const detailLanes = details.map((row): Lane => {
-      const kind = detailKind(row) as "command" | "test";
+      const kind = detailKind(row) as DetailKind;
       const jobParent = row.job_id
         ? (jobLaneByJobId.get(row.job_id)?.id ?? null)
         : null;
       const parentId =
-        kind === "test" && row.parent_span_id
+        row.parent_span_id && detailSpanIds.has(row.parent_span_id)
           ? row.parent_span_id
           : jobParent;
       return {
@@ -344,7 +385,7 @@ export async function GET(request: NextRequest) {
         outcome: kind === "test" ? row.test_outcome : null,
         url: null,
         critical: false,
-        childCount: kind === "command"
+        childCount: kind === "command" || kind === "docker-stage"
           ? (childCountByParent.get(row.span_id) ?? 0)
           : 0,
       };
@@ -386,9 +427,19 @@ export async function GET(request: NextRequest) {
     const commandCount = detailLanes.filter(
       (lane) => lane.kind === "command",
     ).length;
-    const testCount = jobId === null
-      ? [...childCountByParent.values()].reduce((sum, count) => sum + count, 0)
-      : detailLanes.filter((lane) => lane.kind === "test").length;
+    const testCount = detailCounts
+      .filter((row) => row.ci_kind === "test")
+      .reduce((sum, row) => sum + Number(row.child_count), 0);
+    const dockerStageCount = detailLanes.filter(
+      (lane) => lane.kind === "docker-stage",
+    ).length;
+    const dockerChildCount = detailCounts
+      .filter((row) => row.ci_kind === "docker-instruction")
+      .reduce((sum, row) => sum + Number(row.child_count), 0);
+    const dockerInstructionCount =
+      dockerChildCount +
+      detailLanes.filter((lane) => lane.kind === "docker-internal").length;
+    const nestedDetailCount = testCount + dockerChildCount;
 
     return NextResponse.json(
       {
@@ -401,10 +452,13 @@ export async function GET(request: NextRequest) {
           observedStart: new Date(observedStart).toISOString(),
           observedEnd: new Date(observedEnd).toISOString(),
           observedDurationMs: Math.max(0, observedEnd - observedStart),
-          spanCount: jobId === null ? rows.length + testCount : rows.length,
+          spanCount:
+            jobId === null ? rows.length + nestedDetailCount : rows.length,
           laneCount: jobLanes.length,
           commandCount,
           testCount,
+          dockerStageCount,
+          dockerInstructionCount,
           traceCount: new Set(rows.map((row) => row.trace_id)).size,
           queueCount: new Set(
             jobLanes.map((lane) => lane.queue).filter(Boolean),

--- a/src/components/build-waterfall.tsx
+++ b/src/components/build-waterfall.tsx
@@ -3,7 +3,14 @@
 import { useMemo, useState } from "react";
 import useSWR from "swr";
 
-type LaneKind = "job" | "step" | "command" | "test";
+type LaneKind =
+  | "job"
+  | "step"
+  | "command"
+  | "test"
+  | "docker-stage"
+  | "docker-instruction"
+  | "docker-internal";
 
 interface WaterfallLane {
   id: string;
@@ -39,6 +46,8 @@ interface TraceResponse {
     laneCount: number;
     commandCount: number;
     testCount: number;
+    dockerStageCount: number;
+    dockerInstructionCount: number;
     traceCount: number;
     queueCount: number;
     criticalCount: number;
@@ -108,8 +117,19 @@ function GridLines() {
 }
 
 function laneDepth(lane: WaterfallLane): number {
-  if (lane.kind === "test") return 2;
-  if (lane.kind === "command") return 1;
+  if (
+    lane.kind === "test" ||
+    lane.kind === "docker-instruction"
+  ) {
+    return 2;
+  }
+  if (
+    lane.kind === "command" ||
+    lane.kind === "docker-stage" ||
+    lane.kind === "docker-internal"
+  ) {
+    return 1;
+  }
   return 0;
 }
 
@@ -120,6 +140,9 @@ function laneColor(lane: WaterfallLane): string {
   if (lane.status === "failed") return "bg-red-500 dark:bg-red-500";
   if (lane.status === "skipped") return "bg-zinc-300 dark:bg-zinc-600";
   if (lane.kind === "test") return "bg-emerald-500 dark:bg-emerald-500";
+  if (lane.kind === "docker-stage") return "bg-violet-500 dark:bg-violet-500";
+  if (lane.kind === "docker-instruction") return "bg-teal-500 dark:bg-teal-500";
+  if (lane.kind === "docker-internal") return "bg-slate-400 dark:bg-slate-500";
   if (lane.kind === "command") return "bg-cyan-500 dark:bg-cyan-500";
   return "bg-blue-500 dark:bg-blue-500";
 }
@@ -202,14 +225,18 @@ export function BuildWaterfall({
 
   const visibleLanes = useMemo(() => {
     const flattened: WaterfallLane[] = [];
+    const appendChildren = (parentId: string, visited: Set<string>) => {
+      for (const child of childrenByParent.get(parentId) ?? []) {
+        if (visited.has(child.id)) continue;
+        visited.add(child.id);
+        flattened.push(child);
+        if (expanded.has(child.id)) appendChildren(child.id, visited);
+      }
+    };
     for (const job of visibleJobs) {
       flattened.push(job);
       if (!expanded.has(job.id)) continue;
-      for (const command of childrenByParent.get(job.id) ?? []) {
-        flattened.push(command);
-        if (!expanded.has(command.id)) continue;
-        flattened.push(...(childrenByParent.get(command.id) ?? []));
-      }
+      appendChildren(job.id, new Set([job.id]));
     }
     return flattened;
   }, [childrenByParent, expanded, visibleJobs]);
@@ -239,10 +266,14 @@ export function BuildWaterfall({
           `/api/builds/trace?${detailParams.toString()}`,
         );
         for (const lane of response.lanes) {
-          if (lane.kind === "command" || lane.kind === "test") {
+          if (lane.kind !== "job" && lane.kind !== "step") {
+            const isJobChild =
+              lane.kind === "command" ||
+              lane.kind === "docker-stage" ||
+              lane.kind === "docker-internal";
             lanes.set(
               lane.id,
-              lane.kind === "command" && jobParentId
+              isJobChild && jobParentId
                 ? { ...lane, parentId: jobParentId }
                 : lane,
             );
@@ -266,7 +297,11 @@ export function BuildWaterfall({
   }
 
   function toggleExpanded(lane: WaterfallLane) {
-    if (lane.kind === "command" && lane.jobId && lane.childCount > 0) {
+    if (
+      (lane.kind === "command" || lane.kind === "docker-stage") &&
+      lane.jobId &&
+      lane.childCount > 0
+    ) {
       void loadJobDetails(lane.jobId, lane.parentId);
     }
     setExpanded((current) => {
@@ -371,8 +406,9 @@ export function BuildWaterfall({
             {isValidating && <span className="text-[11px] text-zinc-400">Checking…</span>}
           </div>
           <p className="mt-1 text-xs leading-5 text-zinc-500 dark:text-zinc-400">
-            Select a traced job to see its commands. Select a pytest command to
-            see every test. Amber jobs are inferred build-limiting work.
+            Select a traced job to see commands and Docker stages. Expand a
+            command or stage for tests or Dockerfile instructions. Amber jobs
+            are inferred build-limiting work.
           </p>
         </div>
         <div className="flex flex-col items-start gap-3 lg:items-end">
@@ -389,6 +425,8 @@ export function BuildWaterfall({
             <span><strong className="font-mono font-semibold text-zinc-800 dark:text-zinc-200">{summary.laneCount}{coverageTotal !== null ? ` of ${coverageTotal}` : ""}</strong> jobs traced</span>
             {summary.commandCount > 0 && <span><strong className="font-mono font-semibold text-cyan-700 dark:text-cyan-300">{summary.commandCount}</strong> commands</span>}
             {summary.testCount > 0 && <span><strong className="font-mono font-semibold text-emerald-700 dark:text-emerald-300">{summary.testCount}</strong> tests</span>}
+            {summary.dockerStageCount > 0 && <span><strong className="font-mono font-semibold text-violet-700 dark:text-violet-300">{summary.dockerStageCount}</strong> Docker stages</span>}
+            {summary.dockerInstructionCount > 0 && <span><strong className="font-mono font-semibold text-teal-700 dark:text-teal-300">{summary.dockerInstructionCount}</strong> Docker steps</span>}
             <span><strong className="font-mono font-semibold text-amber-700 dark:text-amber-300">{summary.criticalCount}</strong> build-limiting</span>
           </div>
         </div>
@@ -399,13 +437,15 @@ export function BuildWaterfall({
           <span className="inline-flex items-center gap-1.5"><span className="h-2 w-4 rounded-sm bg-blue-500" /> job</span>
           {summary.commandCount > 0 && <span className="inline-flex items-center gap-1.5"><span className="h-2 w-4 rounded-sm bg-cyan-500" /> command</span>}
           {summary.testCount > 0 && <span className="inline-flex items-center gap-1.5"><span className="h-2 w-4 rounded-sm bg-emerald-500" /> test</span>}
+          {summary.dockerStageCount > 0 && <span className="inline-flex items-center gap-1.5"><span className="h-2 w-4 rounded-sm bg-violet-500" /> Docker stage</span>}
+          {summary.dockerInstructionCount > 0 && <span className="inline-flex items-center gap-1.5"><span className="h-2 w-4 rounded-sm bg-teal-500" /> Dockerfile step</span>}
           <span className="inline-flex items-center gap-1.5"><span className="h-2 w-4 rounded-sm bg-red-500" /> failed</span>
           <span className="inline-flex items-center gap-1.5"><span className="h-2 w-4 rounded-sm bg-zinc-300 dark:bg-zinc-700" /> queued / skipped</span>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           {expandableJobs.length > 0 && (
             <button type="button" onClick={toggleAllJobs} className="dashboard-control min-h-9 rounded-md border border-cyan-300 bg-cyan-50 px-3 text-xs font-medium text-cyan-800 hover:bg-cyan-100 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-200 dark:hover:bg-cyan-950/70">
-              {allJobsExpanded ? "Collapse commands" : `Show commands (${summary.commandCount})`}
+              {allJobsExpanded ? "Collapse details" : "Show job details"}
             </button>
           )}
           <button
@@ -427,7 +467,7 @@ export function BuildWaterfall({
       <div className="overflow-x-auto pb-2">
         <div className="min-w-[760px] px-5">
           <div className="grid grid-cols-[minmax(16rem,21rem)_minmax(32rem,1fr)] gap-4 border-b border-zinc-200 pb-2 dark:border-zinc-800">
-            <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-400">Job / command / test</div>
+            <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-400">Job / command / Docker / test</div>
             <div className="relative h-5 font-mono text-[10px] text-zinc-400">
               {TICKS.map((tick) => (
                 <span key={tick} className="absolute -translate-x-1/2 first:translate-x-0 last:-translate-x-full" style={{ left: `${tick * 100}%` }}>
@@ -447,28 +487,37 @@ export function BuildWaterfall({
               const runLeft = clampPercent(((start - timelineStart) / timelineDuration) * 100);
               const runWidth = clampPercent(((end - start) / timelineDuration) * 100);
               const children = childrenByParent.get(lane.id) ?? [];
-              const displayedChildCount = lane.kind === "command"
+              const displayedChildCount =
+                lane.kind === "command" || lane.kind === "docker-stage"
                 ? Math.max(lane.childCount, children.length)
                 : children.length;
               const isExpandable = displayedChildCount > 0;
               const isLoadingDetails = Boolean(
-                lane.kind === "command" &&
+                (lane.kind === "command" || lane.kind === "docker-stage") &&
                 lane.jobId &&
                 loadingJobs.has(lane.jobId),
               );
               const hasDetailError = Boolean(
-                lane.kind === "command" &&
+                (lane.kind === "command" || lane.kind === "docker-stage") &&
                 lane.jobId &&
                 detailErrors.has(lane.jobId),
               );
               const depth = laneDepth(lane);
               const detail = `${lane.label} · ${formatTime(lane.startTime)}–${formatTime(lane.endTime)} · ${formatDuration(lane.durationMs)}${lane.outcome ? ` · ${lane.outcome}` : ""}`;
-              const rowTone = depth === 0 ? "" : depth === 1 ? "bg-cyan-50/35 dark:bg-cyan-950/10" : "bg-emerald-50/30 dark:bg-emerald-950/10";
+              const rowTone = depth === 0
+                ? ""
+                : lane.kind === "docker-stage"
+                  ? "bg-violet-50/35 dark:bg-violet-950/10"
+                  : lane.kind === "docker-instruction" || lane.kind === "docker-internal"
+                    ? "bg-teal-50/30 dark:bg-teal-950/10"
+                    : depth === 1
+                      ? "bg-cyan-50/35 dark:bg-cyan-950/10"
+                      : "bg-emerald-50/30 dark:bg-emerald-950/10";
 
               return (
                 <div key={lane.id} className={`grid min-h-10 grid-cols-[minmax(16rem,21rem)_minmax(32rem,1fr)] items-center gap-4 border-b border-zinc-200/70 last:border-0 dark:border-zinc-800/70 ${rowTone}`}>
                   <div className="relative min-w-0 py-1.5" style={{ paddingLeft: `${depth * 18}px` }}>
-                    {depth > 0 && <span aria-hidden="true" className={`absolute inset-y-0 w-px ${depth === 1 ? "left-2 bg-cyan-200 dark:bg-cyan-900" : "left-6 bg-emerald-200 dark:bg-emerald-900"}`} />}
+                    {depth > 0 && <span aria-hidden="true" className={`absolute inset-y-0 w-px ${depth === 1 ? "left-2 bg-cyan-200 dark:bg-cyan-900" : "left-6 bg-zinc-200 dark:bg-zinc-800"}`} />}
                     <div className="flex items-center gap-1.5">
                       {isExpandable ? (
                         <button type="button" onClick={() => toggleExpanded(lane)} aria-expanded={expanded.has(lane.id)} aria-label={`${expanded.has(lane.id) ? "Collapse" : "Expand"} ${lane.label}`} className="dashboard-control flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-500 hover:bg-zinc-200/70 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-100">
@@ -478,8 +527,8 @@ export function BuildWaterfall({
                       {lane.critical && <span aria-label="Inferred build-limiting job" className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" />}
                       <span className={`truncate text-xs text-zinc-800 dark:text-zinc-200 ${depth === 0 ? "font-medium" : "font-mono text-[11px]"}`} title={lane.label}>{lane.label}</span>
                       {isExpandable && <span className="shrink-0 rounded bg-zinc-200/70 px-1.5 py-0.5 font-mono text-[9px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">{displayedChildCount}</span>}
-                      {isLoadingDetails && <span className="shrink-0 text-[9px] text-cyan-600 dark:text-cyan-400">loading tests…</span>}
-                      {hasDetailError && <span className="shrink-0 text-[9px] text-red-600 dark:text-red-400">test trace load failed; select again to retry</span>}
+                      {isLoadingDetails && <span className="shrink-0 text-[9px] text-cyan-600 dark:text-cyan-400">loading details…</span>}
+                      {hasDetailError && <span className="shrink-0 text-[9px] text-red-600 dark:text-red-400">trace details failed; select again to retry</span>}
                       <span className="ml-auto shrink-0 font-mono text-[10px] text-zinc-400">{formatDuration(lane.durationMs)}</span>
                     </div>
                     {depth === 0 && (


### PR DESCRIPTION
## Summary

- recognize Docker stage, Dockerfile instruction, and BuildKit internal spans in the existing trace API
- attach stages and internal operations to the Build image job, with Dockerfile instructions nested under their stage
- render recursively expandable Docker trace rows with distinct stage, instruction, and internal-operation colors
- report Docker stage and step coverage alongside existing command and pytest counts

No database migration is needed; this uses attributes already stored in `otel_spans`.

## Collector dependency

The producer is included in vllm-project/vllm#52851. That PR captures the exact Buildx history reference, converts the native BuildKit OpenTelemetry trace, and uploads it through the existing fail-open Buildkite OIDC path.

This dashboard PR is safe to merge first and remains dormant until producer spans arrive.

## Validation

- `npm test` — 6 passed
- `npm run lint -- src/app/api/builds/trace/route.ts src/components/build-waterfall.tsx` — passed
- `npm run build` — passed

## AI assistance

Codex was used to prepare and validate this change. This draft must be reviewed line-by-line by the human submitter before it is marked ready.