### PR TITLE
Add Main CI failed-job alert lifecycle

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -7,4 +7,8 @@
 
 ## Relationships
 
-- **Alert Production to CI Dashboard**: Alert Production defines and writes Fast and Full CI alert records. CI Dashboard reads those records, independently owns Queue Wait Alerts, and does not mutate schema during requests.
+- **Alert Production to CI Dashboard**: Alert Production defines and writes
+  Fast CI observations, Full CI comparisons, and Main CI Job Alert episodes.
+  CI Dashboard reads those records, independently owns Queue Wait Alerts, and
+  does not mutate schema during requests. Main CI diagnosis remains a curated
+  Slack concern rather than dashboard state.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Next.js dashboard for observing vLLM's Buildkite CI: build status, job runtime
 
 - **Builds** — pass/fail rates, durations, and per-job breakdowns for recent pipeline builds.
 - **Jobs** — latest job failures and per-job historical run times.
+- **Alerts** — Fast CI observations, analyzed Full CI comparisons, and exact
+  main-branch job failures that remain open until the same job passes again.
 - **Tests** — Test Engine reliability, execution counts, and duration history.
 - **Queue** — live agent queue depth, waiting builds, and Slack alerts when queues back up.
 - **Cost** — compute hours and dollar cost per queue, derived from AWS on-demand pricing.
@@ -19,10 +21,12 @@ A Next.js dashboard for observing vLLM's Buildkite CI: build status, job runtime
 - **Operational store**: Postgres (Supabase) — short-term agent and queue-depth samples written by cron jobs.
 - **Sources polled**:
   - Buildkite GraphQL API (queue depth, running jobs, connected agents, and current wait distribution) — every 5 minutes
+  - Buildkite REST API (main-branch failed-job lifecycle) — every 5 minutes
   - Databricks warehouse (build/job history) — on dashboard requests with short-lived caching
   - Queue alerting → Slack — every 15 minutes
 - **Alert production**: The separately deployed Python worker lives in
-  [`alerting/`](./alerting).
+  [`alerting/`](./alerting). Main CI lifecycle records intentionally contain
+  no automated diagnosis; curated analysis continues in Slack.
 - **Schema migrations**: All Postgres table definitions and migration execution
   live in the Python [`migrations/`](./migrations) module. Runtime request
   handlers never create or alter tables.

--- a/alerting/CONTEXT.md
+++ b/alerting/CONTEXT.md
@@ -36,8 +36,21 @@ _Avoid_: Backup, snapshot of the database
 An observation that one Fast CI job entered an eligible failure state within 30 seconds. It has no resolution lifecycle.
 _Avoid_: Incident, alert lifecycle
 
+**Main CI Job Observation**:
+A hard terminal command-job outcome on the main branch, keyed by configured
+step identity plus rendered job name so matrix cells remain independent.
+_Avoid_: Test failure, diagnosis
+
+**Main CI Job Alert**:
+One failure episode for a Main CI job. Repeated hard failures refresh the open
+episode; only a positively observed pass of the same job in the same or a newer
+build resolves it. Missing, soft-failed, canceled, or older late-finishing jobs
+do not resolve an episode.
+_Avoid_: Full CI Failure Condition, automated diagnosis
+
 **Scan Cursor**:
-The latest durable Fast CI scan target used to derive the next overlapping observation window.
+The latest durable Fast or Main CI scan target used to derive the next
+overlapping observation window.
 _Avoid_: Last event time, checkpoint
 
 **Notification Intent**:

--- a/alerting/README.md
+++ b/alerting/README.md
@@ -1,7 +1,8 @@
 # Alert Production
 
-This bounded context produces durable vLLM CI alert history for the Full CI
-comparison and Fast CI fast-failure signals. It processes scheduled
+This bounded context produces durable vLLM CI alert history for Full CI
+comparisons, Fast CI fast-failure signals, and exact Main CI job failure
+episodes. It processes scheduled
 reconciliation commands idempotently against Postgres as the system of record
 and delivers Slack notifications through a transactional outbox. The dashboard
 application in this repository reads its records but does not own ingestion.
@@ -10,9 +11,9 @@ application in this repository reads its records but does not own ingestion.
 
 The package uses vertical domain slices rather than layer-only folders:
 
-- `commands.py` defines the scheduled-command value object shared by both
+- `commands.py` defines the scheduled-command value object shared by all
   slices.
-- `fast_ci.py` and `full_ci.py` keep each signal's domain records,
+- `fast_ci.py`, `full_ci.py`, and `main_ci.py` keep each signal's domain records,
   reconciliation behavior, source port, and source adapter together.
 - `runtime.py` exposes the small application interface:
   `process_command` and `dispatch_due_notifications`.
@@ -43,6 +44,11 @@ repository-level relationship with the dashboard is recorded in
 - `full_ci.py` — the Buildkite query adapter, Full CI run and
   job-outcome records, and chronological reconciliation handler. Analyzer
   invocation remains outside this ingest-only slice.
+- `main_ci.py` — the five-minute Buildkite main-branch poller and exact-job
+  lifecycle. It ignores soft/non-command/non-terminal jobs, protects newer
+  outcomes from older builds finishing late, and resolves only on a positive
+  pass. It writes raw lifecycle and Buildkite evidence only; Sherlock's
+  diagnosis remains in Slack.
 - `analyzer.py` — the Full CI analyzer compatibility adapter. It materializes
   the working files the unchanged analyzer skill expects (summary, full build
   data, previous-failure cache, agent memory hydrated from the latest
@@ -57,16 +63,18 @@ repository-level relationship with the dashboard is recorded in
   legacy Full CI cache, last-reported build state, analyzer memory, and Fast CI
   SQLite deduplication keys.
 - `control.py` — applies durable per-path `shadow`, `live`, or `disabled`
-  controls from S3 to the two systemd timers. Missing controls default to
+  controls from S3 to the three systemd timers. Missing controls default to
   `shadow`.
 - `cutover.py` — exports persisted shadow payloads for comparison and archives
   pending live payloads as non-deliverable shadow records during rollback.
-- `postgres.py` — production execution, outbox, Fast CI, and Full CI
+- `postgres.py` — production execution, outbox, Fast CI, Full CI, and Main CI
   stores.
   `PostgresAlertStore.commit_scan` performs the event inserts, batch inserts,
   cursor update, and execution completion in one Postgres transaction;
   `commit_reconciliation` atomically stores ordered Full CI runs, outcomes,
-  comparisons, and execution completion. Runtime factories wire the production
+  comparisons, and execution completion; `commit_main_ci_scan` atomically
+  advances exact job state, opens/updates/resolves alert episodes, advances the
+  cursor, and completes execution. Runtime factories wire the production
   Databricks and Buildkite clients.
 - `slack.py` — configured incoming-webhook and bot-token delivery. It resolves
   logical webhook destinations without storing webhook secrets in Postgres,
@@ -119,8 +127,10 @@ enabling the new path, and preserves Postgres and S3 baselines on rollback.
 
 - `FastCIScanHandler` registers as `fast_ci_scan`,
   `FullCIReconciliationHandler` registers as `full_ci_reconcile`, and
-  `FullCIAnalysisHandler` registers as `full_ci_analyze`. The Full CI worker
-  exposes them as the `full-ci` and `full-ci-analyze` consumers so the
+  `FullCIAnalysisHandler` registers as `full_ci_analyze`, while
+  `MainCIReconciliationHandler` registers as `main_ci_reconcile`. Workers
+  expose them as the `fast-ci`, `full-ci`, `full-ci-analyze`, and `main-ci`
+  consumers so the
   long-running LLM analysis never blocks ingest.
 - The Postgres adapters must mark an execution complete in the same
   transaction that commits the handler's durable effects, and lease outbox
@@ -138,6 +148,6 @@ enabling the new path, and preserves Postgres and S3 baselines on rollback.
 cd alerting
 uv sync --extra dev
 uv run pytest
-uv run mypy __init__.py analyzer.py commands.py control.py cutover.py fast_ci.py full_ci.py memory.py migration.py ports.py postgres.py runtime.py slack.py worker.py tests
+uv run mypy __init__.py analyzer.py commands.py control.py cutover.py fast_ci.py full_ci.py main_ci.py memory.py migration.py ports.py postgres.py runtime.py slack.py worker.py tests
 uv run ruff check .
 ```

--- a/alerting/__init__.py
+++ b/alerting/__init__.py
@@ -41,6 +41,12 @@ from alerting.full_ci import (
     FullCIReconciliationState,
     FullCIRun,
 )
+from alerting.main_ci import (
+    BuildkiteMainCISource,
+    MainCIJobAlert,
+    MainCIJobObservation,
+    MainCIReconciliationHandler,
+)
 from alerting.ports import (
     ClaimOutcome,
     DestinationMode,
@@ -57,6 +63,7 @@ from alerting.postgres import (
     build_fast_ci_runtime,
     build_full_ci_analysis_runtime,
     build_full_ci_runtime,
+    build_main_ci_runtime,
 )
 from alerting.runtime import (
     AlertingRuntime,
@@ -79,6 +86,7 @@ __all__ = [
     "ScheduledCommand",
     "BuildkiteFullCISource",
     "BuildkiteRestClient",
+    "BuildkiteMainCISource",
     "ComparisonContext",
     "CompletedAnalysis",
     "DatabricksFastCISource",
@@ -99,6 +107,9 @@ __all__ = [
     "FullCIReconciliationHandler",
     "FullCIReconciliationState",
     "FullCIRun",
+    "MainCIJobAlert",
+    "MainCIJobObservation",
+    "MainCIReconciliationHandler",
     "GitHubRestClient",
     "HandlerCompletion",
     "NotificationIntent",
@@ -119,6 +130,7 @@ __all__ = [
     "build_fast_ci_runtime",
     "build_full_ci_analysis_runtime",
     "build_full_ci_runtime",
+    "build_main_ci_runtime",
     "pack_checkpoint",
     "unpack_checkpoint",
 ]

--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -876,7 +876,7 @@ class S3CheckpointStore:
         self._prefix = prefix
 
     def _client(self) -> Any:
-        import boto3  # type: ignore[import-untyped]  # optional, production-only
+        import boto3  # type: ignore[import-not-found,import-untyped]  # optional, production-only
 
         return boto3.client("s3")
 

--- a/alerting/control.py
+++ b/alerting/control.py
@@ -36,10 +36,12 @@ class UnitControl(Protocol):
 _UNITS = {
     AlertPath.FAST_CI: ("alerting-fast-ci.timer", "alerting-fast-ci.service"),
     AlertPath.FULL_CI: ("alerting-full-ci.timer", "alerting-full-ci.service"),
+    AlertPath.MAIN_CI: ("alerting-main-ci.timer", "alerting-main-ci.service"),
 }
 _MODE_FILES = {
     AlertPath.FAST_CI: "fast-ci.mode",
     AlertPath.FULL_CI: "full-ci.mode",
+    AlertPath.MAIN_CI: "main-ci.mode",
 }
 
 
@@ -78,7 +80,7 @@ def reconcile_controls(
 class S3AlertControl:
     def __init__(self, *, bucket: str, client: Any | None = None) -> None:
         if client is None:
-            import boto3  # type: ignore[import-untyped]
+            import boto3  # type: ignore[import-not-found,import-untyped]
 
             client = boto3.client("s3")
         self._bucket = bucket

--- a/alerting/cutover.py
+++ b/alerting/cutover.py
@@ -12,6 +12,8 @@ from typing import Any
 from alerting.ports import AlertPath, NotificationIntentRecord
 from alerting.postgres import PostgresAlertStore
 
+_SLACK_DELIVERY_PATHS = (AlertPath.FAST_CI, AlertPath.FULL_CI)
+
 
 def _database_url() -> str:
     value = os.environ.get("DATABASE_URL")
@@ -39,12 +41,16 @@ def _parser() -> argparse.ArgumentParser:
     commands = parser.add_subparsers(dest="command", required=True)
     export = commands.add_parser("export-shadow")
     export.add_argument(
-        "--path", choices=[path.value for path in AlertPath], required=True
+        "--path",
+        choices=[path.value for path in _SLACK_DELIVERY_PATHS],
+        required=True,
     )
     export.add_argument("--limit", type=int, default=10)
     archive = commands.add_parser("archive-pending")
     archive.add_argument(
-        "--path", choices=[path.value for path in AlertPath], required=True
+        "--path",
+        choices=[path.value for path in _SLACK_DELIVERY_PATHS],
+        required=True,
     )
     archive.add_argument("--confirm-path", required=True)
     return parser

--- a/alerting/full_ci.py
+++ b/alerting/full_ci.py
@@ -8,7 +8,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Protocol, cast
 
 from alerting.commands import ScheduledCommand
@@ -134,7 +134,7 @@ class BuildkiteRestClient:
     def list_builds(
         self, *, start_time: datetime | None, up_to: datetime
     ) -> list[dict[str, Any]]:
-        query: dict[str, str | int] = {
+        query: dict[str, str | int | list[str]] = {
             "branch": "main",
             "created_to": _iso8601(up_to),
             "exclude_jobs": "true",
@@ -142,11 +142,16 @@ class BuildkiteRestClient:
         }
         if start_time is not None:
             query["created_from"] = _iso8601(start_time)
+        return self._list_build_pages(query)
+
+    def _list_build_pages(
+        self, query: dict[str, str | int | list[str]]
+    ) -> list[dict[str, Any]]:
         builds: list[dict[str, Any]] = []
         page = 1
         while True:
             query["page"] = page
-            url = f"{self._BUILDS_URL}?{urllib.parse.urlencode(query)}"
+            url = f"{self._BUILDS_URL}?{urllib.parse.urlencode(query, doseq=True)}"
             payload = self._get_json(url)
             if not isinstance(payload, list):
                 raise RuntimeError("Buildkite builds response was not a list")
@@ -155,6 +160,40 @@ class BuildkiteRestClient:
             if len(rows) < 100:
                 return builds
             page += 1
+
+    def list_job_builds(
+        self, *, observed_from: datetime, up_to: datetime
+    ) -> list[dict[str, Any]]:
+        """Return active plus recently finished main builds with embedded jobs.
+
+        The two bounded queries avoid re-downloading days of large build
+        matrices while still catching jobs from an older build that becomes
+        terminal between polling ticks.
+        """
+        common: dict[str, str | int | list[str]] = {
+            "branch": "main",
+            "created_from": _iso8601(observed_from - timedelta(days=2)),
+            "created_to": _iso8601(up_to),
+            "include_retried_jobs": "false",
+            "per_page": 100,
+        }
+        active = self._list_build_pages(
+            {
+                **common,
+                "state": ["creating", "scheduled", "running", "failing", "canceling"],
+            }
+        )
+        finished = self._list_build_pages(
+            {
+                **common,
+                "state": "finished",
+                "finished_from": _iso8601(observed_from),
+            }
+        )
+        by_id: dict[str, dict[str, Any]] = {}
+        for build in [*active, *finished]:
+            by_id[str(build["id"])] = build
+        return list(by_id.values())
 
     def list_jobs(self, build_number: int) -> list[dict[str, Any]]:
         url: str | None = (

--- a/alerting/main_ci.py
+++ b/alerting/main_ci.py
@@ -1,0 +1,211 @@
+"""Main-branch CI job alert lifecycle reconciliation.
+
+Every hard terminal failure opens (or refreshes) one alert keyed by the
+Buildkite step key. Only a positively observed pass of that same logical job
+in the same or a newer main build resolves it. Older builds that finish late
+cannot overwrite a newer outcome.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Protocol
+
+from alerting.commands import ScheduledCommand
+from alerting.ports import Clock
+from alerting.runtime import HandlerCompletion
+
+INITIAL_LOOKBACK = timedelta(days=1)
+SAFETY_OVERLAP = timedelta(minutes=30)
+FAILURE_STATES = frozenset({"failed", "failing", "broken", "timed_out"})
+TRACKED_STATES = FAILURE_STATES | {"passed"}
+
+
+@dataclass(frozen=True)
+class MainCIJobObservation:
+    """One hard terminal outcome from a command job on the main branch."""
+
+    job_key: str
+    job_id: str
+    job_name: str
+    job_url: str
+    state: str
+    finished_at: datetime
+    build_id: str
+    build_number: int
+    build_url: str
+    commit_sha: str
+
+    def __post_init__(self) -> None:
+        if self.finished_at.tzinfo is None:
+            raise ValueError("finished_at must be timezone-aware")
+        if self.state not in TRACKED_STATES:
+            raise ValueError(f"untracked Main CI job state: {self.state}")
+
+    @property
+    def failed(self) -> bool:
+        return self.state in FAILURE_STATES
+
+    @property
+    def order(self) -> tuple[int, datetime, str]:
+        """Newer builds win even when an older build finishes later."""
+        return (self.build_number, self.finished_at, self.job_id)
+
+
+@dataclass(frozen=True)
+class MainCIJobAlert:
+    """One open-or-resolved failure episode for a logical main CI job."""
+
+    alert_id: int
+    job_key: str
+    job_name: str
+    opened_at: datetime
+    first_failure: MainCIJobObservation
+    last_failure: MainCIJobObservation
+    failure_count: int
+    resolved_at: datetime | None = None
+    resolution: MainCIJobObservation | None = None
+
+    @property
+    def status(self) -> str:
+        return "resolved" if self.resolved_at is not None else "open"
+
+
+def ordered_unique_observations(
+    observations: list[MainCIJobObservation],
+) -> list[MainCIJobObservation]:
+    seen: set[str] = set()
+    ordered: list[MainCIJobObservation] = []
+    for observation in sorted(observations, key=lambda item: item.order):
+        if observation.job_id in seen:
+            continue
+        seen.add(observation.job_id)
+        ordered.append(observation)
+    return ordered
+
+
+class MainCIBuildkitePort(Protocol):
+    def list_job_builds(
+        self, *, observed_from: datetime, up_to: datetime
+    ) -> list[dict[str, Any]]: ...
+
+
+def _parse_datetime(value: Any) -> datetime:
+    parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("Buildkite finished_at must be timezone-aware")
+    return parsed
+
+
+class BuildkiteMainCISource:
+    """Map recently active or finished main builds into terminal outcomes."""
+
+    def __init__(self, buildkite: MainCIBuildkitePort) -> None:
+        self._buildkite = buildkite
+
+    def fetch_observations(
+        self, *, start_time: datetime, end_time: datetime
+    ) -> list[MainCIJobObservation]:
+        builds = self._buildkite.list_job_builds(
+            observed_from=start_time,
+            up_to=end_time,
+        )
+        observations: list[MainCIJobObservation] = []
+        for build in builds:
+            build_id = str(build["id"])
+            build_number = int(build["number"])
+            build_url = str(build.get("web_url") or "")
+            commit_sha = str(build.get("commit") or "")
+            jobs = build.get("jobs")
+            if not isinstance(jobs, list):
+                continue
+            for job in jobs:
+                if not isinstance(job, dict):
+                    continue
+                name = str(job.get("name") or "").strip()
+                state = str(job.get("state") or "")
+                finished_value = job.get("finished_at")
+                if (
+                    not name
+                    or job.get("type") != "script"
+                    or bool(job.get("soft_failed"))
+                    or state not in TRACKED_STATES
+                    or finished_value is None
+                ):
+                    continue
+                finished_at = _parse_datetime(finished_value)
+                if finished_at < start_time or finished_at > end_time:
+                    continue
+                job_id = str(job["id"])
+                step_key = str(job.get("step_key") or "").strip()
+                # Matrix expansions share a configured step key. Include the
+                # rendered job name so one matrix cell cannot resolve another.
+                job_key = f"step:{step_key}|name:{name}" if step_key else f"name:{name}"
+                observations.append(
+                    MainCIJobObservation(
+                        job_key=job_key,
+                        job_id=job_id,
+                        job_name=name,
+                        job_url=str(job.get("web_url") or f"{build_url}#{job_id}"),
+                        state=state,
+                        finished_at=finished_at,
+                        build_id=build_id,
+                        build_number=build_number,
+                        build_url=build_url,
+                        commit_sha=commit_sha,
+                    )
+                )
+        return ordered_unique_observations(observations)
+
+
+class MainCISource(Protocol):
+    def fetch_observations(
+        self, *, start_time: datetime, end_time: datetime
+    ) -> list[MainCIJobObservation]: ...
+
+
+class MainCIStore(Protocol):
+    def main_ci_scan_cursor(self) -> datetime | None: ...
+
+    def commit_main_ci_scan(
+        self,
+        *,
+        command: ScheduledCommand,
+        observations: list[MainCIJobObservation],
+        scanned_through: datetime,
+        now: datetime,
+    ) -> None:
+        """Atomically reconcile outcomes, advance the cursor, and complete."""
+        ...
+
+
+class MainCIReconciliationHandler:
+    """Poll a cursor window and reconcile exact job alert lifecycles."""
+
+    def __init__(
+        self, *, source: MainCISource, store: MainCIStore, clock: Clock
+    ) -> None:
+        self._source = source
+        self._store = store
+        self._clock = clock
+
+    def __call__(self, command: ScheduledCommand) -> HandlerCompletion:
+        cursor = self._store.main_ci_scan_cursor()
+        if cursor is None:
+            start_time = command.target_time - INITIAL_LOOKBACK
+        elif command.target_time >= cursor:
+            start_time = cursor - SAFETY_OVERLAP
+        else:
+            start_time = command.target_time - SAFETY_OVERLAP
+        observations = self._source.fetch_observations(
+            start_time=start_time,
+            end_time=command.target_time,
+        )
+        self._store.commit_main_ci_scan(
+            command=command,
+            observations=observations,
+            scanned_through=command.target_time,
+            now=self._clock.now(),
+        )
+        return HandlerCompletion.TRANSACTIONAL

--- a/alerting/memory.py
+++ b/alerting/memory.py
@@ -35,6 +35,11 @@ from alerting.full_ci import (
     FullCIRun,
     ordered_unique_runs,
 )
+from alerting.main_ci import (
+    MainCIJobAlert,
+    MainCIJobObservation,
+    ordered_unique_observations,
+)
 from alerting.ports import (
     AlertPath,
     ClaimOutcome,
@@ -437,6 +442,87 @@ class InMemoryFullCIStore:
             for run in self.runs()
             if run.build_id in self._comparisons
         ]
+
+
+class InMemoryMainCIStore:
+    """Atomic in-memory model of Main CI current state and alert episodes."""
+
+    def __init__(self, *, executions: InMemoryAutomationExecutionStore) -> None:
+        self._executions = executions
+        self._cursor: datetime | None = None
+        self._states: dict[str, MainCIJobObservation] = {}
+        self._alerts: list[MainCIJobAlert] = []
+        self._active: dict[str, int] = {}
+
+    def main_ci_scan_cursor(self) -> datetime | None:
+        return self._cursor
+
+    def commit_main_ci_scan(
+        self,
+        *,
+        command: ScheduledCommand,
+        observations: list[MainCIJobObservation],
+        scanned_through: datetime,
+        now: datetime,
+    ) -> None:
+        execution_snapshot = self._executions._snapshot()
+        cursor_snapshot = self._cursor
+        states_snapshot = dict(self._states)
+        alerts_snapshot = list(self._alerts)
+        active_snapshot = dict(self._active)
+        try:
+            for observation in ordered_unique_observations(observations):
+                previous = self._states.get(observation.job_key)
+                if previous is not None and previous.order >= observation.order:
+                    continue
+                self._states[observation.job_key] = observation
+                active_index = self._active.get(observation.job_key)
+                if observation.failed:
+                    if active_index is None:
+                        alert = MainCIJobAlert(
+                            alert_id=len(self._alerts) + 1,
+                            job_key=observation.job_key,
+                            job_name=observation.job_name,
+                            opened_at=observation.finished_at,
+                            first_failure=observation,
+                            last_failure=observation,
+                            failure_count=1,
+                        )
+                        self._alerts.append(alert)
+                        self._active[observation.job_key] = len(self._alerts) - 1
+                    else:
+                        active = self._alerts[active_index]
+                        self._alerts[active_index] = replace(
+                            active,
+                            job_name=observation.job_name,
+                            last_failure=observation,
+                            failure_count=active.failure_count + 1,
+                        )
+                elif active_index is not None:
+                    active = self._alerts[active_index]
+                    self._alerts[active_index] = replace(
+                        active,
+                        job_name=observation.job_name,
+                        resolved_at=observation.finished_at,
+                        resolution=observation,
+                    )
+                    del self._active[observation.job_key]
+            if self._cursor is None or scanned_through > self._cursor:
+                self._cursor = scanned_through
+            self._executions.complete(command.idempotency_key, now=now)
+        except Exception:
+            self._executions._restore(execution_snapshot)
+            self._cursor = cursor_snapshot
+            self._states = states_snapshot
+            self._alerts = alerts_snapshot
+            self._active = active_snapshot
+            raise
+
+    def alerts(self) -> list[MainCIJobAlert]:
+        return list(self._alerts)
+
+    def state(self, job_key: str) -> MainCIJobObservation | None:
+        return self._states.get(job_key)
 
 
 class InMemoryAnalyzerStore:

--- a/alerting/ports.py
+++ b/alerting/ports.py
@@ -52,6 +52,7 @@ class OutboxStatus(Enum):
 class AlertPath(StrEnum):
     FAST_CI = "fast_ci"
     FULL_CI = "full_ci"
+    MAIN_CI = "main_ci"
 
 
 class DeliveryMode(StrEnum):

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -33,6 +33,7 @@ from alerting.full_ci import (
     FullCIRun,
     ordered_unique_runs,
 )
+from alerting.main_ci import MainCIJobObservation, ordered_unique_observations
 from alerting.ports import (
     AlertPath,
     ClaimOutcome,
@@ -778,6 +779,215 @@ class PostgresAlertStore:
             processed_build_ids=frozenset(row[0] for row in rows),
         )
 
+    def main_ci_scan_cursor(self) -> datetime | None:
+        with self._connection_factory() as connection:
+            row = connection.execute(
+                """
+                SELECT scanned_through
+                FROM alerting_main_ci_scan_cursors
+                WHERE cursor_name = 'main_ci'
+                """
+            ).fetchone()
+        return row[0] if row is not None else None
+
+    def commit_main_ci_scan(
+        self,
+        *,
+        command: ScheduledCommand,
+        observations: list[MainCIJobObservation],
+        scanned_through: datetime,
+        now: datetime,
+    ) -> None:
+        with self._connection_factory() as connection:
+            with connection.transaction():
+                connection.execute(
+                    """
+                    SELECT pg_advisory_xact_lock(
+                        hashtext('alerting_main_ci_reconcile')
+                    )
+                    """
+                )
+                for observation in ordered_unique_observations(observations):
+                    current = connection.execute(
+                        """
+                        SELECT latest_build_number, latest_finished_at,
+                               latest_job_id
+                        FROM alerting_main_ci_job_states
+                        WHERE job_key = %s
+                        FOR UPDATE
+                        """,
+                        (observation.job_key,),
+                    ).fetchone()
+                    if current is not None and (
+                        current[0], current[1], current[2]
+                    ) >= observation.order:
+                        continue
+
+                    connection.execute(
+                        """
+                        INSERT INTO alerting_main_ci_job_states (
+                            job_key, job_name, latest_job_id, latest_job_state,
+                            latest_finished_at, latest_build_id,
+                            latest_build_number, latest_build_url,
+                            latest_job_url, latest_commit_sha, updated_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        ON CONFLICT (job_key) DO UPDATE
+                        SET job_name = EXCLUDED.job_name,
+                            latest_job_id = EXCLUDED.latest_job_id,
+                            latest_job_state = EXCLUDED.latest_job_state,
+                            latest_finished_at = EXCLUDED.latest_finished_at,
+                            latest_build_id = EXCLUDED.latest_build_id,
+                            latest_build_number = EXCLUDED.latest_build_number,
+                            latest_build_url = EXCLUDED.latest_build_url,
+                            latest_job_url = EXCLUDED.latest_job_url,
+                            latest_commit_sha = EXCLUDED.latest_commit_sha,
+                            updated_at = EXCLUDED.updated_at
+                        """,
+                        (
+                            observation.job_key,
+                            observation.job_name,
+                            observation.job_id,
+                            observation.state,
+                            observation.finished_at,
+                            observation.build_id,
+                            observation.build_number,
+                            observation.build_url,
+                            observation.job_url,
+                            observation.commit_sha,
+                            now,
+                        ),
+                    )
+
+                    if observation.failed:
+                        updated = connection.execute(
+                            """
+                            UPDATE alerting_main_ci_job_alerts
+                            SET job_name = %s,
+                                last_failed_at = %s,
+                                last_failure_job_id = %s,
+                                last_failure_state = %s,
+                                last_failure_build_id = %s,
+                                last_failure_build_number = %s,
+                                last_failure_build_url = %s,
+                                last_failure_job_url = %s,
+                                last_failure_commit_sha = %s,
+                                failure_count = failure_count + 1,
+                                updated_at = %s
+                            WHERE job_key = %s AND status = 'open'
+                            RETURNING alert_id
+                            """,
+                            (
+                                observation.job_name,
+                                observation.finished_at,
+                                observation.job_id,
+                                observation.state,
+                                observation.build_id,
+                                observation.build_number,
+                                observation.build_url,
+                                observation.job_url,
+                                observation.commit_sha,
+                                now,
+                                observation.job_key,
+                            ),
+                        ).fetchone()
+                        if updated is None:
+                            connection.execute(
+                                """
+                                INSERT INTO alerting_main_ci_job_alerts (
+                                    job_key, job_name, status, opened_at,
+                                    first_failure_job_id, first_failure_state,
+                                    first_failure_build_id,
+                                    first_failure_build_number,
+                                    first_failure_build_url,
+                                    first_failure_job_url,
+                                    first_failure_commit_sha,
+                                    last_failed_at, last_failure_job_id,
+                                    last_failure_state, last_failure_build_id,
+                                    last_failure_build_number,
+                                    last_failure_build_url, last_failure_job_url,
+                                    last_failure_commit_sha, failure_count,
+                                    created_at, updated_at
+                                ) VALUES (
+                                    %s, %s, 'open', %s, %s, %s, %s, %s, %s,
+                                    %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                                    1, %s, %s
+                                )
+                                """,
+                                (
+                                    observation.job_key,
+                                    observation.job_name,
+                                    observation.finished_at,
+                                    observation.job_id,
+                                    observation.state,
+                                    observation.build_id,
+                                    observation.build_number,
+                                    observation.build_url,
+                                    observation.job_url,
+                                    observation.commit_sha,
+                                    observation.finished_at,
+                                    observation.job_id,
+                                    observation.state,
+                                    observation.build_id,
+                                    observation.build_number,
+                                    observation.build_url,
+                                    observation.job_url,
+                                    observation.commit_sha,
+                                    now,
+                                    now,
+                                ),
+                            )
+                    else:
+                        connection.execute(
+                            """
+                            UPDATE alerting_main_ci_job_alerts
+                            SET status = 'resolved', resolved_at = %s,
+                                resolution_job_id = %s,
+                                resolution_build_id = %s,
+                                resolution_build_number = %s,
+                                resolution_build_url = %s,
+                                resolution_job_url = %s,
+                                resolution_commit_sha = %s,
+                                updated_at = %s
+                            WHERE job_key = %s AND status = 'open'
+                            """,
+                            (
+                                observation.finished_at,
+                                observation.job_id,
+                                observation.build_id,
+                                observation.build_number,
+                                observation.build_url,
+                                observation.job_url,
+                                observation.commit_sha,
+                                now,
+                                observation.job_key,
+                            ),
+                        )
+
+                connection.execute(
+                    """
+                    INSERT INTO alerting_main_ci_scan_cursors (
+                        cursor_name, scanned_through
+                    ) VALUES ('main_ci', %s)
+                    ON CONFLICT (cursor_name) DO UPDATE
+                    SET scanned_through = GREATEST(
+                        alerting_main_ci_scan_cursors.scanned_through,
+                        EXCLUDED.scanned_through
+                    )
+                    """,
+                    (scanned_through,),
+                )
+                completed = connection.execute(
+                    """
+                    UPDATE alerting_automation_executions
+                    SET status = 'completed', completed_at = %s,
+                        lease_expires_at = NULL, last_error = NULL
+                    WHERE idempotency_key = %s AND status = 'running'
+                    """,
+                    (now, command.idempotency_key),
+                )
+                if completed.rowcount != 1:
+                    raise RuntimeError("Main CI execution was not running at commit")
+
     def commit_reconciliation(
         self,
         *,
@@ -1197,6 +1407,29 @@ def build_full_ci_runtime(
         alert_path=AlertPath.FULL_CI,
     )
 
+
+def build_main_ci_runtime(
+    *,
+    database_url: str,
+    buildkite_token: str,
+    slack: SlackPort,
+    clock: Clock,
+) -> AlertingRuntime:
+    """Wire Main CI exact-job lifecycle reconciliation into the runtime."""
+    from alerting.full_ci import BuildkiteRestClient
+    from alerting.main_ci import BuildkiteMainCISource, MainCIReconciliationHandler
+
+    store = PostgresAlertStore.from_database_url(database_url)
+    source = BuildkiteMainCISource(BuildkiteRestClient(token=buildkite_token))
+    handler = MainCIReconciliationHandler(source=source, store=store, clock=clock)
+    return AlertingRuntime(
+        executions=store,
+        outbox=store,
+        slack=slack,
+        clock=clock,
+        handlers={"main_ci_reconcile": handler},
+        alert_path=AlertPath.MAIN_CI,
+    )
 
 def build_full_ci_analysis_runtime(
     *,

--- a/alerting/tests/test_control.py
+++ b/alerting/tests/test_control.py
@@ -45,6 +45,7 @@ def test_reconcile_controls_defaults_missing_path_to_shadow_and_disables_one_pat
         {
             AlertPath.FAST_CI: None,
             AlertPath.FULL_CI: ControlMode.DISABLED,
+            AlertPath.MAIN_CI: ControlMode.DISABLED,
         }
     )
     units = RecordingUnits()
@@ -58,9 +59,15 @@ def test_reconcile_controls_defaults_missing_path_to_shadow_and_disables_one_pat
     assert (tmp_path / "full-ci.mode").read_text() == (
         "ALERTING_DELIVERY_MODE=shadow\n"
     )
+    assert (tmp_path / "main-ci.mode").read_text() == (
+        "ALERTING_DELIVERY_MODE=shadow\n"
+    )
     assert units.enabled == ["alerting-fast-ci.timer"]
-    assert units.disabled == ["alerting-full-ci.timer"]
-    assert units.stopped == ["alerting-full-ci.service"]
+    assert units.disabled == ["alerting-full-ci.timer", "alerting-main-ci.timer"]
+    assert units.stopped == [
+        "alerting-full-ci.service",
+        "alerting-main-ci.service",
+    ]
 
 
 def test_live_control_enables_only_selected_path(tmp_path: Path) -> None:
@@ -68,6 +75,7 @@ def test_live_control_enables_only_selected_path(tmp_path: Path) -> None:
         {
             AlertPath.FAST_CI: ControlMode.DISABLED,
             AlertPath.FULL_CI: ControlMode.LIVE,
+            AlertPath.MAIN_CI: ControlMode.DISABLED,
         }
     )
     units = RecordingUnits()
@@ -76,3 +84,21 @@ def test_live_control_enables_only_selected_path(tmp_path: Path) -> None:
 
     assert (tmp_path / "full-ci.mode").read_text() == ("ALERTING_DELIVERY_MODE=live\n")
     assert units.enabled == ["alerting-full-ci.timer"]
+
+
+def test_main_ci_live_control_enables_its_independent_timer(tmp_path: Path) -> None:
+    controls = MemoryAlertControl(
+        {
+            AlertPath.FAST_CI: ControlMode.DISABLED,
+            AlertPath.FULL_CI: ControlMode.DISABLED,
+            AlertPath.MAIN_CI: ControlMode.LIVE,
+        }
+    )
+    units = RecordingUnits()
+
+    reconcile_controls(controls=controls, units=units, mode_dir=tmp_path)
+
+    assert (tmp_path / "main-ci.mode").read_text() == (
+        "ALERTING_DELIVERY_MODE=live\n"
+    )
+    assert units.enabled == ["alerting-main-ci.timer"]

--- a/alerting/tests/test_main_ci.py
+++ b/alerting/tests/test_main_ci.py
@@ -1,0 +1,280 @@
+"""Main CI failed-job alert lifecycle through the scheduled-command seam."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from alerting.commands import ScheduledCommand
+from alerting.full_ci import BuildkiteRestClient
+from alerting.main_ci import (
+    INITIAL_LOOKBACK,
+    SAFETY_OVERLAP,
+    BuildkiteMainCISource,
+    MainCIJobObservation,
+    MainCIReconciliationHandler,
+)
+from alerting.memory import (
+    FixedClock,
+    InMemoryAutomationExecutionStore,
+    InMemoryMainCIStore,
+    InMemoryOutboxStore,
+    RecordingSlackPort,
+)
+from alerting.runtime import AlertingRuntime, ProcessStatus
+
+START = datetime(2026, 8, 29, 10, 0, tzinfo=timezone.utc)
+
+
+class FixtureSource:
+    def __init__(self) -> None:
+        self.observations: list[MainCIJobObservation] = []
+        self.calls: list[tuple[datetime, datetime]] = []
+
+    def fetch_observations(
+        self, *, start_time: datetime, end_time: datetime
+    ) -> list[MainCIJobObservation]:
+        self.calls.append((start_time, end_time))
+        return [
+            item
+            for item in self.observations
+            if start_time <= item.finished_at <= end_time
+        ]
+
+
+class RecordingBuildkite:
+    def __init__(self, builds: list[dict[str, Any]]) -> None:
+        self.builds = builds
+        self.calls: list[tuple[datetime, datetime]] = []
+
+    def list_job_builds(
+        self, *, observed_from: datetime, up_to: datetime
+    ) -> list[dict[str, Any]]:
+        self.calls.append((observed_from, up_to))
+        return self.builds
+
+
+class RecordingRestClient(BuildkiteRestClient):
+    def __init__(self) -> None:
+        super().__init__(token="not-used")
+        self.queries: list[dict[str, str | int | list[str]]] = []
+
+    def _list_build_pages(
+        self, query: dict[str, str | int | list[str]]
+    ) -> list[dict[str, Any]]:
+        self.queries.append(dict(query))
+        if query["state"] == "finished":
+            return [{"id": "shared"}, {"id": "finished"}]
+        return [{"id": "active"}, {"id": "shared"}]
+
+
+def observation(
+    *,
+    build_number: int,
+    state: str,
+    minutes: int,
+    job_id: str | None = None,
+) -> MainCIJobObservation:
+    actual_job_id = job_id or f"job-{build_number}-{state}"
+    return MainCIJobObservation(
+        job_key="step:gpu-test|name:GPU correctness",
+        job_id=actual_job_id,
+        job_name="GPU correctness",
+        job_url=f"https://buildkite.com/vllm/ci/builds/{build_number}#{actual_job_id}",
+        state=state,
+        finished_at=START + timedelta(minutes=minutes),
+        build_id=f"build-{build_number}",
+        build_number=build_number,
+        build_url=f"https://buildkite.com/vllm/ci/builds/{build_number}",
+        commit_sha=f"commit-{build_number}",
+    )
+
+
+def runtime_for(
+    source: FixtureSource,
+) -> tuple[AlertingRuntime, InMemoryMainCIStore, FixedClock]:
+    clock = FixedClock(START)
+    executions = InMemoryAutomationExecutionStore()
+    store = InMemoryMainCIStore(executions=executions)
+    runtime = AlertingRuntime(
+        executions=executions,
+        outbox=InMemoryOutboxStore(),
+        slack=RecordingSlackPort(),
+        clock=clock,
+        handlers={
+            "main_ci_reconcile": MainCIReconciliationHandler(
+                source=source,
+                store=store,
+                clock=clock,
+            )
+        },
+    )
+    return runtime, store, clock
+
+
+def reconcile(runtime: AlertingRuntime, target: datetime) -> None:
+    result = runtime.process_command(
+        ScheduledCommand(command_type="main_ci_reconcile", target_time=target)
+    )
+    assert result.status is ProcessStatus.COMPLETED
+
+
+def test_failure_episode_updates_resolves_only_on_pass_and_can_reopen() -> None:
+    source = FixtureSource()
+    runtime, store, _ = runtime_for(source)
+
+    source.observations = [observation(build_number=100, state="failed", minutes=1)]
+    reconcile(runtime, START + timedelta(minutes=2))
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("open", 1)
+    ]
+
+    source.observations.append(
+        observation(build_number=101, state="timed_out", minutes=6)
+    )
+    reconcile(runtime, START + timedelta(minutes=7))
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("open", 2)
+    ]
+
+    source.observations.append(
+        observation(build_number=102, state="passed", minutes=11)
+    )
+    reconcile(runtime, START + timedelta(minutes=12))
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("resolved", 2)
+    ]
+
+    source.observations.append(
+        observation(build_number=103, state="failed", minutes=16)
+    )
+    reconcile(runtime, START + timedelta(minutes=17))
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("resolved", 2),
+        ("open", 1),
+    ]
+
+
+def test_older_build_finishing_late_cannot_overwrite_newer_outcome() -> None:
+    source = FixtureSource()
+    runtime, store, _ = runtime_for(source)
+    source.observations = [
+        observation(build_number=201, state="failed", minutes=2),
+        observation(build_number=200, state="passed", minutes=3),
+    ]
+
+    reconcile(runtime, START + timedelta(minutes=4))
+
+    assert store.state("step:gpu-test|name:GPU correctness") == source.observations[0]
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("open", 1)
+    ]
+
+
+def test_scan_uses_initial_backfill_then_a_safety_overlap() -> None:
+    source = FixtureSource()
+    runtime, store, _ = runtime_for(source)
+    first_target = START + timedelta(minutes=2)
+    second_target = START + timedelta(minutes=7)
+
+    reconcile(runtime, first_target)
+    reconcile(runtime, second_target)
+
+    assert source.calls == [
+        (first_target - INITIAL_LOOKBACK, first_target),
+        (first_target - SAFETY_OVERLAP, second_target),
+    ]
+    assert store.main_ci_scan_cursor() == second_target
+
+
+def test_buildkite_source_keeps_hard_terminal_script_jobs_and_matrix_identity() -> None:
+    buildkite = RecordingBuildkite(
+        [
+            {
+                "id": "build-300",
+                "number": 300,
+                "web_url": "https://buildkite.com/vllm/ci/builds/300",
+                "commit": "abc123",
+                "jobs": [
+                    {
+                        "id": "matrix-a",
+                        "name": "GPU correctness / shard 1",
+                        "type": "script",
+                        "step_key": "gpu-correctness",
+                        "state": "failed",
+                        "soft_failed": False,
+                        "finished_at": "2026-08-29T09:55:00Z",
+                        "web_url": "https://example.test/matrix-a",
+                    },
+                    {
+                        "id": "matrix-b",
+                        "name": "GPU correctness / shard 2",
+                        "type": "script",
+                        "step_key": "gpu-correctness",
+                        "state": "passed",
+                        "soft_failed": False,
+                        "finished_at": "2026-08-29T09:56:00Z",
+                        "web_url": "https://example.test/matrix-b",
+                    },
+                    {
+                        "id": "soft",
+                        "name": "Optional check",
+                        "type": "script",
+                        "step_key": "optional",
+                        "state": "failed",
+                        "soft_failed": True,
+                        "finished_at": "2026-08-29T09:57:00Z",
+                    },
+                    {
+                        "id": "waiting",
+                        "name": "Still waiting",
+                        "type": "script",
+                        "step_key": "waiting",
+                        "state": "scheduled",
+                        "soft_failed": False,
+                        "finished_at": None,
+                    },
+                    {
+                        "id": "group",
+                        "name": "Group",
+                        "type": "group",
+                        "state": "failed",
+                        "soft_failed": False,
+                        "finished_at": "2026-08-29T09:58:00Z",
+                    },
+                ],
+            }
+        ]
+    )
+
+    rows = BuildkiteMainCISource(buildkite).fetch_observations(
+        start_time=START - timedelta(minutes=10),
+        end_time=START,
+    )
+
+    assert [row.job_id for row in rows] == ["matrix-a", "matrix-b"]
+    assert [row.job_key for row in rows] == [
+        "step:gpu-correctness|name:GPU correctness / shard 1",
+        "step:gpu-correctness|name:GPU correctness / shard 2",
+    ]
+    assert buildkite.calls == [(START - timedelta(minutes=10), START)]
+
+
+def test_buildkite_client_unions_active_and_recently_finished_builds() -> None:
+    client = RecordingRestClient()
+    observed_from = START - timedelta(minutes=30)
+
+    rows = client.list_job_builds(observed_from=observed_from, up_to=START)
+
+    assert {row["id"] for row in rows} == {"active", "shared", "finished"}
+    assert client.queries[0]["state"] == [
+        "creating",
+        "scheduled",
+        "running",
+        "failing",
+        "canceling",
+    ]
+    assert client.queries[1]["state"] == "finished"
+    assert client.queries[1]["finished_from"] == "2026-08-29T09:30:00Z"
+    for query in client.queries:
+        assert query["branch"] == "main"
+        assert query["include_retried_jobs"] == "false"
+        assert "exclude_jobs" not in query

--- a/alerting/tests/test_worker.py
+++ b/alerting/tests/test_worker.py
@@ -71,3 +71,15 @@ def test_timer_worker_uses_explicit_live_delivery_mode(
 
     assert worker.main(["full-ci-analyze"]) == 0
     assert observed_modes == [DeliveryMode.LIVE]
+
+
+def test_main_ci_timer_uses_its_lifecycle_reconciliation_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = RecordingRuntime()
+    monkeypatch.setattr(worker, "_runtime", lambda *args: runtime)
+
+    assert worker.main(["main-ci"]) == 0
+    assert [command.command_type for command in runtime.commands] == [
+        "main_ci_reconcile"
+    ]

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -13,6 +13,7 @@ from alerting.postgres import (
     build_fast_ci_runtime,
     build_full_ci_analysis_runtime,
     build_full_ci_runtime,
+    build_main_ci_runtime,
 )
 from alerting.runtime import AlertingRuntime, ProcessStatus
 from alerting.slack import SlackDeliveryPort
@@ -84,6 +85,13 @@ def _runtime(
             clock=clock,
             delivery_mode=delivery_mode,
         )
+    if consumer == "main-ci":
+        return build_main_ci_runtime(
+            database_url=database_url,
+            buildkite_token=_required_environment("BUILDKITE_TOKEN"),
+            slack=_slack(),
+            clock=clock,
+        )
     raise ValueError(f"unknown consumer: {consumer}")
 
 
@@ -95,6 +103,7 @@ def scheduled_command(consumer: str, target_time: datetime) -> ScheduledCommand:
         "fast-ci": "fast_ci_scan",
         "full-ci": "full_ci_reconcile",
         "full-ci-analyze": "full_ci_analyze",
+        "main-ci": "main_ci_reconcile",
     }
     try:
         command_type = command_types[consumer]
@@ -106,7 +115,12 @@ def scheduled_command(consumer: str, target_time: datetime) -> ScheduledCommand:
 
 def main(arguments: Sequence[str] | None = None) -> int:
     args = list(arguments if arguments is not None else sys.argv[1:])
-    if len(args) != 1 or args[0] not in {"fast-ci", "full-ci", "full-ci-analyze"}:
+    if len(args) != 1 or args[0] not in {
+        "fast-ci",
+        "full-ci",
+        "full-ci-analyze",
+        "main-ci",
+    }:
         return 2
 
     consumer = args[0]

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -48,12 +48,15 @@ when validating before merge.
 
 ## Shadow, cutover, and rollback
 
-Both paths start in shadow mode. Durable controls live at
+All three paths start in shadow mode. Durable controls live at
 `s3://CHECKPOINT_BUCKET/control/fast_ci.mode` and
-`s3://CHECKPOINT_BUCKET/control/full_ci.mode`; allowed values are `shadow`,
+`s3://CHECKPOINT_BUCKET/control/full_ci.mode`, plus
+`s3://CHECKPOINT_BUCKET/control/main_ci.mode`; allowed values are `shadow`,
 `live`, and `disabled`. A root oneshot reconciles those objects every minute,
 but workers run as the non-login `alerting` user. Shadow runs persist source
 observations and rendered Slack payloads without leasing them for delivery.
+Main CI currently writes dashboard lifecycle only and renders no Slack payload;
+its mode still controls the independent five-minute timer.
 
 Run the repeatable operator wizard from the repository root:
 
@@ -70,8 +73,8 @@ selected old producer, and never rewinds Postgres or S3 state.
 
 ## Recovery check
 
-Stop both timers before a scheduled tick, wait through the tick, then start the
-timers again. `Persistent=true` and `OnBootSec` start reconciliation, while the
-Postgres cursors and processed-run history recover every missed Fast or Full CI
-observation. Full and Fast CI have separate timers and services, so a long Full
-CI execution does not occupy or delay the Fast CI service.
+Stop all three timers before a scheduled tick, wait through the tick, then
+start the timers again. `Persistent=true` and `OnBootSec` start reconciliation,
+while the Postgres cursors and processed-run history recover missed Fast, Full,
+or Main CI observations. Each path has a separate timer and service, so a long
+Full CI execution cannot occupy either frequent poller.

--- a/deploy/aws/bin/run-worker
+++ b/deploy/aws/bin/run-worker
@@ -6,6 +6,7 @@ credentials_path="/run/alerting/${consumer}.env"
 case "$consumer" in
   fast-ci) alert_path=fast-ci ;;
   full-ci|full-ci-analyze) alert_path=full-ci ;;
+  main-ci) alert_path=main-ci ;;
   *) echo "unknown consumer: $consumer" >&2; exit 2 ;;
 esac
 mode_path="/run/alerting/${alert_path}.mode"

--- a/deploy/aws/systemd/alerting-main-ci.service
+++ b/deploy/aws/systemd/alerting-main-ci.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Reconcile Main CI job alert lifecycles
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=alerting
+Group=alerting
+ExecStart=/opt/alerting/bin/run-worker main-ci
+StandardOutput=null
+StandardError=null
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+TimeoutStartSec=10min

--- a/deploy/aws/systemd/alerting-main-ci.timer
+++ b/deploy/aws/systemd/alerting-main-ci.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Schedule Main CI job alert reconciliation every five minutes
+
+[Timer]
+OnBootSec=2min
+OnCalendar=*-*-* *:00/5:00 UTC
+Persistent=true
+AccuracySec=30s
+RandomizedDelaySec=0
+Unit=alerting-main-ci.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/aws/tests/test_alerting_worker_infrastructure.py
+++ b/deploy/aws/tests/test_alerting_worker_infrastructure.py
@@ -58,25 +58,39 @@ def test_fast_ci_timer_uses_pacific_wall_clock_every_fifteen_minutes() -> None:
     assert "Persistent=true" in timer
 
 
+def test_main_ci_timer_polls_every_five_minutes_and_recovers_after_downtime() -> None:
+    timer = read("systemd/alerting-main-ci.timer")
+
+    assert "OnCalendar=*-*-* *:00/5:00 UTC" in timer
+    assert "OnBootSec=" in timer
+    assert "Persistent=true" in timer
+
+
 def test_consumers_are_independent_and_units_never_contain_sensitive_data() -> None:
     full_service = read("systemd/alerting-full-ci.service")
     fast_service = read("systemd/alerting-fast-ci.service")
+    main_service = read("systemd/alerting-main-ci.service")
     unit_text = "\n".join(
         [
             full_service,
             fast_service,
+            main_service,
             read("systemd/alerting-full-ci.timer"),
             read("systemd/alerting-fast-ci.timer"),
+            read("systemd/alerting-main-ci.timer"),
         ]
     )
 
     assert "run-worker full-ci" in full_service
     assert "run-worker full-ci-analyze" in full_service
     assert "run-worker fast-ci" in fast_service
+    assert "run-worker main-ci" in main_service
     assert "StandardOutput=null" in full_service
     assert "StandardError=null" in full_service
     assert "StandardOutput=null" in fast_service
     assert "StandardError=null" in fast_service
+    assert "StandardOutput=null" in main_service
+    assert "StandardError=null" in main_service
     for sensitive_name in (
         "DATABASE_URL",
         "TOKEN",
@@ -118,6 +132,7 @@ def test_installation_creates_a_non_login_user_and_s3_controlled_timers() -> Non
     assert "systemctl enable --now alerting-control.timer" in installer
     assert "systemctl enable --now alerting-full-ci.timer" not in installer
     assert "systemctl enable --now alerting-fast-ci.timer" not in installer
+    assert "systemctl enable --now alerting-main-ci.timer" not in installer
 
 
 def test_s3_control_reconciles_each_path_without_cloudwatch_or_sqs() -> None:
@@ -172,7 +187,11 @@ def test_retention_timer_prunes_daily_without_sensitive_data() -> None:
 
 @pytest.mark.parametrize(
     ("consumer", "command_type"),
-    [("full-ci", "full_ci_reconcile"), ("fast-ci", "fast_ci_scan")],
+    [
+        ("full-ci", "full_ci_reconcile"),
+        ("fast-ci", "fast_ci_scan"),
+        ("main-ci", "main_ci_reconcile"),
+    ],
 )
 def test_timer_wake_up_creates_a_minute_stable_reconciliation_command(
     consumer: str, command_type: str

--- a/migrations/sql/0014_main_ci_job_alerts.sql
+++ b/migrations/sql/0014_main_ci_job_alerts.sql
@@ -1,0 +1,121 @@
+-- Current Main CI job state is separate from alert episodes. This prevents an
+-- older build that finishes late from reopening or resolving a newer outcome.
+CREATE TABLE IF NOT EXISTS alerting_main_ci_scan_cursors (
+    cursor_name     text PRIMARY KEY CHECK (cursor_name = 'main_ci'),
+    scanned_through timestamptz NOT NULL,
+    updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS alerting_main_ci_job_states (
+    job_key                     text PRIMARY KEY,
+    job_name                    text NOT NULL,
+    latest_job_id               text NOT NULL UNIQUE,
+    latest_job_state            text NOT NULL
+        CHECK (latest_job_state IN ('passed', 'failed', 'failing', 'broken', 'timed_out')),
+    latest_finished_at          timestamptz NOT NULL,
+    latest_build_id             text NOT NULL,
+    latest_build_number         bigint NOT NULL,
+    latest_build_url            text NOT NULL,
+    latest_job_url              text NOT NULL,
+    latest_commit_sha           text NOT NULL,
+    updated_at                  timestamptz NOT NULL
+);
+
+-- An alert is one failure episode. Repeated failures update the open episode;
+-- a positively observed pass resolves it, and a later failure opens a new one.
+CREATE TABLE IF NOT EXISTS alerting_main_ci_job_alerts (
+    alert_id                    bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    job_key                     text NOT NULL,
+    job_name                    text NOT NULL,
+    status                      text NOT NULL
+        CHECK (status IN ('open', 'resolved')),
+    opened_at                   timestamptz NOT NULL,
+    first_failure_job_id        text NOT NULL,
+    first_failure_state         text NOT NULL
+        CHECK (first_failure_state IN ('failed', 'failing', 'broken', 'timed_out')),
+    first_failure_build_id      text NOT NULL,
+    first_failure_build_number  bigint NOT NULL,
+    first_failure_build_url     text NOT NULL,
+    first_failure_job_url       text NOT NULL,
+    first_failure_commit_sha    text NOT NULL,
+    last_failed_at              timestamptz NOT NULL,
+    last_failure_job_id         text NOT NULL,
+    last_failure_state          text NOT NULL
+        CHECK (last_failure_state IN ('failed', 'failing', 'broken', 'timed_out')),
+    last_failure_build_id       text NOT NULL,
+    last_failure_build_number   bigint NOT NULL,
+    last_failure_build_url      text NOT NULL,
+    last_failure_job_url        text NOT NULL,
+    last_failure_commit_sha     text NOT NULL,
+    failure_count               integer NOT NULL CHECK (failure_count > 0),
+    resolved_at                 timestamptz,
+    resolution_job_id           text,
+    resolution_build_id         text,
+    resolution_build_number     bigint,
+    resolution_build_url        text,
+    resolution_job_url          text,
+    resolution_commit_sha       text,
+    created_at                  timestamptz NOT NULL,
+    updated_at                  timestamptz NOT NULL,
+    CHECK (
+        (status = 'open'
+         AND resolved_at IS NULL
+         AND resolution_job_id IS NULL
+         AND resolution_build_id IS NULL
+         AND resolution_build_number IS NULL
+         AND resolution_build_url IS NULL
+         AND resolution_job_url IS NULL
+         AND resolution_commit_sha IS NULL)
+        OR
+        (status = 'resolved'
+         AND resolved_at IS NOT NULL
+         AND resolution_job_id IS NOT NULL
+         AND resolution_build_id IS NOT NULL
+         AND resolution_build_number IS NOT NULL
+         AND resolution_build_url IS NOT NULL
+         AND resolution_job_url IS NOT NULL
+         AND resolution_commit_sha IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS alerting_main_ci_job_alerts_open_idx
+    ON alerting_main_ci_job_alerts (job_key)
+    WHERE status = 'open';
+
+CREATE INDEX IF NOT EXISTS alerting_main_ci_job_alerts_history_idx
+    ON alerting_main_ci_job_alerts (
+        status, (COALESCE(resolved_at, last_failed_at)) DESC
+    );
+
+-- The worker has no Main CI Slack renderer yet, but path-scoping it now keeps
+-- controls and any future outbox records independent from Fast and Full CI.
+ALTER TABLE alerting_notification_outbox
+    DROP CONSTRAINT IF EXISTS alerting_notification_outbox_path_check;
+ALTER TABLE alerting_notification_outbox
+    ADD CONSTRAINT alerting_notification_outbox_path_check
+    CHECK (alert_path IN ('fast_ci', 'full_ci', 'main_ci'));
+
+ALTER TABLE public.alerting_main_ci_scan_cursors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.alerting_main_ci_job_states ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.alerting_main_ci_job_alerts ENABLE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE
+    api_role name;
+    protected_tables constant text :=
+        'public.alerting_main_ci_scan_cursors, '
+        'public.alerting_main_ci_job_states, '
+        'public.alerting_main_ci_job_alerts';
+BEGIN
+    FOREACH api_role IN ARRAY ARRAY['anon'::name, 'authenticated'::name]
+    LOOP
+        IF EXISTS (SELECT FROM pg_roles WHERE rolname = api_role) THEN
+            EXECUTE format(
+                'REVOKE ALL PRIVILEGES ON TABLE %s FROM %I',
+                protected_tables,
+                api_role
+            );
+        END IF;
+    END LOOP;
+END;
+$$;

--- a/migrations/tests/test_migrations.py
+++ b/migrations/tests/test_migrations.py
@@ -56,6 +56,9 @@ def test_expected_tables_are_created() -> None:
         "alerting_full_ci_failure_conditions",
         "alerting_full_ci_import_baselines",
         "alerting_fast_ci_imported_deduplication_keys",
+        "alerting_main_ci_scan_cursors",
+        "alerting_main_ci_job_states",
+        "alerting_main_ci_job_alerts",
     }
 
     for table in expected_tables:
@@ -141,6 +144,24 @@ def test_shadow_delivery_schema_is_path_scoped_and_never_due() -> None:
     assert "CHECK (alert_path IN ('fast_ci', 'full_ci'))" in sql
     assert "CHECK (delivery_mode IN ('live', 'shadow'))" in sql
     assert "WHERE delivery_mode = 'live'" in sql
+
+
+def test_main_ci_schema_preserves_one_open_episode_and_positive_pass_resolution() -> None:
+    sql = (MIGRATIONS_DIR / "0014_main_ci_job_alerts.sql").read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS alerting_main_ci_job_states" in sql
+    assert "latest_build_number         bigint NOT NULL" in sql
+    assert "CREATE TABLE IF NOT EXISTS alerting_main_ci_job_alerts" in sql
+    assert "WHERE status = 'open'" in sql
+    assert "status IN ('open', 'resolved')" in sql
+    assert "resolution_job_id           text" in sql
+    assert "'fast_ci', 'full_ci', 'main_ci'" in sql
+    for table in (
+        "alerting_main_ci_scan_cursors",
+        "alerting_main_ci_job_states",
+        "alerting_main_ci_job_alerts",
+    ):
+        assert f"ALTER TABLE public.{table} ENABLE ROW LEVEL SECURITY" in sql
 
 
 def test_dashboard_schema_keeps_legacy_additive_columns_and_covering_index() -> None:

--- a/src/CONTEXT.md
+++ b/src/CONTEXT.md
@@ -1,12 +1,19 @@
 # CI Dashboard
 
-This context presents CI operational state and alert history for maintainers and public readers, and owns the queue-wait alert lifecycle. Fast and Full CI alert qualification belongs to Alert Production.
+This context presents CI operational state and alert history for maintainers
+and public readers, and owns the queue-wait alert lifecycle. Fast, Full, and
+Main CI alert qualification belongs to Alert Production.
 
 ## Language
 
 **Alert History**:
 The read-only sequence of durable records produced by Alert Production.
 _Avoid_: Notification history, Slack history
+
+**Main CI Job Alert View**:
+The read-only open and recently resolved failure episodes for exact
+main-branch jobs. It presents Buildkite evidence but no automated diagnosis.
+_Avoid_: Incident analysis, Slack ledger
 
 **CI Health View**:
 A dashboard presentation of build, job, queue, test, and alert state.

--- a/src/app/alerts/alerts-content.tsx
+++ b/src/app/alerts/alerts-content.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { FastCIAlerts } from "@/components/fast-ci-alerts";
 import { FullCIAlerts } from "@/components/full-ci-alerts";
+import { MainCIAlerts } from "@/components/main-ci-alerts";
 import {
   groupFastFailureEvents,
   type FastFailureEvent,
@@ -13,6 +14,10 @@ import {
   viewFullCiComparisons,
   type FullCiComparison,
 } from "@/lib/alerts-full-ci";
+import {
+  viewMainCiJobAlerts,
+  type MainCiJobAlert,
+} from "@/lib/alerts-main-ci";
 import {
   ALERT_TIME_WINDOWS,
   alertWindowCutoff,
@@ -23,9 +28,10 @@ import {
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
-type AlertTab = "fast-ci" | "full-ci";
+type AlertTab = "main-ci" | "fast-ci" | "full-ci";
 
 const ALERT_TABS: readonly { value: AlertTab; label: string }[] = [
+  { value: "main-ci", label: "Main CI jobs" },
   { value: "fast-ci", label: "Fast CI" },
   { value: "full-ci", label: "Full CI" },
 ];
@@ -42,6 +48,11 @@ interface FullCIAlertsResponse {
 interface FastCIAlertsResponse {
   events?: FastFailureEvent[];
   windowDays?: number;
+  error?: string;
+}
+
+interface MainCIAlertsResponse {
+  alerts?: MainCiJobAlert[];
   error?: string;
 }
 
@@ -125,6 +136,34 @@ function FullCISection({ timeWindow }: { timeWindow: AlertTimeWindow }) {
       failed={Boolean(error || data?.error)}
     >
       <FullCIAlerts comparisons={comparisons} />
+    </AlertSection>
+  );
+}
+
+function MainCISection({ timeWindow }: { timeWindow: AlertTimeWindow }) {
+  const { data, isLoading, error } = useSWR<MainCIAlertsResponse>(
+    "/api/alerts/main-ci",
+    fetcher,
+    { refreshInterval: 5 * 60 * 1000 },
+  );
+
+  const alerts = useMemo(
+    () =>
+      viewMainCiJobAlerts(
+        data?.alerts ?? [],
+        alertWindowCutoff(timeWindow),
+      ),
+    [data, timeWindow],
+  );
+
+  return (
+    <AlertSection
+      title="Main CI job alerts"
+      description="Hard command-job failures on the main branch. A failure stays open across builds until that exact Buildkite step positively passes again; soft failures, missing jobs, and older builds finishing late do not resolve it."
+      isLoading={isLoading}
+      failed={Boolean(error || data?.error)}
+    >
+      <MainCIAlerts alerts={alerts} />
     </AlertSection>
   );
 }
@@ -264,7 +303,9 @@ export default function AlertsContent() {
         )}
       </div>
 
-      {tab === "fast-ci" ? (
+      {tab === "main-ci" ? (
+        <MainCISection timeWindow={timeWindow} />
+      ) : tab === "fast-ci" ? (
         <FastCISection timeWindow={timeWindow} softFailedOnly={softFailedOnly} />
       ) : (
         <FullCISection timeWindow={timeWindow} />

--- a/src/app/api/alerts/main-ci/route.ts
+++ b/src/app/api/alerts/main-ci/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import {
+  toMainCiJobAlert,
+  type MainCiJobAlertRow,
+} from "@/lib/alerts-main-ci";
+
+export const dynamic = "force-dynamic";
+
+const MAX_ALERTS = 500;
+
+export async function GET() {
+  try {
+    const db = getDb();
+    const rows = await db<MainCiJobAlertRow[]>`
+      SELECT alert_id, job_key, job_name, status, opened_at,
+             first_failure_job_id, first_failure_state,
+             first_failure_build_id, first_failure_build_number,
+             first_failure_build_url, first_failure_job_url,
+             first_failure_commit_sha,
+             last_failed_at, last_failure_job_id, last_failure_state,
+             last_failure_build_id, last_failure_build_number,
+             last_failure_build_url, last_failure_job_url,
+             last_failure_commit_sha, failure_count,
+             resolved_at, resolution_job_id, resolution_build_id,
+             resolution_build_number, resolution_build_url,
+             resolution_job_url, resolution_commit_sha
+      FROM alerting_main_ci_job_alerts
+      WHERE status = 'open' OR resolved_at >= now() - interval '30 days'
+      ORDER BY (status = 'open') DESC,
+               COALESCE(resolved_at, last_failed_at) DESC
+      LIMIT ${MAX_ALERTS}
+    `;
+    return NextResponse.json(
+      { alerts: rows.map(toMainCiJobAlert) },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    console.error("Failed to load Main CI job alerts:", error);
+    return NextResponse.json(
+      { error: "Main CI job alerts could not be loaded." },
+      { status: 500, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/src/components/main-ci-alerts.test.ts
+++ b/src/components/main-ci-alerts.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MainCIAlerts } from "./main-ci-alerts";
+import type { MainCiJobAlert } from "../lib/alerts-main-ci";
+
+function alert(overrides: Partial<MainCiJobAlert> = {}): MainCiJobAlert {
+  return {
+    alertId: "1",
+    jobKey: "step:gpu|name:GPU test",
+    jobName: "GPU test",
+    status: "open",
+    openedAt: "2026-08-29T08:00:00.000Z",
+    firstFailure: {
+      buildkiteJobId: "job-1",
+      state: "failed",
+      finishedAt: "2026-08-29T08:00:00.000Z",
+      buildkiteBuildId: "build-100",
+      buildNumber: 100,
+      buildUrl: "https://buildkite.com/vllm/ci/builds/100",
+      jobUrl: "https://example.test/job-1",
+      commitSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    },
+    lastFailure: {
+      buildkiteJobId: "job-2",
+      state: "failed",
+      finishedAt: "2026-08-29T09:00:00.000Z",
+      buildkiteBuildId: "build-101",
+      buildNumber: 101,
+      buildUrl: "https://buildkite.com/vllm/ci/builds/101",
+      jobUrl: "https://example.test/job-2",
+      commitSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    },
+    failureCount: 2,
+    resolvedAt: null,
+    resolution: null,
+    ...overrides,
+  };
+}
+
+test("empty lifecycle history renders an explicit empty state", () => {
+  const markup = renderToStaticMarkup(createElement(MainCIAlerts, { alerts: [] }));
+  assert.match(markup, /No Main CI job alerts/);
+});
+
+test("open alert renders first and latest exact failure evidence", () => {
+  const markup = renderToStaticMarkup(
+    createElement(MainCIAlerts, { alerts: [alert()] }),
+  );
+
+  assert.match(markup, /Open/);
+  assert.match(markup, /2 failed runs/);
+  assert.match(markup, /First failure/);
+  assert.match(markup, /Latest failure/);
+  assert.match(markup, /https:\/\/buildkite\.com\/vllm\/ci\/builds\/101/);
+});
+
+test("resolved alert renders the exact pass that closed it", () => {
+  const passed = {
+    ...alert().lastFailure,
+    buildkiteJobId: "job-3",
+    state: "passed",
+    finishedAt: "2026-08-29T09:30:00.000Z",
+    buildkiteBuildId: "build-102",
+    buildNumber: 102,
+    buildUrl: "https://buildkite.com/vllm/ci/builds/102",
+    jobUrl: "https://example.test/job-3",
+    commitSha: "cccccccccccccccccccccccccccccccccccccccc",
+  };
+  const markup = renderToStaticMarkup(
+    createElement(MainCIAlerts, {
+      alerts: [
+        alert({
+          status: "resolved",
+          resolvedAt: passed.finishedAt,
+          resolution: passed,
+        }),
+      ],
+    }),
+  );
+
+  assert.match(markup, /Resolved/);
+  assert.match(markup, /Passed again/);
+  assert.match(markup, /https:\/\/buildkite\.com\/vllm\/ci\/builds\/102/);
+});
+

--- a/src/components/main-ci-alerts.tsx
+++ b/src/components/main-ci-alerts.tsx
@@ -1,0 +1,120 @@
+import { JobName } from "@/components/job-name";
+import { type MainCiJobAlert } from "@/lib/alerts-main-ci";
+import { commitUrl, formatAlertDateTime } from "@/lib/alerts-shared";
+
+const STATUS_CLASSES = {
+  open: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+  resolved:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300",
+} as const;
+
+function BuildLink({
+  label,
+  buildNumber,
+  buildUrl,
+  jobUrl,
+}: {
+  label: string;
+  buildNumber: number;
+  buildUrl: string;
+  jobUrl: string;
+}) {
+  return (
+    <span className="flex flex-wrap items-baseline gap-x-1.5">
+      <span className="text-zinc-500 dark:text-zinc-400">{label}</span>
+      <a
+        href={buildUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="text-blue-600 hover:underline dark:text-blue-400"
+      >
+        build {buildNumber}
+      </a>
+      <a
+        href={jobUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="text-blue-600 hover:underline dark:text-blue-400"
+      >
+        job
+      </a>
+    </span>
+  );
+}
+
+function AlertCard({ alert }: { alert: MainCiJobAlert }) {
+  return (
+    <article className="overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 border-b border-zinc-200 px-4 py-3 sm:px-5 dark:border-zinc-800">
+        <span className="min-w-0 truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          <JobName name={alert.jobName} />
+        </span>
+        <span
+          className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${STATUS_CLASSES[alert.status]}`}
+        >
+          {alert.status === "open" ? "Open" : "Resolved"}
+        </span>
+        <span className="text-xs text-zinc-500 dark:text-zinc-400">
+          {alert.failureCount} failed {alert.failureCount === 1 ? "run" : "runs"}
+        </span>
+        <span className="ml-auto text-xs text-zinc-500 dark:text-zinc-400">
+          {alert.status === "open" ? "last failed" : "resolved"}{" "}
+          {formatAlertDateTime(
+            alert.resolvedAt ?? alert.lastFailure.finishedAt,
+          )}
+        </span>
+      </div>
+      <div className="space-y-1 px-4 py-3 text-xs sm:px-5">
+        <BuildLink
+          label="First failure"
+          buildNumber={alert.firstFailure.buildNumber}
+          buildUrl={alert.firstFailure.buildUrl}
+          jobUrl={alert.firstFailure.jobUrl}
+        />
+        {alert.lastFailure.buildkiteJobId !==
+          alert.firstFailure.buildkiteJobId && (
+          <BuildLink
+            label="Latest failure"
+            buildNumber={alert.lastFailure.buildNumber}
+            buildUrl={alert.lastFailure.buildUrl}
+            jobUrl={alert.lastFailure.jobUrl}
+          />
+        )}
+        {alert.resolution && (
+          <BuildLink
+            label="Passed again"
+            buildNumber={alert.resolution.buildNumber}
+            buildUrl={alert.resolution.buildUrl}
+            jobUrl={alert.resolution.jobUrl}
+          />
+        )}
+        <a
+          href={commitUrl(alert.lastFailure.commitSha)}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-block font-mono text-blue-600 hover:underline dark:text-blue-400"
+        >
+          {alert.lastFailure.commitSha.slice(0, 7)}
+        </a>
+      </div>
+    </article>
+  );
+}
+
+export function MainCIAlerts({ alerts }: { alerts: MainCiJobAlert[] }) {
+  if (alerts.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center rounded-xl border border-dashed border-zinc-300 text-sm text-zinc-400 dark:border-zinc-700">
+        No Main CI job alerts are active or resolved in this window.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {alerts.map((alert) => (
+        <AlertCard key={alert.alertId} alert={alert} />
+      ))}
+    </div>
+  );
+}

--- a/src/lib/alerts-main-ci.test.ts
+++ b/src/lib/alerts-main-ci.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  toMainCiJobAlert,
+  viewMainCiJobAlerts,
+  type MainCiJobAlertRow,
+} from "./alerts-main-ci";
+
+function alertRow(
+  overrides: Partial<MainCiJobAlertRow> = {},
+): MainCiJobAlertRow {
+  return {
+    alert_id: 42,
+    job_key: "step:gpu|name:GPU test",
+    job_name: "GPU test",
+    status: "open",
+    opened_at: new Date("2026-08-29T08:00:00.000Z"),
+    first_failure_job_id: "job-1",
+    first_failure_state: "failed",
+    first_failure_build_id: "build-100",
+    first_failure_build_number: 100,
+    first_failure_build_url: "https://buildkite.com/vllm/ci/builds/100",
+    first_failure_job_url: "https://example.test/job-1",
+    first_failure_commit_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    last_failed_at: new Date("2026-08-29T09:00:00.000Z"),
+    last_failure_job_id: "job-2",
+    last_failure_state: "timed_out",
+    last_failure_build_id: "build-101",
+    last_failure_build_number: 101,
+    last_failure_build_url: "https://buildkite.com/vllm/ci/builds/101",
+    last_failure_job_url: "https://example.test/job-2",
+    last_failure_commit_sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    failure_count: 2,
+    resolved_at: null,
+    resolution_job_id: null,
+    resolution_build_id: null,
+    resolution_build_number: null,
+    resolution_build_url: null,
+    resolution_job_url: null,
+    resolution_commit_sha: null,
+    ...overrides,
+  };
+}
+
+test("row mapping exposes only the alert episode and exact Buildkite evidence", () => {
+  const alert = toMainCiJobAlert(alertRow());
+
+  assert.equal(alert.alertId, "42");
+  assert.equal(alert.status, "open");
+  assert.equal(alert.failureCount, 2);
+  assert.equal(alert.firstFailure.buildNumber, 100);
+  assert.equal(alert.lastFailure.buildNumber, 101);
+  assert.equal(alert.resolution, null);
+});
+
+test("a positive pass is represented as the resolution", () => {
+  const resolvedAt = new Date("2026-08-29T09:30:00.000Z");
+  const alert = toMainCiJobAlert(
+    alertRow({
+      status: "resolved",
+      resolved_at: resolvedAt,
+      resolution_job_id: "job-3",
+      resolution_build_id: "build-102",
+      resolution_build_number: 102,
+      resolution_build_url: "https://buildkite.com/vllm/ci/builds/102",
+      resolution_job_url: "https://example.test/job-3",
+      resolution_commit_sha: "cccccccccccccccccccccccccccccccccccccccc",
+    }),
+  );
+
+  assert.equal(alert.resolvedAt, resolvedAt.toISOString());
+  assert.deepEqual(alert.resolution, {
+    buildkiteJobId: "job-3",
+    state: "passed",
+    finishedAt: resolvedAt.toISOString(),
+    buildkiteBuildId: "build-102",
+    buildNumber: 102,
+    buildUrl: "https://buildkite.com/vllm/ci/builds/102",
+    jobUrl: "https://example.test/job-3",
+    commitSha: "cccccccccccccccccccccccccccccccccccccccc",
+  });
+});
+
+test("open alerts survive the time filter and sort ahead of resolved history", () => {
+  const oldOpen = toMainCiJobAlert(
+    alertRow({
+      alert_id: 1,
+      last_failed_at: new Date("2026-08-01T00:00:00.000Z"),
+    }),
+  );
+  const recentResolved = toMainCiJobAlert(
+    alertRow({
+      alert_id: 2,
+      status: "resolved",
+      resolved_at: new Date("2026-08-29T09:30:00.000Z"),
+      resolution_job_id: "job-3",
+      resolution_build_id: "build-102",
+      resolution_build_number: 102,
+      resolution_build_url: "https://buildkite.com/vllm/ci/builds/102",
+      resolution_job_url: "https://example.test/job-3",
+      resolution_commit_sha: "cccccccccccccccccccccccccccccccccccccccc",
+    }),
+  );
+  const staleResolved = {
+    ...recentResolved,
+    alertId: "3",
+    resolvedAt: "2026-08-01T00:00:00.000Z",
+  };
+
+  assert.deepEqual(
+    viewMainCiJobAlerts(
+      [recentResolved, staleResolved, oldOpen],
+      new Date("2026-08-28T00:00:00.000Z"),
+    ).map((alert) => alert.alertId),
+    ["1", "2"],
+  );
+});
+

--- a/src/lib/alerts-main-ci.ts
+++ b/src/lib/alerts-main-ci.ts
@@ -1,0 +1,152 @@
+/** Presentation mapping for exact Main CI job alert episodes. */
+
+export type MainCiAlertStatus = "open" | "resolved";
+
+export interface MainCiOutcomeRef {
+  buildkiteJobId: string;
+  state: string;
+  finishedAt: string;
+  buildkiteBuildId: string;
+  buildNumber: number;
+  buildUrl: string;
+  jobUrl: string;
+  commitSha: string;
+}
+
+export interface MainCiJobAlert {
+  alertId: string;
+  jobKey: string;
+  jobName: string;
+  status: MainCiAlertStatus;
+  openedAt: string;
+  firstFailure: MainCiOutcomeRef;
+  lastFailure: MainCiOutcomeRef;
+  failureCount: number;
+  resolvedAt: string | null;
+  resolution: MainCiOutcomeRef | null;
+}
+
+export interface MainCiJobAlertRow {
+  alert_id: string | number;
+  job_key: string;
+  job_name: string;
+  status: MainCiAlertStatus;
+  opened_at: Date;
+  first_failure_job_id: string;
+  first_failure_state: string;
+  first_failure_build_id: string;
+  first_failure_build_number: number | string;
+  first_failure_build_url: string;
+  first_failure_job_url: string;
+  first_failure_commit_sha: string;
+  last_failed_at: Date;
+  last_failure_job_id: string;
+  last_failure_state: string;
+  last_failure_build_id: string;
+  last_failure_build_number: number | string;
+  last_failure_build_url: string;
+  last_failure_job_url: string;
+  last_failure_commit_sha: string;
+  failure_count: number | string;
+  resolved_at: Date | null;
+  resolution_job_id: string | null;
+  resolution_build_id: string | null;
+  resolution_build_number: number | string | null;
+  resolution_build_url: string | null;
+  resolution_job_url: string | null;
+  resolution_commit_sha: string | null;
+}
+
+function outcome(
+  jobId: string,
+  state: string,
+  finishedAt: Date,
+  buildId: string,
+  buildNumber: number | string,
+  buildUrl: string,
+  jobUrl: string,
+  commitSha: string,
+): MainCiOutcomeRef {
+  return {
+    buildkiteJobId: jobId,
+    state,
+    finishedAt: finishedAt.toISOString(),
+    buildkiteBuildId: buildId,
+    buildNumber: Number(buildNumber),
+    buildUrl,
+    jobUrl,
+    commitSha,
+  };
+}
+
+export function toMainCiJobAlert(row: MainCiJobAlertRow): MainCiJobAlert {
+  const resolution =
+    row.resolved_at !== null &&
+    row.resolution_job_id !== null &&
+    row.resolution_build_id !== null &&
+    row.resolution_build_number !== null &&
+    row.resolution_build_url !== null &&
+    row.resolution_job_url !== null &&
+    row.resolution_commit_sha !== null
+      ? outcome(
+          row.resolution_job_id,
+          "passed",
+          row.resolved_at,
+          row.resolution_build_id,
+          row.resolution_build_number,
+          row.resolution_build_url,
+          row.resolution_job_url,
+          row.resolution_commit_sha,
+        )
+      : null;
+  return {
+    alertId: String(row.alert_id),
+    jobKey: row.job_key,
+    jobName: row.job_name,
+    status: row.status,
+    openedAt: row.opened_at.toISOString(),
+    firstFailure: outcome(
+      row.first_failure_job_id,
+      row.first_failure_state,
+      row.opened_at,
+      row.first_failure_build_id,
+      row.first_failure_build_number,
+      row.first_failure_build_url,
+      row.first_failure_job_url,
+      row.first_failure_commit_sha,
+    ),
+    lastFailure: outcome(
+      row.last_failure_job_id,
+      row.last_failure_state,
+      row.last_failed_at,
+      row.last_failure_build_id,
+      row.last_failure_build_number,
+      row.last_failure_build_url,
+      row.last_failure_job_url,
+      row.last_failure_commit_sha,
+    ),
+    failureCount: Number(row.failure_count),
+    resolvedAt: row.resolved_at?.toISOString() ?? null,
+    resolution,
+  };
+}
+
+/** Open alerts remain visible regardless of age; resolved history obeys the window. */
+export function viewMainCiJobAlerts(
+  alerts: readonly MainCiJobAlert[],
+  cutoff: Date,
+): MainCiJobAlert[] {
+  return [...alerts]
+    .filter(
+      (alert) =>
+        alert.status === "open" ||
+        (alert.resolvedAt !== null &&
+          new Date(alert.resolvedAt).getTime() >= cutoff.getTime()),
+    )
+    .sort((a, b) => {
+      if (a.status !== b.status) return a.status === "open" ? -1 : 1;
+      const aTime = a.resolvedAt ?? a.lastFailure.finishedAt;
+      const bTime = b.resolvedAt ?? b.lastFailure.finishedAt;
+      return bTime.localeCompare(aTime) || a.jobName.localeCompare(b.jobName);
+    });
+}


### PR DESCRIPTION
## Summary

- poll recent/active `main` Buildkite builds every five minutes
- open or refresh one durable failure episode per exact step + rendered job name
- resolve only after a positively observed pass in the same or a newer build
- add a **Main CI jobs** dashboard tab with open and recently resolved evidence
- keep diagnosis out of the dashboard; curated analysis remains in Slack

Soft failures, non-command jobs, canceled/missing jobs, and older builds finishing late cannot resolve an alert. Matrix-expanded jobs stay independent.

## Deployment order

1. apply migration `0014_main_ci_job_alerts.sql`
2. deploy the dashboard
3. deploy/reconcile the AWS alert worker; the new `main_ci` control defaults to shadow and enables its independent timer

The Main CI worker writes lifecycle records only and sends no Slack notifications.

## Verification

- `uv run --project alerting pytest alerting/tests deploy/aws/tests` (119 passed)
- `uv run --project migrations pytest migrations/tests` (24 passed)
- `uv run --project alerting ruff check alerting migrations deploy/aws/tests`
- `uv run --project alerting mypy ...` (31 source files)
- `npm test` (53 passed)
- `npm run lint`
- `npm run build`
- read-only live Buildkite dry run: 4,317 terminal observations / 385 logical jobs over 24h
