### PR TITLE
Stop Queue page from exhausting Buildkite GraphQL budget

### DIFF
--- a/src/app/api/queue/jobs/reprioritize/route.ts
+++ b/src/app/api/queue/jobs/reprioritize/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { BuildkiteQueueError, reprioritizeQueueJob } from "@/lib/buildkite-queue-jobs";
+import { isBuildkiteQueueError, reprioritizeQueueJob } from "@/lib/buildkite-queue-jobs";
 
 export const dynamic = "force-dynamic";
 
@@ -44,10 +44,14 @@ export async function POST(request: NextRequest) {
       { headers: { "Cache-Control": "no-store" } },
     );
   } catch (error) {
-    if (error instanceof BuildkiteQueueError) {
+    if (isBuildkiteQueueError(error)) {
+      const headers: Record<string, string> = { "Cache-Control": "no-store" };
+      if (error.retryAfterSeconds !== undefined) {
+        headers["Retry-After"] = String(error.retryAfterSeconds);
+      }
       return NextResponse.json(
         { error: error.message, code: error.code },
-        { status: error.status, headers: { "Cache-Control": "no-store" } },
+        { status: error.status, headers },
       );
     }
 

--- a/src/app/api/queue/jobs/route.ts
+++ b/src/app/api/queue/jobs/route.ts
@@ -1,13 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
-import { BuildkiteQueueError, getQueueJobs } from "@/lib/buildkite-queue-jobs";
+import { getQueueJobs, isBuildkiteQueueError } from "@/lib/buildkite-queue-jobs";
 
 export const dynamic = "force-dynamic";
 
 function responseError(error: unknown) {
-  if (error instanceof BuildkiteQueueError) {
+  if (isBuildkiteQueueError(error)) {
+    const headers: Record<string, string> = { "Cache-Control": "no-store" };
+    if (error.retryAfterSeconds !== undefined) {
+      headers["Retry-After"] = String(error.retryAfterSeconds);
+    }
     return NextResponse.json(
       { error: error.message, code: error.code },
-      { status: error.status, headers: { "Cache-Control": "no-store" } },
+      { status: error.status, headers },
     );
   }
 
@@ -22,12 +26,10 @@ export async function GET(request: NextRequest) {
   const queue = request.nextUrl.searchParams.get("queue") ?? "";
 
   try {
-    const { jobs, waitingCount, metrics } = await getQueueJobs(queue);
+    const { jobs } = await getQueueJobs(queue);
     return NextResponse.json(
       {
         jobs,
-        waitingCount,
-        metrics,
         operatorAccessRequired: Boolean(process.env.BUILDKITE_QUEUE_OPERATOR_TOKEN),
       },
       { headers: { "Cache-Control": "no-store" } },

--- a/src/app/queue/page.tsx
+++ b/src/app/queue/page.tsx
@@ -107,13 +107,6 @@ export default function QueuePage() {
     keepPreviousData: true,
   });
   const queueJobsQuery = useQueueWaitingJobs(queue);
-  const liveMetrics = queueJobsQuery.data?.metrics;
-  // The Buildkite queue metric is the source of truth for the current
-  // waiting count. Individual job details may be unavailable when an Agent
-  // Stack has already reserved those jobs, but the metric remains available.
-  const liveWaitingJobs = queueJobsQuery.data
-    ? (queueJobsQuery.data.waitingCount ?? queueJobsQuery.data.jobs.length)
-    : undefined;
 
   const historyMatchesQueue = metricsData?.query.queue === (queue || null);
   const historyMatchesSelection =
@@ -149,35 +142,8 @@ export default function QueuePage() {
       .map(([time, v]) => ({ time, ...v }))
       .sort((a, b) => a.time - b.time);
 
-    // Add or replace the current point with the direct Buildkite GraphQL
-    // snapshot. Historical points are persisted by the five-minute poller.
-    if (
-      queue &&
-      liveMetrics?.connectedAgents != null &&
-      liveMetrics.runningJobs != null &&
-      liveMetrics.waitingJobs != null
-    ) {
-      const latest = chartData[chartData.length - 1];
-      const livePointTime = Date.parse(liveMetrics.polledAt);
-
-      if (Number.isFinite(livePointTime)) {
-        const livePoint = {
-          time: livePointTime,
-          running: liveMetrics.runningJobs,
-          scheduled: liveMetrics.waitingJobs,
-          waiting: 0,
-          agents: liveMetrics.connectedAgents,
-        };
-        if (latest && Math.abs(livePointTime - latest.time) < 5 * 60_000) {
-          chartData[chartData.length - 1] = livePoint;
-        } else {
-          chartData.push(livePoint);
-        }
-      }
-    }
-
     return chartData;
-  }, [historyMatchesQueue, liveMetrics, metricsData, queue]);
+  }, [historyMatchesQueue, metricsData, queue]);
 
   const chartTickInterval = Math.max(1, Math.floor(overviewChartData.length / 10));
 
@@ -226,44 +192,20 @@ export default function QueuePage() {
     (sum, metric) => sum + effectiveWaiting(metric.queue, metric.jobs_scheduled, metric.jobs_waiting),
     0,
   );
-  const totalAgents = queue && liveMetrics?.connectedAgents != null
-    ? liveMetrics.connectedAgents
-    : savedTotalAgents;
-  const runningJobs = queue && liveMetrics?.runningJobs != null
-    ? liveMetrics.runningJobs
-    : savedRunningJobs;
-  const busyAgents = queue && liveMetrics?.connectedAgents != null
-    ? Math.min(totalAgents, runningJobs)
-    : savedBusyAgents;
-  const idleAgents = queue && liveMetrics?.connectedAgents != null
-    ? Math.max(0, totalAgents - busyAgents)
-    : savedIdleAgents;
-  const currentWaitingJobs = queue
-    ? (liveMetrics?.waitingJobs ?? liveWaitingJobs ?? savedWaitingJobs)
-    : savedWaitingJobs;
-  const liveWaitingJobsDetail = !queue
+  const totalAgents = savedTotalAgents;
+  const runningJobs = savedRunningJobs;
+  const busyAgents = savedBusyAgents;
+  const idleAgents = savedIdleAgents;
+  const currentWaitingJobs = savedWaitingJobs;
+  const waitingJobsDetail = !queue
     ? "Select a queue"
     : queueJobsQuery.error
-      ? "Live count unavailable"
-      : liveWaitingJobs === undefined
-        ? "Loading live queue"
-        : queueJobsQuery.data?.waitingCount != null
-          ? "Buildkite queue metric"
-          : "Live command jobs";
+      ? "Buildkite snapshot · details unavailable"
+      : "Buildkite snapshot";
 
   function waitMetric(
-    liveValue: number | null | undefined,
     savedField: "p50_wait_secs" | "p95_wait_secs" | "p99_wait_secs",
   ): { seconds: number | null; detail?: string } {
-    if (queue && liveMetrics) {
-      const sampleSize = liveMetrics?.waitSampleSize ?? 0;
-      return {
-        seconds: liveValue ?? null,
-        detail: sampleSize > 0
-          ? `${sampleSize} runnable job${sampleSize === 1 ? "" : "s"} · Buildkite API`
-          : "No runnable jobs · Buildkite API",
-      };
-    }
     const withWait = filtered.filter((metric) => metric[savedField] != null);
     if (withWait.length === 0) return { seconds: null };
     const worst = withWait.reduce((a, b) => (a[savedField]! > b[savedField]! ? a : b));
@@ -273,9 +215,9 @@ export default function QueuePage() {
     };
   }
 
-  const p50Wait = waitMetric(liveMetrics?.p50WaitSecs, "p50_wait_secs");
-  const p95Wait = waitMetric(liveMetrics?.p95WaitSecs, "p95_wait_secs");
-  const p99Wait = waitMetric(liveMetrics?.p99WaitSecs, "p99_wait_secs");
+  const p50Wait = waitMetric("p50_wait_secs");
+  const p95Wait = waitMetric("p95_wait_secs");
+  const p99Wait = waitMetric("p99_wait_secs");
 
   return (
     <div className="space-y-6">
@@ -322,7 +264,7 @@ export default function QueuePage() {
         <StatCard
           label="Waiting Jobs"
           value={currentWaitingJobs}
-          detail={liveWaitingJobsDetail}
+          detail={waitingJobsDetail}
           color={currentWaitingJobs > 0 ? "yellow" : "default"}
         />
         <StatCard
@@ -413,7 +355,13 @@ export default function QueuePage() {
         </div>
       </div>
 
-      {queue && <QueueWaitingJobs queue={queue} query={queueJobsQuery} />}
+      {queue && (
+        <QueueWaitingJobs
+          queue={queue}
+          query={queueJobsQuery}
+          waitingCount={savedWaitingJobs}
+        />
+      )}
 
       {/* Queue Summary Table */}
       <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">

--- a/src/components/queue-waiting-jobs.tsx
+++ b/src/components/queue-waiting-jobs.tsx
@@ -13,18 +13,6 @@ export interface QueueJob {
 
 export interface QueueJobsResponse {
   jobs: QueueJob[];
-  waitingCount: number | null;
-  metrics: {
-    polledAt: string;
-    connectedAgents: number | null;
-    runningJobs: number | null;
-    waitingJobs: number | null;
-    p50WaitSecs: number | null;
-    p90WaitSecs: number | null;
-    p95WaitSecs: number | null;
-    p99WaitSecs: number | null;
-    waitSampleSize: number;
-  };
   operatorAccessRequired: boolean;
 }
 
@@ -56,15 +44,18 @@ export function useQueueWaitingJobs(queue: string) {
   return useSWR<QueueJobsResponse>(url, fetchJson, {
     refreshInterval: 5 * 60_000,
     keepPreviousData: true,
+    shouldRetryOnError: false,
   });
 }
 
 export function QueueWaitingJobs({
   queue,
   query,
+  waitingCount,
 }: {
   queue: string;
   query: ReturnType<typeof useQueueWaitingJobs>;
+  waitingCount: number | null;
 }) {
   const [operatorToken, setOperatorToken] = useState("");
   const [showAccess, setShowAccess] = useState(false);
@@ -113,8 +104,10 @@ export function QueueWaitingJobs({
 
   const canPromote = Boolean(data?.operatorAccessRequired && operatorToken);
   const showTable = Boolean(data && (data.jobs.length > 0 || isValidating || error));
-  const reportedWaitingCount = data?.waitingCount ?? data?.jobs.length;
-  const hasReservedJobs = Boolean(data && data.waitingCount !== null && data.waitingCount > data.jobs.length);
+  const reportedWaitingCount = waitingCount ?? data?.jobs.length ?? null;
+  const hasReservedJobs = Boolean(
+    data && waitingCount !== null && waitingCount > data.jobs.length,
+  );
 
   return (
     <section className="overflow-hidden rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
@@ -123,7 +116,7 @@ export function QueueWaitingJobs({
           <div>
             <div className="flex items-center gap-2">
               <h2 className="text-base font-semibold tracking-tight">Waiting jobs</h2>
-              {data && (
+              {reportedWaitingCount !== null && (
                 <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold tabular-nums text-amber-800 dark:bg-amber-950/60 dark:text-amber-300">
                   {reportedWaitingCount}
                 </span>
@@ -202,7 +195,7 @@ export function QueueWaitingJobs({
 
       {error && !data && (
         <div className="flex min-h-36 flex-col items-center justify-center gap-3 px-5 text-center text-sm text-zinc-500 dark:text-zinc-400">
-          <p>Waiting jobs couldn&apos;t be loaded.</p>
+          <p>{error instanceof Error ? error.message : "Waiting jobs couldn't be loaded."}</p>
           <button
             type="button"
             onClick={() => void mutate()}

--- a/src/lib/buildkite-queue-jobs.ts
+++ b/src/lib/buildkite-queue-jobs.ts
@@ -1,4 +1,4 @@
-import { fetchBuildkiteQueueSnapshots } from "@/lib/buildkite-queue-metrics";
+import { unstable_cache } from "next/cache";
 
 const GRAPHQL_ENDPOINT = "https://graphql.buildkite.com/v1";
 const REST_ENDPOINT = "https://api.buildkite.com/v2";
@@ -56,6 +56,10 @@ interface ClusterQueueTarget {
   queueId: string;
 }
 
+interface ClusterQueueIndexEntry extends ClusterQueueTarget {
+  key: string;
+}
+
 interface ClusterQueuesGraphQLResponse {
   data?: {
     organization?: {
@@ -87,18 +91,6 @@ interface ClusterQueuePageGraphQLResponse {
 
 export interface QueueJobsResult {
   jobs: QueueJob[];
-  waitingCount: number | null;
-  metrics: {
-    polledAt: string;
-    connectedAgents: number | null;
-    runningJobs: number | null;
-    waitingJobs: number | null;
-    p50WaitSecs: number | null;
-    p90WaitSecs: number | null;
-    p95WaitSecs: number | null;
-    p99WaitSecs: number | null;
-    waitSampleSize: number;
-  };
 }
 
 export class BuildkiteQueueError extends Error {
@@ -106,9 +98,24 @@ export class BuildkiteQueueError extends Error {
     message: string,
     public readonly status: number,
     public readonly code: string,
+    public readonly retryAfterSeconds?: number,
   ) {
     super(message);
+    this.name = "BuildkiteQueueError";
+    Object.setPrototypeOf(this, new.target.prototype);
   }
+}
+
+export function isBuildkiteQueueError(error: unknown): error is BuildkiteQueueError {
+  if (error instanceof BuildkiteQueueError) return true;
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as Partial<BuildkiteQueueError>;
+  return (
+    candidate.name === "BuildkiteQueueError" &&
+    typeof candidate.message === "string" &&
+    typeof candidate.status === "number" &&
+    typeof candidate.code === "string"
+  );
 }
 
 function getToken(): string {
@@ -136,6 +143,19 @@ function queueRule(queue: string): string {
 
 function requestError(response: Response, errors?: Array<{ message: string }>): BuildkiteQueueError {
   const detail = errors?.map((error) => error.message).join(" ");
+  const complexityLimit = detail?.match(
+    /exceeded the limit of \d+ complexity points.*?try again in (\d+) seconds/i,
+  );
+  if (complexityLimit) {
+    const retryAfterSeconds = Number.parseInt(complexityLimit[1], 10);
+    return new BuildkiteQueueError(
+      `Buildkite is temporarily rate-limiting queue details. Try again in ${retryAfterSeconds} seconds.`,
+      429,
+      "BUILDKITE_RATE_LIMITED",
+      retryAfterSeconds,
+    );
+  }
+
   const message =
     response.status === 401
       ? "The configured Buildkite API token is no longer valid."
@@ -144,7 +164,7 @@ function requestError(response: Response, errors?: Array<{ message: string }>): 
         : detail || "Buildkite could not load the queue jobs.";
   return new BuildkiteQueueError(
     message,
-    response.status >= 500 ? 502 : response.status || 502,
+    response.status >= 500 || response.ok ? 502 : response.status || 502,
     "BUILDKITE_REQUEST_FAILED",
   );
 }
@@ -216,8 +236,12 @@ async function getClusterQueuePage(
   return queues;
 }
 
-async function getClusterQueue(queue: string): Promise<ClusterQueueTarget | null> {
-  const token = getToken();
+async function fetchClusterQueueIndex(
+  token: string,
+  organizationSlug: string,
+): Promise<ClusterQueueIndexEntry[]> {
+  const index: ClusterQueueIndexEntry[] = [];
+  const seenKeys = new Set<string>();
   let after: string | null = null;
 
   do {
@@ -259,7 +283,7 @@ async function getClusterQueue(queue: string): Promise<ClusterQueueTarget | null
           }
         `,
         variables: {
-          organization: organization(),
+          organization: organizationSlug,
           first: JOBS_PAGE_SIZE,
           after,
         },
@@ -290,16 +314,22 @@ async function getClusterQueue(queue: string): Promise<ClusterQueueTarget | null
     }
 
     for (const { node: cluster } of clusters.edges) {
-      const clusterQueue = cluster.queues.edges.find(({ node }) => node.key === queue)?.node;
-      if (clusterQueue) return { clusterId: cluster.id, queueId: clusterQueue.id };
+      for (const { node } of cluster.queues.edges) {
+        if (seenKeys.has(node.key)) continue;
+        seenKeys.add(node.key);
+        index.push({ key: node.key, clusterId: cluster.id, queueId: node.id });
+      }
 
       let queueAfter = cluster.queues.pageInfo.hasNextPage
         ? cluster.queues.pageInfo.endCursor
         : null;
       while (queueAfter) {
         const queues = await getClusterQueuePage(token, cluster.id, queueAfter);
-        const paginatedQueue = queues.edges.find(({ node }) => node.key === queue)?.node;
-        if (paginatedQueue) return { clusterId: cluster.id, queueId: paginatedQueue.id };
+        for (const { node } of queues.edges) {
+          if (seenKeys.has(node.key)) continue;
+          seenKeys.add(node.key);
+          index.push({ key: node.key, clusterId: cluster.id, queueId: node.id });
+        }
         queueAfter = queues.pageInfo.hasNextPage ? queues.pageInfo.endCursor : null;
       }
     }
@@ -307,13 +337,27 @@ async function getClusterQueue(queue: string): Promise<ClusterQueueTarget | null
     after = clusters.pageInfo.hasNextPage ? clusters.pageInfo.endCursor : null;
   } while (after);
 
-  return null;
+  return index;
 }
 
-async function graphqlQueueJobs(queue: string): Promise<QueueJob[]> {
+const getCachedClusterQueueIndex = unstable_cache(
+  async (organizationSlug: string) => fetchClusterQueueIndex(getToken(), organizationSlug),
+  ["buildkite-cluster-queue-index-v1"],
+  { revalidate: 60 * 60 },
+);
+
+async function getClusterQueue(queue: string): Promise<ClusterQueueTarget | null> {
+  const index = await getCachedClusterQueueIndex(organization());
+  const target = index.find((candidate) => candidate.key === queue);
+  return target ? { clusterId: target.clusterId, queueId: target.queueId } : null;
+}
+
+async function graphqlQueueJobs(
+  queue: string,
+  clusterQueue: ClusterQueueTarget | null,
+): Promise<QueueJob[]> {
   const token = getToken();
   const agentQueryRule = queueRule(queue);
-  const clusterQueue = await getClusterQueue(queue);
   const jobs: QueueJob[] = [];
   let after: string | null = null;
 
@@ -416,26 +460,9 @@ async function graphqlQueueJobs(queue: string): Promise<QueueJob[]> {
 }
 
 export async function getQueueJobs(queue: string): Promise<QueueJobsResult> {
-  const [jobs, snapshots] = await Promise.all([
-    graphqlQueueJobs(queue),
-    fetchBuildkiteQueueSnapshots(getToken(), organization()),
-  ]);
-  const snapshot = snapshots.find((candidate) => candidate.queue === queue);
-  return {
-    jobs,
-    waitingCount: snapshot?.waitingJobs ?? null,
-    metrics: {
-      polledAt: snapshot?.polledAt ?? new Date().toISOString(),
-      connectedAgents: snapshot?.connectedAgents ?? null,
-      runningJobs: snapshot?.runningJobs ?? null,
-      waitingJobs: snapshot?.waitingJobs ?? null,
-      p50WaitSecs: snapshot?.p50 ?? null,
-      p90WaitSecs: snapshot?.p90 ?? null,
-      p95WaitSecs: snapshot?.p95 ?? null,
-      p99WaitSecs: snapshot?.p99 ?? null,
-      waitSampleSize: snapshot?.sampleSize ?? 0,
-    },
-  };
+  queueRule(queue);
+  const clusterQueue = await getClusterQueue(queue);
+  return { jobs: await graphqlQueueJobs(queue, clusterQueue) };
 }
 
 export async function reprioritizeQueueJob(queue: string, jobUuid: string): Promise<{ priority: number }> {
@@ -443,7 +470,7 @@ export async function reprioritizeQueueJob(queue: string, jobUuid: string): Prom
     throw new BuildkiteQueueError("A valid job UUID is required.", 400, "INVALID_JOB");
   }
 
-  const jobs = await graphqlQueueJobs(queue);
+  const { jobs } = await getQueueJobs(queue);
   const job = jobs.find((candidate) => candidate.uuid === jobUuid);
   if (!job) {
     throw new BuildkiteQueueError(


### PR DESCRIPTION
## Why

Every `/api/queue/jobs` request was running both the queue-job query and a complete organization-wide queue metrics crawl. The Queue page therefore multiplied Buildkite GraphQL complexity usage by every viewer until the organization hit its 20,000-point budget, making waiting-job details return 502s.

## What changed

- keep queue cards and wait percentiles on the persisted five-minute metrics snapshot
- remove the full organization metrics crawl from the interactive jobs endpoint
- cache cluster/queue discovery for one hour
- return a safe 429 plus `Retry-After` when Buildkite reports complexity throttling
- keep the aggregate waiting count visible when individual job details are temporarily unavailable

## Validation

- `npx tsc --noEmit`
- focused ESLint on all five changed files
- `npm test` (9/9)
- `npm run build`
- `git diff --check`

Full-repository `npm run lint` still reports the pre-existing `prefer-const` error in `src/app/api/alerts/queue/route.ts:166`; this PR does not touch that file.