### PR TITLE
Self-heal analyzer checkpoints after stack recreation + DR runbook

### DIFF
--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -73,6 +73,15 @@ class AnalyzerError(Exception):
     """The analyzer failed or produced an invalid result. Nothing persists."""
 
 
+class CheckpointUnavailable(AnalyzerError):
+    """The referenced checkpoint cannot be read from the configured bucket.
+
+    Raised when a stack recreation swapped the bucket out from under stored
+    references (foreign bucket, missing object, access denied). Recoverable:
+    the handler falls back to empty memory and uploads a fresh checkpoint.
+    """
+
+
 class CauseCategory(StrEnum):
     INFRASTRUCTURE = "infrastructure"
     FLAKY_TEST = "flaky_test"
@@ -579,12 +588,19 @@ class FullCIAnalysisHandler:
             # and its own commit uploads the initial checkpoint.
             memory_files: dict[str, bytes] = {}
         else:
-            blob = self._checkpoints.download(checkpoint.s3_uri)
-            if hashlib.sha256(blob).hexdigest() != checkpoint.sha256:
-                raise AnalyzerError(
-                    f"checkpoint checksum mismatch for {checkpoint.s3_uri}"
-                )
-            memory_files = unpack_checkpoint(blob)
+            try:
+                blob = self._checkpoints.download(checkpoint.s3_uri)
+            except CheckpointUnavailable:
+                # A stack recreation swaps the bucket and strands stored URIs.
+                # Restart from empty memory rather than wedging the analyzer;
+                # this run's commit uploads the new bucket's first checkpoint.
+                memory_files = {}
+            else:
+                if hashlib.sha256(blob).hexdigest() != checkpoint.sha256:
+                    raise AnalyzerError(
+                        f"checkpoint checksum mismatch for {checkpoint.s3_uri}"
+                    )
+                memory_files = unpack_checkpoint(blob)
 
         commit_sha = str(build.get("commit") or context.current.commit_sha)
         with tempfile.TemporaryDirectory(prefix="full-ci-analysis-") as tmp:
@@ -831,7 +847,7 @@ class S3CheckpointStore:
         self._prefix = prefix
 
     def _client(self) -> Any:
-        import boto3  # type: ignore[import-not-found,import-untyped]  # optional, production-only
+        import boto3  # type: ignore[import-untyped]  # optional, production-only
 
         return boto3.client("s3")
 
@@ -849,10 +865,18 @@ class S3CheckpointStore:
     def download(self, s3_uri: str) -> bytes:
         parsed = urllib.parse.urlsplit(s3_uri)
         if parsed.scheme != "s3" or parsed.netloc != self._bucket:
-            raise AnalyzerError(
+            raise CheckpointUnavailable(
                 f"checkpoint URI is outside the configured bucket: {s3_uri}"
             )
-        response = self._client().get_object(
-            Bucket=self._bucket, Key=parsed.path.lstrip("/")
-        )
+        try:
+            response = self._client().get_object(
+                Bucket=self._bucket, Key=parsed.path.lstrip("/")
+            )
+        except Exception as exc:
+            code = getattr(exc, "response", {}).get("Error", {}).get("Code")
+            if code in {"NoSuchKey", "NoSuchBucket", "404", "AccessDenied"}:
+                raise CheckpointUnavailable(
+                    f"checkpoint cannot be read: {s3_uri} ({code})"
+                ) from exc
+            raise
         return cast(bytes, response["Body"].read())

--- a/alerting/tests/test_analyzer.py
+++ b/alerting/tests/test_analyzer.py
@@ -17,6 +17,7 @@ from alerting.analyzer import (
     AnalyzerError,
     CauseCategory,
     CheckpointRef,
+    CheckpointUnavailable,
     CompletedAnalysis,
     FailureCache,
     FailureCondition,
@@ -182,9 +183,14 @@ class FakeCheckpoints:
     def __init__(self) -> None:
         self.objects: dict[str, bytes] = {}
         self._fail = False
+        self._unavailable = False
 
     def fail_next(self) -> None:
         self._fail = True
+
+    def make_unavailable(self) -> None:
+        """Simulate a stack recreation stranding stored checkpoint URIs."""
+        self._unavailable = True
 
     def upload(self, files: Mapping[str, bytes]) -> CheckpointRef:
         if self._fail:
@@ -200,6 +206,8 @@ class FakeCheckpoints:
         )
 
     def download(self, s3_uri: str) -> bytes:
+        if self._unavailable:
+            raise CheckpointUnavailable(f"bucket is gone: {s3_uri}")
         if s3_uri not in self.objects:
             raise RuntimeError(f"checkpoint object missing: {s3_uri}")
         return self.objects[s3_uri]
@@ -872,6 +880,41 @@ def test_corrupted_checkpoint_leaves_baseline_authoritative() -> None:
     assert harness.store.analyses() == []
     assert harness.outbox.records() == []
     assert harness.runner.runs == 0
+
+
+def test_stranded_checkpoint_uri_restarts_from_empty_memory() -> None:
+    """A recreated stack's new bucket strands old URIs; analysis must not wedge."""
+    run1 = make_run(1, RUN1_AT)
+    run2 = make_run(2, RUN2_AT)
+    harness = Harness(
+        runs=[run1, run2],
+        builds={
+            2: build_json(
+                2,
+                mostly_passing_jobs([("Job A", "failed", False)]),
+                scheduled_at=RUN2_AT,
+            )
+        },
+    )
+    assert harness.store.latest_checkpoint() is not None
+    harness.checkpoints.make_unavailable()
+    observed: dict[str, Any] = {}
+
+    def capture(working_dir: Path) -> None:
+        memory = working_dir / ".claude/agent-memory/vllm-ci-failure-analyzer"
+        observed["memory_files"] = (
+            list(memory.rglob("*")) if memory.is_dir() else []
+        )
+        well_behaved(working_dir)
+
+    harness.runner.on_run(capture)
+
+    assert harness.analyze().status is ProcessStatus.COMPLETED
+    assert observed["memory_files"] == []
+    # The completed analysis uploads the new bucket's first checkpoint.
+    assert harness.store.latest_checkpoint() is not None
+    analyses = harness.store.analyses()
+    assert [analysis.current_build_id for analysis in analyses] == [run2.build_id]
 
 
 def test_failure_before_analysis_persists_nothing() -> None:

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -78,3 +78,6 @@ start the timers again. `Persistent=true` and `OnBootSec` start reconciliation,
 while the Postgres cursors and processed-run history recover missed Fast, Full,
 or Main CI observations. Each path has a separate timer and service, so a long
 Full CI execution cannot occupy either frequent poller.
+
+For instance replacement and stack recreation, see
+[disaster-recovery.md](disaster-recovery.md).

--- a/deploy/aws/disaster-recovery.md
+++ b/deploy/aws/disaster-recovery.md
@@ -1,0 +1,63 @@
+# Disaster recovery
+
+The alerting worker is disposable. All durable state lives in Postgres (runs,
+comparisons, analyses, scan cursors, outbox, execution records) and the S3
+checkpoint bucket (analyzer memory, delivery modes), both outside the instance.
+
+## Instance replacement (crash, termination, rebuild)
+
+Redeploy the stack with the same parameters; CloudFormation recreates the
+instance and UserData reprovisions it from scratch:
+
+```bash
+aws cloudformation deploy \
+  --stack-name <stack-name> \
+  --template-file deploy/aws/alerting-worker.yaml \
+  --parameter-overrides VpcId=... SubnetId=... WorkerSecretArn=... GitHubReadOnlySecretArn=... \
+  --capabilities CAPABILITY_IAM
+```
+
+The bucket, role, and secrets are reused (`DeletionPolicy: Retain`). After
+boot:
+
+- control service re-syncs delivery modes from S3 within one minute;
+- timers are `Persistent=true`, so missed runs fire immediately;
+- scans resume from their Postgres cursors; pending Slack notifications
+  dispatch from the outbox; a command that was in flight replays
+  idempotently once its 30-minute lease expires.
+
+Nothing else to do. Expected recovery time: ~10 minutes.
+
+## Stack recreation (delete + create)
+
+A new stack creates a **new** checkpoint bucket (auto-generated name). The old
+bucket is retained but the new instance role cannot read it. Effects:
+
+- **Delivery modes** reset to `shadow` — deliberate, so a fresh deployment
+  never posts to Slack unprompted. Re-apply after verifying:
+
+  ```bash
+  printf 'live\n' | aws s3 cp - "s3://<new-bucket>/control/fast_ci.mode" --only-show-errors
+  printf 'live\n' | aws s3 cp - "s3://<new-bucket>/control/full_ci.mode" --only-show-errors
+  ```
+
+- **Analyzer memory** heals itself: stored checkpoint URIs point at the old
+  bucket, the analyzer detects the unreadable reference, starts from empty
+  memory once, and its first completed analysis uploads the new bucket's
+  initial checkpoint. No database edits needed. The first report may classify
+  ongoing failures as new for one comparison.
+
+## Verifying health after recovery
+
+```bash
+systemctl list-timers 'alerting-*' --no-pager
+```
+
+All timers (control, fast-ci, full-ci, retention, main-ci) should be active
+with future trigger times. Execution status is in Postgres:
+
+```sql
+SELECT command_type, status, last_error, updated_at
+FROM alerting_automation_executions
+ORDER BY updated_at DESC LIMIT 10;
+```


### PR DESCRIPTION
## Summary

Makes stack recreation (gap 2 in disaster recovery) self-healing instead of a manual SQL/runbook procedure:

- `S3CheckpointStore.download` raises a dedicated `CheckpointUnavailable` for foreign-bucket, missing-object, and access-denied reads (previously a generic `AnalyzerError` that wedged the analyzer forever).
- `FullCIAnalysisHandler` catches it and restarts from empty memory; the completed analysis uploads the new bucket's first checkpoint, so Postgres references advance on their own. Checksum mismatches remain hard failures.
- New `deploy/aws/disaster-recovery.md`: instance replacement is a single stack redeploy (everything resumes from Postgres/S3 automatically); stack recreation needs only the two `control/*.mode" writes (shadow-by-default stays deliberate).

## Test plan
- New test: stranded checkpoint URI -> analysis completes with empty memory and uploads a fresh checkpoint
- 114 alerting tests pass, ruff clean, mypy clean for touched files
- Pre-existing mypy issue on main in control.py:83 (unused ignore from #81) left alone