### PR TITLE
Alerts: brand icons for job names, Fast CI pagination

### DIFF
--- a/src/components/fast-ci-alerts.tsx
+++ b/src/components/fast-ci-alerts.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { NotificationBadge } from "@/components/alert-notification-badge";
+import { JobName } from "@/components/job-name";
 import { type FastFailureGroup } from "@/lib/alerts-fast-ci";
 import {
   commitUrl,
@@ -62,7 +64,7 @@ function GroupCard({ group }: { group: FastFailureGroup }) {
               rel="noreferrer"
               className="min-w-0 truncate text-blue-600 hover:underline dark:text-blue-400"
             >
-              {event.jobName}
+              <JobName name={event.jobName} />
             </a>
             <span className="shrink-0 text-xs font-medium text-red-600 dark:text-red-400">
               {event.state}
@@ -92,8 +94,15 @@ function GroupCard({ group }: { group: FastFailureGroup }) {
  * Fast Failure Events are immutable observations, so this view reports them and
  * their Slack notification state only. It deliberately exposes no resolution,
  * acknowledgement, or suppression controls.
+ *
+ * A busy week can produce hundreds of groups, so the list is paginated rather
+ * than rendered to the end.
  */
+const PAGE_SIZE = 10;
+
 export function FastCIAlerts({ groups }: { groups: FastFailureGroup[] }) {
+  const [page, setPage] = useState(0);
+
   if (groups.length === 0) {
     return (
       <div className="flex h-48 items-center justify-center rounded-xl border border-dashed border-zinc-300 text-sm text-zinc-400 dark:border-zinc-700">
@@ -102,11 +111,44 @@ export function FastCIAlerts({ groups }: { groups: FastFailureGroup[] }) {
     );
   }
 
+  const pageCount = Math.ceil(groups.length / PAGE_SIZE);
+  const currentPage = Math.min(page, pageCount - 1);
+  const pageGroups = groups.slice(
+    currentPage * PAGE_SIZE,
+    (currentPage + 1) * PAGE_SIZE,
+  );
+
   return (
     <div className="space-y-3">
-      {groups.map((group) => (
+      {pageGroups.map((group) => (
         <GroupCard key={group.key} group={group} />
       ))}
+      {pageCount > 1 && (
+        <div className="flex items-center justify-between text-xs text-zinc-500 dark:text-zinc-400">
+          <span>
+            Page {currentPage + 1} of {pageCount} · {groups.length}{" "}
+            {groups.length === 1 ? "group" : "groups"}
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={currentPage === 0}
+              onClick={() => setPage(currentPage - 1)}
+              className="dashboard-control rounded-full border border-zinc-300 px-3 py-1.5 font-semibold disabled:opacity-40 dark:border-zinc-700"
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              disabled={currentPage >= pageCount - 1}
+              onClick={() => setPage(currentPage + 1)}
+              className="dashboard-control rounded-full border border-zinc-300 px-3 py-1.5 font-semibold disabled:opacity-40 dark:border-zinc-700"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/full-ci-alerts.tsx
+++ b/src/components/full-ci-alerts.tsx
@@ -1,4 +1,5 @@
 import { NotificationBadge } from "@/components/alert-notification-badge";
+import { JobName } from "@/components/job-name";
 import {
   CAUSE_LABELS,
   LIFECYCLE_LABELS,
@@ -94,7 +95,7 @@ function ConditionRow({
     <li className="px-4 py-2.5 text-sm sm:px-5">
       <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
         <span className="min-w-0 truncate font-medium text-zinc-900 dark:text-zinc-100">
-          {condition.jobName}
+          <JobName name={condition.jobName} />
         </span>
         <span
           className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${LIFECYCLE_CLASSES[condition.lifecycle]}`}

--- a/src/components/job-name.test.ts
+++ b/src/components/job-name.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { splitJobName } from "./job-name";
+
+test("a known vendor shortcode becomes an icon segment", () => {
+  const segments = splitJobName(":nvidia: (H200) Language Models Shard 3");
+  assert.deepEqual(
+    segments.map((segment) => segment.type),
+    ["icon", "text"],
+  );
+  assert.equal(segments[0].type === "icon" && segments[0].icon.title, "NVIDIA");
+  assert.equal(
+    segments[1].type === "text" && segments[1].text,
+    "(H200) Language Models Shard 3",
+  );
+});
+
+test("amd and docker shortcodes resolve too, case-insensitively", () => {
+  for (const [code, title] of [
+    [":amd:", "AMD"],
+    [":AMD:", "AMD"],
+    [":docker:", "Docker"],
+  ] as const) {
+    const segments = splitJobName(`${code} build image`);
+    assert.equal(segments[0].type === "icon" && segments[0].icon.title, title);
+  }
+});
+
+test("an unknown shortcode is stripped, not shown literally", () => {
+  const segments = splitJobName(":tensorrt: engine build");
+  assert.deepEqual(segments, [{ type: "text", text: "engine build" }]);
+});
+
+test("a name without shortcodes passes through unchanged", () => {
+  assert.deepEqual(splitJobName("lint"), [{ type: "text", text: "lint" }]);
+});

--- a/src/components/job-name.tsx
+++ b/src/components/job-name.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+
+/**
+ * Buildkite job names carry custom emoji shortcodes (":nvidia: ..."), which
+ * render as raw text outside Buildkite. Known vendor shortcodes become inline
+ * brand icons (SVG paths from simple-icons, CC0); unknown shortcodes are
+ * stripped rather than shown literally.
+ */
+
+interface BrandIconDef {
+  title: string;
+  fill: string;
+  path: string;
+}
+
+const BRAND_ICONS: Record<string, BrandIconDef> = {
+  nvidia: {
+    title: "NVIDIA",
+    fill: "#76B900",
+    path: "M8.948 8.798v-1.43a6.7 6.7 0 0 1 .424-.018c3.922-.124 6.493 3.374 6.493 3.374s-2.774 3.851-5.75 3.851c-.398 0-.787-.062-1.158-.185v-4.346c1.528.185 1.837.857 2.747 2.385l2.04-1.714s-1.492-1.952-4-1.952a6.016 6.016 0 0 0-.796.035m0-4.735v2.138l.424-.027c5.45-.185 9.01 4.47 9.01 4.47s-4.08 4.964-8.33 4.964c-.37 0-.733-.035-1.095-.097v1.325c.3.035.61.062.91.062 3.957 0 6.82-2.023 9.593-4.408.459.371 2.34 1.263 2.73 1.652-2.633 2.208-8.772 3.984-12.253 3.984-.335 0-.653-.018-.971-.053v1.864H24V4.063zm0 10.326v1.131c-3.657-.654-4.673-4.46-4.673-4.46s1.758-1.944 4.673-2.262v1.237H8.94c-1.528-.186-2.73 1.245-2.73 1.245s.68 2.412 2.739 3.11M2.456 10.9s2.164-3.197 6.5-3.533V6.201C4.153 6.59 0 10.653 0 10.653s2.35 6.802 8.948 7.42v-1.237c-4.84-.6-6.492-5.936-6.492-5.936z",
+  },
+  amd: {
+    title: "AMD",
+    fill: "#ED1C24",
+    path: "M18.324 9.137l1.559 1.56h2.556v2.557L24 14.814V9.137zM2 9.52l-2 4.96h1.309l.37-.982H3.9l.408.982h1.338L3.432 9.52zm4.209 0v4.955h1.238v-3.092l1.338 1.562h.188l1.338-1.556v3.091h1.238V9.52H10.47l-1.592 1.845L7.287 9.52zm6.283 0v4.96h2.057c1.979 0 2.88-1.046 2.88-2.472 0-1.36-.937-2.488-2.747-2.488zm1.237.91h.792c1.17 0 1.63.711 1.63 1.57 0 .728-.372 1.572-1.616 1.572h-.806zm-10.985.273l.791 1.932H2.008zm17.137.307l-1.604 1.603v2.25h2.246l1.604-1.607h-2.246z",
+  },
+  docker: {
+    title: "Docker",
+    fill: "#2496ED",
+    path: "M13.983 11.078h2.119a.186.186 0 00.186-.185V9.006a.186.186 0 00-.186-.186h-2.119a.185.185 0 00-.185.185v1.888c0 .102.083.185.185.185m-2.954-5.43h2.118a.186.186 0 00.186-.186V3.574a.186.186 0 00-.186-.185h-2.118a.185.185 0 00-.185.185v1.888c0 .102.082.185.185.185m0 2.716h2.118a.187.187 0 00.186-.186V6.29a.186.186 0 00-.186-.185h-2.118a.185.185 0 00-.185.185v1.887c0 .102.082.185.185.186m-2.93 0h2.12a.186.186 0 00.184-.186V6.29a.185.185 0 00-.185-.185H8.1a.185.185 0 00-.185.185v1.887c0 .102.083.185.185.186m-2.964 0h2.119a.186.186 0 00.185-.186V6.29a.185.185 0 00-.185-.185H5.136a.186.186 0 00-.186.185v1.887c0 .102.084.185.186.186m5.893 2.715h2.118a.186.186 0 00.186-.185V9.006a.186.186 0 00-.186-.186h-2.118a.185.185 0 00-.185.185v1.888c0 .102.082.185.185.185m-2.93 0h2.12a.185.185 0 00.184-.185V9.006a.185.185 0 00-.184-.186h-2.12a.185.185 0 00-.184.185v1.888c0 .102.083.185.185.185m-2.964 0h2.119a.185.185 0 00.185-.185V9.006a.185.185 0 00-.184-.186h-2.12a.186.186 0 00-.186.186v1.887c0 .102.084.185.186.185m-2.92 0h2.12a.185.185 0 00.184-.185V9.006a.185.185 0 00-.184-.186h-2.12a.185.185 0 00-.184.185v1.888c0 .102.082.185.185.185M23.763 9.89c-.065-.051-.672-.51-1.954-.51-.338.001-.676.03-1.01.087-.248-1.7-1.653-2.53-1.716-2.566l-.344-.199-.226.327c-.284.438-.49.922-.612 1.43-.23.97-.09 1.882.403 2.661-.595.332-1.55.413-1.744.42H.751a.751.751 0 00-.75.748 11.376 11.376 0 00.692 4.062c.545 1.428 1.355 2.48 2.41 3.124 1.18.723 3.1 1.137 5.275 1.137.983.003 1.963-.086 2.93-.266a12.248 12.248 0 003.823-1.389c.98-.567 1.86-1.288 2.61-2.136 1.252-1.418 1.998-2.997 2.553-4.4h.221c1.372 0 2.215-.549 2.68-1.009.309-.293.55-.65.707-1.046l.098-.288Z",
+  },
+};
+
+export type JobNameSegment =
+  | { type: "text"; text: string }
+  | { type: "icon"; icon: BrandIconDef };
+
+/** Split a job name into text and icon segments; unknown shortcodes vanish. */
+export function splitJobName(name: string): JobNameSegment[] {
+  const segments: JobNameSegment[] = [];
+  const parts = name.split(/:([a-z0-9_+-]+):/gi);
+  let afterIcon = false;
+  for (let index = 0; index < parts.length; index++) {
+    if (index % 2 === 0) {
+      let text = parts[index];
+      if (afterIcon) text = text.replace(/^\s+/, "");
+      if (text) segments.push({ type: "text", text });
+      afterIcon = false;
+    } else {
+      const icon = BRAND_ICONS[parts[index].toLowerCase()];
+      if (icon) segments.push({ type: "icon", icon });
+      // A consumed shortcode always swallows the space that followed it.
+      afterIcon = true;
+    }
+  }
+  return segments;
+}
+
+export function JobName({ name }: { name: string }) {
+  const nodes: ReactNode[] = splitJobName(name).map((segment, index) =>
+    segment.type === "text" ? (
+      segment.text
+    ) : (
+      <svg
+        key={index}
+        role="img"
+        aria-label={segment.icon.title}
+        viewBox="0 0 24 24"
+        fill={segment.icon.fill}
+        className="mr-1 inline-block h-3.5 w-3.5 align-[-0.15em]"
+      >
+        <path d={segment.icon.path} />
+      </svg>
+    ),
+  );
+  return <>{nodes}</>;
+}


### PR DESCRIPTION
## Summary

Follow-up to #77.

- Job names carrying Buildkite emoji shortcodes (`:nvidia:`, `:amd:`, `:docker:`) now render inline brand SVG icons (vendored from simple-icons, CC0) instead of raw shortcode text; unknown shortcodes are stripped. Applied to Fast CI job links and Full CI condition rows on the alerts page.
- Fast CI alert groups paginate client-side at 10 per page with Previous/Next controls; page index clamps when the time-window filter shrinks the list.

## Test plan
- 47/47 frontend tsx tests pass (4 new for the shortcode splitter)
- `tsc --noEmit`, eslint, and `next build` clean