### PR TITLE
Replace Claude Code analyzer runner with Kimi K3 API loop

### DIFF
--- a/alerting/README.md
+++ b/alerting/README.md
@@ -44,15 +44,21 @@ repository-level relationship with the dashboard is recorded in
   job-outcome records, and chronological reconciliation handler. Analyzer
   invocation remains outside this ingest-only slice.
 - `analyzer.py` — the Full CI analyzer compatibility adapter. It materializes
-  the working files the unchanged analyzer skill expects (summary, full build
-  data, previous-failure cache, agent memory hydrated from the latest
-  referenced S3 checkpoint), invokes the skill non-interactively, validates
-  its outputs, uploads a new immutable versioned checkpoint, and commits the
-  classifications, PR attribution, rendered report, checkpoint reference, and
-  Slack notification intent in one Postgres transaction per comparison. A
-  fixed classification is persisted only for a positively observed pass, and
-  fixing-PR attribution only for a verified merged revert. Any failure leaves
-  the previous baseline authoritative and finalizes no outbox row.
+  the working files the bundled analyzer instructions expect (summary, full
+  build data, previous-failure cache, agent memory hydrated from the latest
+  referenced S3 checkpoint), invokes the analyzer runner non-interactively,
+  validates its outputs, uploads a new immutable versioned checkpoint, and
+  commits the classifications, PR attribution, rendered report, checkpoint
+  reference, and Slack notification intent in one Postgres transaction per
+  comparison. A fixed classification is persisted only for a positively
+  observed pass, and fixing-PR attribution only for a verified merged revert.
+  Any failure leaves the previous baseline authoritative and finalizes no
+  outbox row.
+- `kimi.py` — the analyzer runner backed by the Kimi chat-completions API. It
+  runs the bundled analyzer instructions as the system message and drives an
+  OpenAI-compatible tool-calling loop whose file tools are sandboxed to the
+  materialized working directory; the shell tool only executes `curl`, so
+  credentials stay in the server-side environment.
 - `migration.py` — the read-only-by-default one-time cutover importer for the
   legacy Full CI cache, last-reported build state, analyzer memory, and Fast CI
   SQLite deduplication keys.
@@ -138,6 +144,6 @@ enabling the new path, and preserves Postgres and S3 baselines on rollback.
 cd alerting
 uv sync --extra dev
 uv run pytest
-uv run mypy __init__.py analyzer.py commands.py control.py cutover.py fast_ci.py full_ci.py memory.py migration.py ports.py postgres.py runtime.py slack.py worker.py tests
+uv run mypy __init__.py analyzer.py commands.py control.py cutover.py fast_ci.py full_ci.py kimi.py memory.py migration.py ports.py postgres.py runtime.py slack.py worker.py tests
 uv run ruff check .
 ```

--- a/alerting/__init__.py
+++ b/alerting/__init__.py
@@ -9,7 +9,6 @@ from alerting.analyzer import (
     AnalyzerError,
     CauseCategory,
     CheckpointRef,
-    ClaudeCodeRunner,
     ComparisonContext,
     CompletedAnalysis,
     FailureCache,
@@ -41,6 +40,7 @@ from alerting.full_ci import (
     FullCIReconciliationState,
     FullCIRun,
 )
+from alerting.kimi import KimiCodeRunner
 from alerting.ports import (
     ClaimOutcome,
     DestinationMode,
@@ -75,7 +75,6 @@ __all__ = [
     "CauseCategory",
     "CheckpointRef",
     "ClaimOutcome",
-    "ClaudeCodeRunner",
     "ScheduledCommand",
     "BuildkiteFullCISource",
     "BuildkiteRestClient",
@@ -101,6 +100,7 @@ __all__ = [
     "FullCIRun",
     "GitHubRestClient",
     "HandlerCompletion",
+    "KimiCodeRunner",
     "NotificationIntent",
     "NotificationIntentRecord",
     "OutboxStatus",

--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -37,6 +37,7 @@ from typing import Any, Protocol, cast
 from zoneinfo import ZoneInfo
 
 from alerting.commands import ScheduledCommand, SCHEMA_VERSION
+from alerting.fast_ci import FAST_CI_SLACK_CHANNEL
 from alerting.full_ci import FullCIJobOutcome, FullCIRun
 from alerting.ports import (
     AlertPath,
@@ -48,7 +49,9 @@ from alerting.ports import (
 
 COMPLETENESS_THRESHOLD = 0.95
 REPORT_CHAR_LIMIT = 2800
-FULL_CI_SLACK_DESTINATION = "vllm-ci"
+# Full CI reports post through the Slack bot token to the same channel Fast CI
+# uses; no separate webhook destination.
+FULL_CI_SLACK_DESTINATION = FAST_CI_SLACK_CHANNEL
 CHECKPOINT_SCHEMA_VERSION = SCHEMA_VERSION
 PACIFIC = ZoneInfo("America/Los_Angeles")
 
@@ -624,7 +627,7 @@ class FullCIAnalysisHandler:
                     alert_ref=f"full-ci-comparison:{context.current.build_id}",
                     alert_path=AlertPath.FULL_CI,
                     delivery_mode=self._delivery_mode,
-                    destination_mode=DestinationMode.WEBHOOK,
+                    destination_mode=DestinationMode.BOT_TOKEN,
                     destination=FULL_CI_SLACK_DESTINATION,
                     payload={"text": outputs.report_text},
                 ),

--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -1,8 +1,9 @@
 """Full CI analyzer compatibility adapter.
 
-The existing Claude-based analyzer skill is invoked unchanged behind this
-adapter. Before analysis the adapter materializes the working files the skill
-expects (`.logs/nightly_summary.json`, `.logs/nightly_full.json`,
+The bundled analyzer instructions run behind this adapter through an
+`AnalyzerRunner` (see `alerting.kimi`). Before analysis the adapter
+materializes the working files the instructions
+expect (`.logs/nightly_summary.json`, `.logs/nightly_full.json`,
 `.logs/failed_tests_cache.json`, and the agent-memory directory) from Postgres,
 Buildkite, and the latest referenced S3 checkpoint. After analysis it validates
 the skill's outputs, uploads a new immutable checkpoint, and transactionally
@@ -22,7 +23,6 @@ import io
 import importlib.resources
 import json
 import re
-import subprocess
 import tarfile
 import tempfile
 import urllib.error
@@ -64,20 +64,6 @@ SUSPICIOUS_PRS_FILE = Path(".logs/suspicious_prs.json")
 SUMMARY_FILE = Path(".logs/nightly_summary.json")
 FULL_BUILD_FILE = Path(".logs/nightly_full.json")
 ANALYZER_AGENT_FILE = Path(".claude/agents/vllm-ci-failure-analyzer.md")
-
-DEFAULT_ANALYZER_PROMPT = (
-    "Use the Task tool to invoke the vllm-ci-failure-analyzer agent with "
-    'subagent_type "vllm-ci-failure-analyzer" and prompt: "Run CI failure '
-    "analysis. Read .logs/nightly_summary.json and execute all phases (A "
-    "through D). Credentials are available only through the environment; "
-    "never include their values in prompts or files. "
-    "The full build JSON is at .logs/nightly_full.json for job ID lookups. "
-    'REVERT_THRESHOLD is available in the environment (default 1)." Wait for '
-    "it to complete, then verify .logs/ci_report.txt was written. If it "
-    'contains "SKIP", that is fine. Otherwise verify with '
-    "`jq -Rs 'length' .logs/ci_report.txt` that the report is at most 2800 "
-    "characters; ask the agent to compact it before returning if it is longer."
-)
 
 
 class AnalyzerError(Exception):
@@ -195,10 +181,10 @@ class FullCIBuildPort(Protocol):
 
 
 class AnalyzerRunner(Protocol):
-    """Runs the existing analyzer skill in a prepared working directory."""
+    """Runs the analyzer instructions in a prepared working directory."""
 
     def run(self, working_dir: Path) -> None:
-        """Raise AnalyzerError on any LLM or subprocess failure."""
+        """Raise AnalyzerError on any LLM failure."""
         ...
 
 
@@ -760,45 +746,6 @@ class FullCIAnalysisHandler:
             summary="passed without a verified cause",
             culprit_pr=prior.culprit_pr if prior is not None else None,
         )
-
-
-class ClaudeCodeRunner:
-    """Invokes the unchanged analyzer skill through the Claude CLI."""
-
-    def __init__(
-        self,
-        *,
-        binary: str = "claude",
-        prompt: str = DEFAULT_ANALYZER_PROMPT,
-        timeout_seconds: int = 1200,
-    ) -> None:
-        self._binary = binary
-        self._prompt = prompt
-        self._timeout_seconds = timeout_seconds
-
-    def run(self, working_dir: Path) -> None:
-        try:
-            completed = subprocess.run(
-                [
-                    self._binary,
-                    "-p",
-                    self._prompt,
-                    "--allowedTools",
-                    "Read,Write,Edit,Glob,Grep,Task,Bash(curl:*)",
-                ],
-                cwd=working_dir,
-                capture_output=True,
-                text=True,
-                timeout=self._timeout_seconds,
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
-            raise AnalyzerError(f"analyzer invocation failed: {exc}") from exc
-        if completed.returncode != 0:
-            tail = (completed.stderr or completed.stdout or "")[-1000:]
-            raise AnalyzerError(
-                f"analyzer exited with status {completed.returncode}: {tail}"
-            )
 
 
 class GitHubRestClient:

--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -572,11 +572,16 @@ class FullCIAnalysisHandler:
         )
         checkpoint = self._store.latest_checkpoint()
         if checkpoint is None:
-            raise AnalyzerError("no analyzer checkpoint is referenced")
-        blob = self._checkpoints.download(checkpoint.s3_uri)
-        if hashlib.sha256(blob).hexdigest() != checkpoint.sha256:
-            raise AnalyzerError(f"checkpoint checksum mismatch for {checkpoint.s3_uri}")
-        memory_files = unpack_checkpoint(blob)
+            # First-ever analysis has no durable memory yet; it starts empty
+            # and its own commit uploads the initial checkpoint.
+            memory_files: dict[str, bytes] = {}
+        else:
+            blob = self._checkpoints.download(checkpoint.s3_uri)
+            if hashlib.sha256(blob).hexdigest() != checkpoint.sha256:
+                raise AnalyzerError(
+                    f"checkpoint checksum mismatch for {checkpoint.s3_uri}"
+                )
+            memory_files = unpack_checkpoint(blob)
 
         commit_sha = str(build.get("commit") or context.current.commit_sha)
         with tempfile.TemporaryDirectory(prefix="full-ci-analysis-") as tmp:

--- a/alerting/full_ci.py
+++ b/alerting/full_ci.py
@@ -8,12 +8,16 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Protocol, cast
 
 from alerting.commands import ScheduledCommand
 from alerting.ports import Clock
 from alerting.runtime import HandlerCompletion
+
+# First-ever reconciliation has no durable run to anchor a fetch window; two
+# days of runs is what an incident responder needs, not the pipeline's history.
+INITIAL_LOOKBACK = timedelta(days=2)
 
 
 @dataclass(frozen=True)
@@ -264,8 +268,11 @@ class FullCIReconciliationHandler:
 
     def __call__(self, command: ScheduledCommand) -> HandlerCompletion:
         state = self._store.reconciliation_state()
+        start_time = state.start_time
+        if start_time is None:
+            start_time = command.target_time - INITIAL_LOOKBACK
         observations = self._source.fetch_runs(
-            start_time=state.start_time,
+            start_time=start_time,
             processed_build_ids=state.processed_build_ids,
             up_to=command.target_time,
         )

--- a/alerting/kimi.py
+++ b/alerting/kimi.py
@@ -37,13 +37,43 @@ KIMI_ANALYZER_PROMPT = (
     "available in the environment (default 1)."
 )
 
-READ_CHAR_LIMIT = 100_000
+READ_CHAR_LIMIT = 40_000
 GLOB_RESULT_LIMIT = 200
 GREP_RESULT_LIMIT = 200
-BASH_OUTPUT_LIMIT = 200_000
+BASH_OUTPUT_LIMIT = 40_000
 BASH_TIMEOUT_SECONDS = 60
 TASK_RESULT_LIMIT = 50_000
 REQUEST_TIMEOUT_SECONDS = 300.0
+# The inferact endpoint counts unset output budget as zero and rejects the
+# request when the prompt alone approaches the context window.
+MAX_OUTPUT_TOKENS = 16_384
+
+# Rough budget for the running conversation: ~4 chars per token against a
+# 1M-token context, minus headroom for system prompt, tools, and output.
+# When exceeded, the oldest tool outputs are elided (pairing with their
+# tool_calls stays intact; only the bulky content goes).
+HISTORY_CHAR_BUDGET = 1_500_000
+_ELIDED = "(older tool output elided to fit the context window)"
+
+
+def _prune_history(messages: list[dict[str, Any]]) -> None:
+    def total_chars() -> int:
+        return sum(len(str(message.get("content") or "")) for message in messages)
+
+    total = total_chars()
+    if total <= HISTORY_CHAR_BUDGET:
+        return
+    for message in messages[2:]:  # system and user prompt always stay
+        if total <= HISTORY_CHAR_BUDGET:
+            return
+        content = message.get("content")
+        if (
+            message.get("role") == "tool"
+            and isinstance(content, str)
+            and len(content) > len(_ELIDED)
+        ):
+            total -= len(content) - len(_ELIDED)
+            message["content"] = _ELIDED
 
 Transport = Callable[[str, dict[str, str], dict[str, Any]], dict[str, Any]]
 
@@ -240,6 +270,7 @@ class KimiCodeRunner:
                         ),
                     }
                 )
+            _prune_history(messages)
         raise AnalyzerError(f"kimi analyzer exceeded {self._max_turns} turns")
 
     def _complete(
@@ -250,6 +281,7 @@ class KimiCodeRunner:
             "messages": messages,
             "tools": tools,
             "tool_choice": "auto",
+            "max_tokens": MAX_OUTPUT_TOKENS,
         }
         response = self._transport(
             f"{self._base_url}/chat/completions",
@@ -453,5 +485,6 @@ def _tool_bash(workdir: Path, command: str) -> str:
         return f"error: command failed: {exc}"
     output = (completed.stdout or "") + (completed.stderr or "")
     if len(output) > BASH_OUTPUT_LIMIT:
-        output = output[:BASH_OUTPUT_LIMIT] + "\n... (truncated)"
+        # Buildkite logs put the failure at the end; keep the tail.
+        output = "... (truncated)\n" + output[-BASH_OUTPUT_LIMIT:]
     return f"exit {completed.returncode}\n{output}"

--- a/alerting/kimi.py
+++ b/alerting/kimi.py
@@ -215,6 +215,7 @@ class KimiCodeRunner:
         model: str = "moonshotai/Kimi-K3",
         timeout_seconds: int = 3600,
         max_turns: int = 200,
+        reasoning_effort: str = "low",
         transport: Transport | None = None,
         clock: Callable[[], float] | None = None,
     ) -> None:
@@ -223,6 +224,7 @@ class KimiCodeRunner:
         self._model = model
         self._timeout_seconds = timeout_seconds
         self._max_turns = max_turns
+        self._reasoning_effort = reasoning_effort
         self._transport = transport or UrllibTransport()
         self._clock = clock or time.monotonic
 
@@ -282,6 +284,9 @@ class KimiCodeRunner:
             "tools": tools,
             "tool_choice": "auto",
             "max_tokens": MAX_OUTPUT_TOKENS,
+            # Log triage is mechanical; low thinking effort keeps the many
+            # sequential investigation calls fast enough for the time budget.
+            "reasoning_effort": self._reasoning_effort,
         }
         response = self._transport(
             f"{self._base_url}/chat/completions",

--- a/alerting/kimi.py
+++ b/alerting/kimi.py
@@ -213,7 +213,7 @@ class KimiCodeRunner:
         api_key: str,
         base_url: str = "https://api2.inferact.dev/v1",
         model: str = "moonshotai/Kimi-K3",
-        timeout_seconds: int = 1200,
+        timeout_seconds: int = 3600,
         max_turns: int = 200,
         transport: Transport | None = None,
         clock: Callable[[], float] | None = None,

--- a/alerting/kimi.py
+++ b/alerting/kimi.py
@@ -1,0 +1,457 @@
+"""Full CI analyzer runner backed by the Kimi K3 chat-completions API.
+
+`KimiCodeRunner` replaces the Claude Code CLI invocation: it runs the bundled
+analyzer instructions (`assets/vllm-ci-failure-analyzer.md`, frontmatter
+stripped) as the system message and drives an OpenAI-compatible tool-calling
+loop. File tools are sandboxed to the materialized working directory and the
+shell tool only executes `curl`, so credentials stay in the server-side
+environment. Tool failures are returned to the model as tool messages so it
+can recover; only transport failures, turn exhaustion, or the overall time
+budget raise `AnalyzerError`, which leaves the previous baseline authoritative.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import json
+import re
+import shlex
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+from alerting.analyzer import AnalyzerError
+
+KIMI_ANALYZER_PROMPT = (
+    "Run CI failure analysis. Read .logs/nightly_summary.json and execute "
+    "all phases (A through D) from the instructions. Read "
+    ".logs/nightly_full.json only for Buildkite job ID lookups. Write "
+    ".logs/ci_report.txt and keep it at or below 2800 characters, and update "
+    ".logs/failed_tests_cache.json and .logs/suspicious_prs.json. "
+    "Credentials are available only through the environment; never include "
+    "their values in prompts, files, or output. REVERT_THRESHOLD is "
+    "available in the environment (default 1)."
+)
+
+READ_CHAR_LIMIT = 100_000
+GLOB_RESULT_LIMIT = 200
+GREP_RESULT_LIMIT = 200
+BASH_OUTPUT_LIMIT = 200_000
+BASH_TIMEOUT_SECONDS = 60
+TASK_RESULT_LIMIT = 50_000
+REQUEST_TIMEOUT_SECONDS = 300.0
+
+Transport = Callable[[str, dict[str, str], dict[str, Any]], dict[str, Any]]
+
+_STRING = {"type": "string"}
+_TOOLS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "Read",
+            "description": "Read a UTF-8 text file inside the working directory.",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": _STRING},
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Write",
+            "description": "Write a file inside the working directory.",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": _STRING, "content": _STRING},
+                "required": ["path", "content"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Edit",
+            "description": "Replace one exact unique string in a file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": _STRING,
+                    "old_string": _STRING,
+                    "new_string": _STRING,
+                },
+                "required": ["path", "old_string", "new_string"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Glob",
+            "description": "List files under the working directory by pattern.",
+            "parameters": {
+                "type": "object",
+                "properties": {"pattern": _STRING},
+                "required": ["pattern"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Grep",
+            "description": "Regex-search files under the working directory.",
+            "parameters": {
+                "type": "object",
+                "properties": {"pattern": _STRING, "path": _STRING},
+                "required": ["pattern"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Bash",
+            "description": "Run a curl command; all other commands are rejected.",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": _STRING},
+                "required": ["command"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Task",
+            "description": (
+                "Run a nested read-only investigation with the same tools "
+                "and return its final text."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {"prompt": _STRING},
+                "required": ["prompt"],
+            },
+        },
+    },
+]
+_TASK_TOOLS = [tool for tool in _TOOLS if tool["function"]["name"] != "Task"]
+
+
+class UrllibTransport:
+    """JSON POST transport for the Kimi API using Python's standard library."""
+
+    def __init__(self, *, timeout_seconds: float = REQUEST_TIMEOUT_SECONDS) -> None:
+        self._timeout_seconds = timeout_seconds
+
+    def __call__(
+        self, url: str, headers: dict[str, str], payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        request = urllib.request.Request(
+            url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self._timeout_seconds) as resp:
+                result: Any = json.load(resp)
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise AnalyzerError(
+                f"kimi API request failed with HTTP {exc.code}: {body[:1000]}"
+            ) from exc
+        except (OSError, TimeoutError, json.JSONDecodeError) as exc:
+            raise AnalyzerError(f"kimi API request failed: {exc}") from exc
+        if not isinstance(result, dict):
+            raise AnalyzerError("kimi API returned a malformed response")
+        return result
+
+
+class KimiCodeRunner:
+    """Runs the analyzer instructions through the Kimi tool-calling API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = "https://api2.inferact.dev/v1",
+        model: str = "kimi-k3",
+        timeout_seconds: int = 1200,
+        max_turns: int = 200,
+        transport: Transport | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+        self._timeout_seconds = timeout_seconds
+        self._max_turns = max_turns
+        self._transport = transport or UrllibTransport()
+        self._clock = clock or time.monotonic
+
+    def run(self, working_dir: Path) -> None:
+        workdir = working_dir.resolve()
+        deadline = self._clock() + self._timeout_seconds
+        self._loop(
+            workdir,
+            _load_system_prompt(),
+            KIMI_ANALYZER_PROMPT,
+            deadline,
+            allow_task=True,
+        )
+
+    def _loop(
+        self,
+        workdir: Path,
+        system: str,
+        prompt: str,
+        deadline: float,
+        *,
+        allow_task: bool,
+    ) -> str:
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": prompt},
+        ]
+        tools = _TOOLS if allow_task else _TASK_TOOLS
+        for _ in range(self._max_turns):
+            if self._clock() >= deadline:
+                raise AnalyzerError("kimi analyzer exceeded its time budget")
+            message = self._complete(messages, tools)
+            messages.append(message)
+            calls = message.get("tool_calls")
+            if not calls:
+                content = message.get("content")
+                return content if isinstance(content, str) else ""
+            for call in cast(list[dict[str, Any]], calls):
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": str(call.get("id") or ""),
+                        "content": self._execute(
+                            call, workdir, system, deadline, allow_task=allow_task
+                        ),
+                    }
+                )
+        raise AnalyzerError(f"kimi analyzer exceeded {self._max_turns} turns")
+
+    def _complete(
+        self, messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "messages": messages,
+            "tools": tools,
+            "tool_choice": "auto",
+        }
+        response = self._transport(
+            f"{self._base_url}/chat/completions",
+            {
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+            payload,
+        )
+        try:
+            message = cast(list[dict[str, Any]], response["choices"])[0]["message"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise AnalyzerError("kimi API returned a malformed response") from exc
+        if not isinstance(message, dict):
+            raise AnalyzerError("kimi API returned a malformed response")
+        return cast(dict[str, Any], message)
+
+    def _execute(
+        self,
+        call: dict[str, Any],
+        workdir: Path,
+        system: str,
+        deadline: float,
+        *,
+        allow_task: bool,
+    ) -> str:
+        function = cast(dict[str, Any], call.get("function") or {})
+        name = str(function.get("name") or "")
+        raw_arguments = function.get("arguments")
+        try:
+            arguments = json.loads(
+                raw_arguments if isinstance(raw_arguments, str) else "{}"
+            )
+        except json.JSONDecodeError:
+            return "error: invalid tool arguments"
+        if not isinstance(arguments, dict):
+            return "error: invalid tool arguments"
+        argument_map = cast(dict[str, Any], arguments)
+        try:
+            if name == "Read":
+                return _tool_read(workdir, str(argument_map.get("path") or ""))
+            if name == "Write":
+                return _tool_write(
+                    workdir,
+                    str(argument_map.get("path") or ""),
+                    str(argument_map.get("content") or ""),
+                )
+            if name == "Edit":
+                return _tool_edit(
+                    workdir,
+                    str(argument_map.get("path") or ""),
+                    str(argument_map.get("old_string") or ""),
+                    str(argument_map.get("new_string") or ""),
+                )
+            if name == "Glob":
+                return _tool_glob(workdir, str(argument_map.get("pattern") or ""))
+            if name == "Grep":
+                return _tool_grep(
+                    workdir,
+                    str(argument_map.get("pattern") or ""),
+                    str(argument_map.get("path") or ""),
+                )
+            if name == "Bash":
+                return _tool_bash(workdir, str(argument_map.get("command") or ""))
+            if name == "Task":
+                if not allow_task:
+                    return "error: nested Task calls are not allowed"
+                result = self._loop(
+                    workdir,
+                    system,
+                    str(argument_map.get("prompt") or ""),
+                    deadline,
+                    allow_task=False,
+                )
+                if len(result) > TASK_RESULT_LIMIT:
+                    return result[:TASK_RESULT_LIMIT] + "\n... (truncated)"
+                return result
+            return f"error: unknown tool: {name}"
+        except (OSError, ValueError) as exc:
+            return f"error: {exc}"
+
+
+def _load_system_prompt() -> str:
+    text = (
+        importlib.resources.files("alerting")
+        .joinpath("assets/vllm-ci-failure-analyzer.md")
+        .read_text(encoding="utf-8")
+    )
+    if text.startswith("---\n"):
+        end = text.find("\n---", 4)
+        if end != -1:
+            text = text[end + 4 :].lstrip("\n")
+    return text
+
+
+def _resolve(workdir: Path, path: str) -> Path:
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        candidate = workdir / candidate
+    resolved = candidate.resolve()
+    if resolved != workdir and workdir not in resolved.parents:
+        raise ValueError(f"path escapes the working directory: {path}")
+    return resolved
+
+
+def _tool_read(workdir: Path, path: str) -> str:
+    target = _resolve(workdir, path)
+    if not target.is_file():
+        return f"error: no such file: {path}"
+    text = target.read_text(encoding="utf-8", errors="replace")
+    if len(text) > READ_CHAR_LIMIT:
+        return text[:READ_CHAR_LIMIT] + "\n... (truncated)"
+    return text
+
+
+def _tool_write(workdir: Path, path: str, content: str) -> str:
+    target = _resolve(workdir, path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    return f"wrote {target.relative_to(workdir)}"
+
+
+def _tool_edit(workdir: Path, path: str, old_string: str, new_string: str) -> str:
+    target = _resolve(workdir, path)
+    if not target.is_file():
+        return f"error: no such file: {path}"
+    text = target.read_text(encoding="utf-8", errors="replace")
+    occurrences = text.count(old_string)
+    if occurrences == 0:
+        return "error: old_string not found"
+    if occurrences > 1:
+        return f"error: old_string is ambiguous ({occurrences} occurrences)"
+    target.write_text(text.replace(old_string, new_string, 1), encoding="utf-8")
+    return f"edited {target.relative_to(workdir)}"
+
+
+def _tool_glob(workdir: Path, pattern: str) -> str:
+    parts = Path(pattern).parts
+    if Path(pattern).is_absolute() or ".." in parts:
+        return f"error: pattern escapes the working directory: {pattern}"
+    try:
+        matches = sorted(
+            entry.relative_to(workdir).as_posix() for entry in workdir.glob(pattern)
+        )
+    except (ValueError, OSError) as exc:
+        return f"error: invalid pattern: {exc}"
+    if not matches:
+        return "no matches"
+    if len(matches) > GLOB_RESULT_LIMIT:
+        shown = matches[:GLOB_RESULT_LIMIT]
+        return "\n".join(shown) + f"\n... ({len(matches) - GLOB_RESULT_LIMIT} more)"
+    return "\n".join(matches)
+
+
+def _tool_grep(workdir: Path, pattern: str, path: str) -> str:
+    try:
+        regex = re.compile(pattern)
+    except re.error as exc:
+        return f"error: invalid regex: {exc}"
+    root = _resolve(workdir, path) if path else workdir
+    if root.is_file():
+        files = [root]
+    else:
+        try:
+            files = sorted(entry for entry in root.rglob("*") if entry.is_file())
+        except OSError as exc:
+            return f"error: cannot search path: {exc}"
+    results: list[str] = []
+    for entry in files:
+        try:
+            text = entry.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if regex.search(line):
+                results.append(f"{entry.relative_to(workdir)}:{lineno}:{line}")
+                if len(results) >= GREP_RESULT_LIMIT:
+                    return "\n".join(results) + "\n... (truncated)"
+    return "\n".join(results) if results else "no matches"
+
+
+def _tool_bash(workdir: Path, command: str) -> str:
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        return f"error: cannot parse command: {exc}"
+    if not tokens or tokens[0] != "curl":
+        return "error: only curl commands are allowed"
+    try:
+        completed = subprocess.run(
+            tokens,
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=BASH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return "error: command timed out"
+    except OSError as exc:
+        return f"error: command failed: {exc}"
+    output = (completed.stdout or "") + (completed.stderr or "")
+    if len(output) > BASH_OUTPUT_LIMIT:
+        output = output[:BASH_OUTPUT_LIMIT] + "\n... (truncated)"
+    return f"exit {completed.returncode}\n{output}"

--- a/alerting/kimi.py
+++ b/alerting/kimi.py
@@ -182,7 +182,7 @@ class KimiCodeRunner:
         *,
         api_key: str,
         base_url: str = "https://api2.inferact.dev/v1",
-        model: str = "kimi-k3",
+        model: str = "moonshotai/Kimi-K3",
         timeout_seconds: int = 1200,
         max_turns: int = 200,
         transport: Transport | None = None,

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -1204,25 +1204,32 @@ def build_full_ci_analysis_runtime(
     buildkite_token: str,
     github_token: str,
     checkpoint_bucket: str,
+    kimi_api_key: str,
     slack: SlackPort,
     clock: Clock,
     runner: AnalyzerRunner | None = None,
+    kimi_base_url: str = "https://api2.inferact.dev/v1",
+    kimi_model: str = "kimi-k3",
     delivery_mode: DeliveryMode = DeliveryMode.LIVE,
 ) -> AlertingRuntime:
     """Wire the production analyzer compatibility adapter into the runtime."""
     from alerting.analyzer import (
-        ClaudeCodeRunner,
         FullCIAnalysisHandler,
         GitHubRestClient,
         S3CheckpointStore,
     )
     from alerting.full_ci import BuildkiteRestClient
+    from alerting.kimi import KimiCodeRunner
 
     store = PostgresAlertStore.from_database_url(database_url)
     handler = FullCIAnalysisHandler(
         store=store,
         builds=BuildkiteRestClient(token=buildkite_token),
-        runner=runner if runner is not None else ClaudeCodeRunner(),
+        runner=runner
+        if runner is not None
+        else KimiCodeRunner(
+            api_key=kimi_api_key, base_url=kimi_base_url, model=kimi_model
+        ),
         checkpoints=S3CheckpointStore(bucket=checkpoint_bucket),
         github=GitHubRestClient(token=github_token),
         clock=clock,

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -1209,7 +1209,7 @@ def build_full_ci_analysis_runtime(
     clock: Clock,
     runner: AnalyzerRunner | None = None,
     kimi_base_url: str = "https://api2.inferact.dev/v1",
-    kimi_model: str = "kimi-k3",
+    kimi_model: str = "moonshotai/Kimi-K3",
     delivery_mode: DeliveryMode = DeliveryMode.LIVE,
 ) -> AlertingRuntime:
     """Wire the production analyzer compatibility adapter into the runtime."""

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -1210,6 +1210,7 @@ def build_full_ci_analysis_runtime(
     runner: AnalyzerRunner | None = None,
     kimi_base_url: str = "https://api2.inferact.dev/v1",
     kimi_model: str = "moonshotai/Kimi-K3",
+    kimi_timeout_seconds: int = 3600,
     delivery_mode: DeliveryMode = DeliveryMode.LIVE,
 ) -> AlertingRuntime:
     """Wire the production analyzer compatibility adapter into the runtime."""
@@ -1228,7 +1229,10 @@ def build_full_ci_analysis_runtime(
         runner=runner
         if runner is not None
         else KimiCodeRunner(
-            api_key=kimi_api_key, base_url=kimi_base_url, model=kimi_model
+            api_key=kimi_api_key,
+            base_url=kimi_base_url,
+            model=kimi_model,
+            timeout_seconds=kimi_timeout_seconds,
         ),
         checkpoints=S3CheckpointStore(bucket=checkpoint_bucket),
         github=GitHubRestClient(token=github_token),

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -1211,6 +1211,7 @@ def build_full_ci_analysis_runtime(
     kimi_base_url: str = "https://api2.inferact.dev/v1",
     kimi_model: str = "moonshotai/Kimi-K3",
     kimi_timeout_seconds: int = 3600,
+    kimi_reasoning_effort: str = "low",
     delivery_mode: DeliveryMode = DeliveryMode.LIVE,
 ) -> AlertingRuntime:
     """Wire the production analyzer compatibility adapter into the runtime."""
@@ -1233,6 +1234,7 @@ def build_full_ci_analysis_runtime(
             base_url=kimi_base_url,
             model=kimi_model,
             timeout_seconds=kimi_timeout_seconds,
+            reasoning_effort=kimi_reasoning_effort,
         ),
         checkpoints=S3CheckpointStore(bucket=checkpoint_bucket),
         github=GitHubRestClient(token=github_token),

--- a/alerting/retention.py
+++ b/alerting/retention.py
@@ -27,7 +27,7 @@ def prune_fast_failure_events(
             "DELETE FROM alerting_fast_failure_events WHERE finished_at < %s",
             (cutoff,),
         )
-        return cursor.rowcount
+        return int(cursor.rowcount)
 
 
 def main() -> int:

--- a/alerting/tests/test_analyzer.py
+++ b/alerting/tests/test_analyzer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import subprocess
 from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -19,7 +18,6 @@ from alerting.analyzer import (
     CauseCategory,
     CheckpointRef,
     CompletedAnalysis,
-    ClaudeCodeRunner,
     FailureCache,
     FailureCondition,
     FailureLifecycle,
@@ -1002,32 +1000,6 @@ def test_incomplete_oldest_comparison_blocks_newer_analysis() -> None:
     assert result.status is ProcessStatus.COMPLETED
     assert harness.store.analyses() == []
     assert harness.runner.runs == 0
-
-
-def test_claude_runner_grants_only_required_read_only_tools(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    invocation: list[str] = []
-
-    def run(args: list[str], **_: object) -> subprocess.CompletedProcess[str]:
-        invocation.extend(args)
-        return subprocess.CompletedProcess(args, 0, "", "")
-
-    monkeypatch.setattr("alerting.analyzer.subprocess.run", run)
-
-    ClaudeCodeRunner(binary="claude-test", prompt="analyze").run(tmp_path)
-
-    assert invocation[:4] == ["claude-test", "-p", "analyze", "--allowedTools"]
-    allowed = invocation[4].split(",")
-    assert allowed == [
-        "Read",
-        "Write",
-        "Edit",
-        "Glob",
-        "Grep",
-        "Task",
-        "Bash(curl:*)",
-    ]
 
 
 def test_missed_comparisons_are_analyzed_chronologically() -> None:

--- a/alerting/tests/test_analyzer.py
+++ b/alerting/tests/test_analyzer.py
@@ -429,7 +429,8 @@ def test_analysis_persists_conditions_report_checkpoint_and_notification() -> No
     memory_files = unpack_checkpoint(harness.checkpoints.objects[checkpoint.s3_uri])
     assert memory_files["MEMORY.md"] == b"# learned"
     notification = notification_for(harness, run2.build_id)
-    assert notification.destination_mode is DestinationMode.WEBHOOK
+    assert notification.destination_mode is DestinationMode.BOT_TOKEN
+    assert notification.destination == "C0ANHBE642Y"
     assert "Job B" in notification.payload["text"]
 
 

--- a/alerting/tests/test_analyzer.py
+++ b/alerting/tests/test_analyzer.py
@@ -562,6 +562,38 @@ def test_first_comparison_uses_imported_failure_cache_and_checkpoint() -> None:
     assert condition.lifecycle is FailureLifecycle.RECURRING
 
 
+def test_first_ever_analysis_without_any_checkpoint_starts_with_empty_memory() -> None:
+    run1 = make_run(1, RUN1_AT)
+    run2 = make_run(2, RUN2_AT)
+    harness = Harness(
+        runs=[run1, run2],
+        builds={
+            2: build_json(
+                2,
+                mostly_passing_jobs([("Job A", "failed", False)]),
+                scheduled_at=RUN2_AT,
+            )
+        },
+        seed_checkpoint=False,
+    )
+    observed: dict[str, Any] = {}
+
+    def capture(working_dir: Path) -> None:
+        memory = working_dir / ".claude/agent-memory/vllm-ci-failure-analyzer"
+        observed["memory_files"] = (
+            list(memory.rglob("*")) if memory.is_dir() else []
+        )
+        well_behaved(working_dir)
+
+    harness.runner.on_run(capture)
+
+    assert harness.analyze().status is ProcessStatus.COMPLETED
+    assert observed["memory_files"] == []
+    checkpoint = harness.store.latest_checkpoint()
+    assert checkpoint is not None
+    assert harness.store.analyses()[0].current_build_id == run2.build_id
+
+
 def test_fixed_requires_a_positively_observed_pass() -> None:
     run1 = make_run(1, RUN1_AT)
     run2 = make_run(2, RUN2_AT)
@@ -812,29 +844,6 @@ def _write_cache_only(working_dir: Path, *, failed_tests: list[str]) -> None:
             }
         )
     )
-
-
-def test_missing_checkpoint_leaves_baseline_authoritative() -> None:
-    run1 = make_run(1, RUN1_AT)
-    run2 = make_run(2, RUN2_AT)
-    harness = Harness(
-        runs=[run1, run2],
-        builds={
-            2: build_json(
-                2,
-                mostly_passing_jobs([("Job A", "failed", False)]),
-                scheduled_at=RUN2_AT,
-            )
-        },
-        seed_checkpoint=False,
-    )
-
-    result = harness.analyze()
-
-    assert result.status is ProcessStatus.FAILED
-    assert harness.store.analyses() == []
-    assert harness.outbox.records() == []
-    assert harness.runner.runs == 0
 
 
 def test_corrupted_checkpoint_leaves_baseline_authoritative() -> None:

--- a/alerting/tests/test_full_ci.py
+++ b/alerting/tests/test_full_ci.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from alerting.commands import ScheduledCommand
 from alerting.full_ci import (
+    INITIAL_LOOKBACK,
     BuildkiteFullCISource,
     FullCIJobOutcome,
     FullCIReconciliationHandler,
@@ -129,7 +130,11 @@ def test_missed_runs_are_ingested_in_order_with_one_comparison_each() -> None:
         for comparison in full_ci.comparisons()
     ] == [("build-100", "build-101"), ("build-101", "build-102")]
     assert source.calls == [
-        (None, frozenset(), baseline.scheduled_at),
+        (
+            baseline.scheduled_at - INITIAL_LOOKBACK,
+            frozenset(),
+            baseline.scheduled_at,
+        ),
         (baseline.scheduled_at, frozenset({baseline.build_id}), START),
     ]
 

--- a/alerting/tests/test_kimi.py
+++ b/alerting/tests/test_kimi.py
@@ -1,0 +1,173 @@
+"""Kimi analyzer runner tool-loop behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from alerting.analyzer import AnalyzerError
+from alerting.kimi import KimiCodeRunner
+
+
+def tool_call(
+    name: str, arguments: dict[str, Any], call_id: str = "call_1"
+) -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": name,
+                                "arguments": json.dumps(arguments),
+                            },
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def final(text: str = "done") -> dict[str, Any]:
+    return {"choices": [{"message": {"role": "assistant", "content": text}}]}
+
+
+class ScriptedTransport:
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self._responses = list(responses)
+        self.payloads: list[dict[str, Any]] = []
+
+    def __call__(
+        self, url: str, headers: dict[str, str], payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.payloads.append({**payload, "messages": list(payload["messages"])})
+        return self._responses.pop(0)
+
+
+def tool_messages(transport: ScriptedTransport) -> list[str]:
+    return [
+        str(message["content"])
+        for payload in transport.payloads
+        for message in payload["messages"]
+        if message.get("role") == "tool"
+    ]
+
+
+def test_runner_writes_report_and_terminates(tmp_path: Path) -> None:
+    transport = ScriptedTransport(
+        [
+            tool_call(
+                "Write", {"path": ".logs/ci_report.txt", "content": "report body"}
+            ),
+            final(),
+        ]
+    )
+
+    KimiCodeRunner(api_key="key", transport=transport).run(tmp_path)
+
+    assert (tmp_path / ".logs/ci_report.txt").read_text() == "report body"
+    assert len(transport.payloads) == 2
+
+
+def test_read_returns_file_contents(tmp_path: Path) -> None:
+    (tmp_path / "note.txt").write_text("hello", encoding="utf-8")
+    transport = ScriptedTransport(
+        [
+            tool_call("Read", {"path": "note.txt"}),
+            final(),
+        ]
+    )
+
+    KimiCodeRunner(api_key="key", transport=transport).run(tmp_path)
+
+    assert tool_messages(transport) == ["hello"]
+
+
+def test_file_tools_reject_paths_outside_the_workdir(tmp_path: Path) -> None:
+    transport = ScriptedTransport(
+        [
+            tool_call("Write", {"path": "../escape.txt", "content": "nope"}),
+            tool_call("Read", {"path": "/etc/hostname"}, call_id="call_2"),
+            final(),
+        ]
+    )
+
+    KimiCodeRunner(api_key="key", transport=transport).run(tmp_path)
+
+    assert not (tmp_path.parent / "escape.txt").exists()
+    messages = tool_messages(transport)
+    assert all(message.startswith("error:") for message in messages)
+    assert any("../escape.txt" in message for message in messages)
+    assert any("/etc/hostname" in message for message in messages)
+
+
+def test_bash_rejects_non_curl_commands(tmp_path: Path) -> None:
+    marker = tmp_path / "marker.txt"
+    marker.write_text("keep", encoding="utf-8")
+    transport = ScriptedTransport(
+        [
+            tool_call("Bash", {"command": "rm marker.txt"}),
+            final(),
+        ]
+    )
+
+    KimiCodeRunner(api_key="key", transport=transport).run(tmp_path)
+
+    assert marker.read_text() == "keep"
+    assert tool_messages(transport) == ["error: only curl commands are allowed"]
+
+
+def test_edit_replaces_one_exact_string(tmp_path: Path) -> None:
+    (tmp_path / "report.txt").write_text("old value", encoding="utf-8")
+    transport = ScriptedTransport(
+        [
+            tool_call(
+                "Edit",
+                {"path": "report.txt", "old_string": "old", "new_string": "new"},
+            ),
+            final(),
+        ]
+    )
+
+    KimiCodeRunner(api_key="key", transport=transport).run(tmp_path)
+
+    assert (tmp_path / "report.txt").read_text() == "new value"
+
+
+def test_task_runs_one_nested_loop_that_cannot_spawn_task(tmp_path: Path) -> None:
+    transport = ScriptedTransport(
+        [
+            tool_call("Task", {"prompt": "investigate"}),
+            tool_call("Task", {"prompt": "deeper"}),
+            final("nested result"),
+            final(),
+        ]
+    )
+
+    KimiCodeRunner(api_key="key", transport=transport).run(tmp_path)
+
+    assert tool_messages(transport) == [
+        "error: nested Task calls are not allowed",
+        "nested result",
+    ]
+
+
+def test_max_turns_exhaustion_raises_analyzer_error(tmp_path: Path) -> None:
+    def infinite(
+        url: str, headers: dict[str, str], payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        return tool_call("Glob", {"pattern": "*"})
+
+    runner = KimiCodeRunner(api_key="key", transport=infinite, max_turns=2)
+
+    with pytest.raises(AnalyzerError, match="exceeded 2 turns"):
+        runner.run(tmp_path)

--- a/alerting/tests/test_kimi.py
+++ b/alerting/tests/test_kimi.py
@@ -171,3 +171,33 @@ def test_max_turns_exhaustion_raises_analyzer_error(tmp_path: Path) -> None:
 
     with pytest.raises(AnalyzerError, match="exceeded 2 turns"):
         runner.run(tmp_path)
+
+
+def test_history_pruning_elides_oldest_tool_outputs(tmp_path: Path) -> None:
+    (tmp_path / "big.txt").write_text("x" * 40_000)
+    responses = [
+        tool_call("Read", {"path": "big.txt"}, call_id=f"c{index}")
+        for index in range(50)
+    ]
+    responses.append(final())
+    transport = ScriptedTransport(responses)
+
+    KimiCodeRunner(api_key="key", transport=transport).run(tmp_path)
+
+    tool_contents = [
+        str(message["content"])
+        for message in transport.payloads[-1]["messages"]
+        if message.get("role") == "tool"
+    ]
+    assert any("(older tool output elided" in content for content in tool_contents)
+    assert tool_contents[-1].startswith("x" * 100)
+    total = sum(len(content) for content in tool_contents)
+    assert total <= 1_500_000 + 40_000
+
+
+def test_requests_carry_an_explicit_output_token_budget(tmp_path: Path) -> None:
+    transport = ScriptedTransport([final()])
+
+    KimiCodeRunner(api_key="key", transport=transport).run(tmp_path)
+
+    assert transport.payloads[0]["max_tokens"] == 16_384

--- a/alerting/tests/test_kimi.py
+++ b/alerting/tests/test_kimi.py
@@ -201,3 +201,11 @@ def test_requests_carry_an_explicit_output_token_budget(tmp_path: Path) -> None:
     KimiCodeRunner(api_key="key", transport=transport).run(tmp_path)
 
     assert transport.payloads[0]["max_tokens"] == 16_384
+
+
+def test_requests_default_to_low_reasoning_effort(tmp_path: Path) -> None:
+    transport = ScriptedTransport([final()])
+
+    KimiCodeRunner(api_key="key", transport=transport).run(tmp_path)
+
+    assert transport.payloads[0]["reasoning_effort"] == "low"

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -85,6 +85,7 @@ def _runtime(
                 "KIMI_BASE_URL", "https://api2.inferact.dev/v1"
             ),
             kimi_model=os.environ.get("KIMI_MODEL", "moonshotai/Kimi-K3"),
+            kimi_timeout_seconds=int(os.environ.get("KIMI_TIMEOUT_SECONDS", "3600")),
             slack=_slack(),
             clock=clock,
             delivery_mode=delivery_mode,

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -80,6 +80,11 @@ def _runtime(
             buildkite_token=_required_environment("BUILDKITE_TOKEN"),
             github_token=_required_environment("GITHUB_TOKEN"),
             checkpoint_bucket=_required_environment("ALERTING_CHECKPOINT_BUCKET"),
+            kimi_api_key=_required_environment("KIMI_API_KEY"),
+            kimi_base_url=os.environ.get(
+                "KIMI_BASE_URL", "https://api2.inferact.dev/v1"
+            ),
+            kimi_model=os.environ.get("KIMI_MODEL", "kimi-k3"),
             slack=_slack(),
             clock=clock,
             delivery_mode=delivery_mode,

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -33,12 +33,10 @@ def _required_environment(name: str) -> str:
 
 
 def _slack() -> SlackDeliveryPort:
-    webhook_urls = {}
-    if url := os.environ.get("VLLM_CI_SLACK_URL"):
-        webhook_urls["vllm-ci"] = url
+    # Both alert paths post through the bot token; no webhook destinations.
     return SlackDeliveryPort(
         bot_token=os.environ.get("SLACK_BOT_TOKEN"),
-        webhook_urls=webhook_urls,
+        webhook_urls={},
     )
 
 

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -84,7 +84,7 @@ def _runtime(
             kimi_base_url=os.environ.get(
                 "KIMI_BASE_URL", "https://api2.inferact.dev/v1"
             ),
-            kimi_model=os.environ.get("KIMI_MODEL", "kimi-k3"),
+            kimi_model=os.environ.get("KIMI_MODEL", "moonshotai/Kimi-K3"),
             slack=_slack(),
             clock=clock,
             delivery_mode=delivery_mode,

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -86,6 +86,7 @@ def _runtime(
             ),
             kimi_model=os.environ.get("KIMI_MODEL", "moonshotai/Kimi-K3"),
             kimi_timeout_seconds=int(os.environ.get("KIMI_TIMEOUT_SECONDS", "3600")),
+            kimi_reasoning_effort=os.environ.get("KIMI_REASONING_EFFORT", "low"),
             slack=_slack(),
             clock=clock,
             delivery_mode=delivery_mode,

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -12,7 +12,8 @@ must be JSON objects whose keys are environment-variable names.
 
 - `WorkerSecretArn` supplies `DATABASE_URL`, `BUILDKITE_TOKEN`,
   `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, `DATABRICKS_WAREHOUSE_ID`, and
-  `SLACK_BOT_TOKEN`, plus the LLM credential used by the Full CI analyzer.
+  `SLACK_BOT_TOKEN`, plus `KIMI_API_KEY`, the Kimi credential used by the
+  Full CI analyzer.
 - `GitHubReadOnlySecretArn` supplies `GITHUB_TOKEN`. Use a fine-grained token
   limited to read-only metadata and contents for required repositories. The
   worker must have no repository write permission.
@@ -24,10 +25,9 @@ instance role, writes them briefly under `/run/alerting`, removes the file
 before starting Python, and suppresses worker stdout and stderr so credentials,
 CI logs, model output, and Slack payloads do not enter the journal.
 
-The installer also installs the Claude Code CLI under the non-login `alerting`
-user. The Full CI analyzer uses the LLM credential from `WorkerSecretArn`, a
-bundled read-only analyzer definition, and the stack checkpoint bucket. It does
-not receive a GitHub write credential.
+The Full CI analyzer calls the Kimi API using `KIMI_API_KEY` from
+`WorkerSecretArn`, with a bundled read-only analyzer definition and the stack
+checkpoint bucket. It does not receive a GitHub write credential.
 
 ## Deploy
 

--- a/deploy/aws/alerting-worker.yaml
+++ b/deploy/aws/alerting-worker.yaml
@@ -144,7 +144,7 @@ Resources:
             - |
               #!/bin/bash
               set -euo pipefail
-              dnf install -y git nodejs22 nodejs22-npm python3.12 python3.12-pip
+              dnf install -y git python3.12 python3.12-pip
               install -d -m 0755 /opt/alerting
               git clone --depth 1 --branch '${RepositoryRef}' '${RepositoryUrl}' /opt/alerting/source
               /opt/alerting/source/deploy/aws/install.sh '${BucketName}' '${WorkerSecret}' '${GitHubSecret}'

--- a/deploy/aws/install.sh
+++ b/deploy/aws/install.sh
@@ -17,12 +17,6 @@ fi
 
 python3.12 -m venv /opt/alerting/venv
 /opt/alerting/venv/bin/pip install --no-cache-dir "${source_root}/alerting[aws,postgres]"
-install -d -m 0755 -o alerting -g alerting \
-  /opt/alerting/npm /opt/alerting/npm-cache /opt/alerting/home
-runuser -u alerting -- env HOME=/opt/alerting/home \
-  npm_config_prefix=/opt/alerting/npm \
-  npm_config_cache=/opt/alerting/npm-cache \
-  npm install --global @anthropic-ai/claude-code
 
 install -d -m 0755 /opt/alerting/bin /etc/alerting
 install -m 0755 "$source_root"/deploy/aws/bin/load-secrets /opt/alerting/bin/load-secrets
@@ -33,7 +27,7 @@ install -m 0644 "$source_root"/deploy/aws/systemd/*.service /etc/systemd/system/
 install -m 0644 "$source_root"/deploy/aws/systemd/*.timer /etc/systemd/system/
 
 printf '%s\n%s\n' "$worker_secret_arn" "$github_secret_arn" > /etc/alerting/secret-arns
-printf 'ALERTING_CHECKPOINT_BUCKET=%s\nPATH=/opt/alerting/npm/bin:/usr/local/bin:/usr/bin:/bin\nDISABLE_AUTOUPDATER=1\n' \
+printf 'ALERTING_CHECKPOINT_BUCKET=%s\nPATH=/usr/local/bin:/usr/bin:/bin\nDISABLE_AUTOUPDATER=1\n' \
   "$checkpoint_bucket" > /etc/alerting/worker.env
 chown root:alerting /etc/alerting/secret-arns /etc/alerting/worker.env
 chmod 0440 /etc/alerting/secret-arns /etc/alerting/worker.env

--- a/deploy/aws/tests/test_alerting_worker_infrastructure.py
+++ b/deploy/aws/tests/test_alerting_worker_infrastructure.py
@@ -25,8 +25,8 @@ def test_stack_provisions_one_disposable_worker_without_deferred_services() -> N
     assert "DeleteOnTermination: true" in template
     assert "HttpTokens: required" in template
     assert "SecurityGroupIngress" not in template
-    assert "nodejs22" in template
-    assert "nodejs22-npm" in template
+    assert "nodejs22" not in template
+    assert "nodejs22-npm" not in template
 
 
 def test_instance_role_is_scoped_to_checkpoint_bucket_and_named_secrets() -> None:
@@ -110,10 +110,8 @@ def test_installation_creates_a_non_login_user_and_s3_controlled_timers() -> Non
     assert "useradd --system" in installer
     assert "--shell /sbin/nologin" in installer
     assert 'alerting[aws,postgres]' in installer
-    assert "@anthropic-ai/claude-code" in installer
-    assert "runuser -u alerting" in installer
-    assert "npm_config_cache=/opt/alerting/npm-cache" in installer
-    assert "HOME=/opt/alerting/home" in installer
+    assert "@anthropic-ai/claude-code" not in installer
+    assert "npm" not in installer
     assert "systemctl start alerting-control.service" in installer
     assert "systemctl enable --now alerting-control.timer" in installer
     assert "systemctl enable --now alerting-full-ci.timer" not in installer


### PR DESCRIPTION
## Summary

The Full CI analyzer no longer shells out to the Claude Code CLI (which required OAuth or Anthropic API credentials the org does not issue). `KimiCodeRunner` (`alerting/kimi.py`) runs the same agentic contract over the OpenAI-compatible Kimi endpoint:

- The existing analyzer skill markdown (`assets/vllm-ci-failure-analyzer.md`) becomes the system prompt — analysis phases and report format unchanged.
- Model gets sandboxed `Read`/`Write`/`Edit`/`Glob`/`Grep` tools (confined to the materialized workdir), curl-only `Bash` (parity with `Bash(curl:*)`), and a depth-capped `Task` subagent loop.
- Outputs land in the same workdir and pass the unchanged `_read_outputs` validation; classification, checkpoint, and memory layout untouched.
- Config: `KIMI_API_KEY` (required, joins `WorkerSecretArn`), `KIMI_BASE_URL` (default `https://api2.inferact.dev/v1`), `KIMI_MODEL` (default `kimi-k3`).
- Worker image drops the Claude Code CLI and Node.js; install.sh and the CloudFormation template updated.
- Also fixes a pre-existing mypy `no-any-return` error in `retention.py`.

## Test plan
- 103 alerting pytest tests pass (7 new `test_kimi.py` covering happy path, sandbox escapes, curl-only Bash, Task depth cap, max-turns exhaustion)
- ruff and mypy clean (32 files)
- 13 deploy infrastructure tests pass

## Rollout
1. Add `KIMI_API_KEY` to the `WorkerSecretArn` secret JSON in Secrets Manager.
2. On the worker host: `git pull` + re-run `deploy/aws/install.sh`.
3. Optionally `npm uninstall -g @anthropic-ai/claude-code` as the alerting user.