### PR TITLE
Show pending Main CI alert rollout

### DIFF
--- a/src/app/alerts/alerts-content.tsx
+++ b/src/app/alerts/alerts-content.tsx
@@ -53,6 +53,7 @@ interface FastCIAlertsResponse {
 
 interface MainCIAlertsResponse {
   alerts?: MainCiJobAlert[];
+  schemaStatus?: "ready" | "pending";
   error?: string;
 }
 
@@ -100,7 +101,7 @@ function AlertSection({
         </div>
       ) : failed ? (
         <div className="flex h-48 items-center justify-center text-sm text-red-500">
-          Failed to load {title} alerts.
+          Failed to load {title}.
         </div>
       ) : (
         children
@@ -163,7 +164,14 @@ function MainCISection({ timeWindow }: { timeWindow: AlertTimeWindow }) {
       isLoading={isLoading}
       failed={Boolean(error || data?.error)}
     >
-      <MainCIAlerts alerts={alerts} />
+      {data?.schemaStatus === "pending" ? (
+        <div className="flex h-48 items-center justify-center rounded-xl border border-dashed border-amber-300 px-6 text-center text-sm text-amber-700 dark:border-amber-800 dark:text-amber-300">
+          Backend rollout pending. Migration 0014 and the Main CI worker must be
+          deployed before this preview can show alerts.
+        </div>
+      ) : (
+        <MainCIAlerts alerts={alerts} />
+      )}
     </AlertSection>
   );
 }

--- a/src/app/api/alerts/main-ci/route.ts
+++ b/src/app/api/alerts/main-ci/route.ts
@@ -4,6 +4,7 @@ import {
   toMainCiJobAlert,
   type MainCiJobAlertRow,
 } from "@/lib/alerts-main-ci";
+import { hasPostgresErrorCode } from "@/lib/postgres-errors";
 
 export const dynamic = "force-dynamic";
 
@@ -32,10 +33,19 @@ export async function GET() {
       LIMIT ${MAX_ALERTS}
     `;
     return NextResponse.json(
-      { alerts: rows.map(toMainCiJobAlert) },
+      { alerts: rows.map(toMainCiJobAlert), schemaStatus: "ready" },
       { headers: { "Cache-Control": "no-store" } },
     );
   } catch (error) {
+    // Preview deployments are created before migration 0014 is intentionally
+    // applied to the shared database. Treat that ordered rollout state as a
+    // neutral, explicit response instead of presenting a broken dashboard.
+    if (hasPostgresErrorCode(error, "42P01")) {
+      return NextResponse.json(
+        { alerts: [], schemaStatus: "pending" },
+        { headers: { "Cache-Control": "no-store" } },
+      );
+    }
     console.error("Failed to load Main CI job alerts:", error);
     return NextResponse.json(
       { error: "Main CI job alerts could not be loaded." },

--- a/src/lib/postgres-errors.test.ts
+++ b/src/lib/postgres-errors.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { hasPostgresErrorCode } from "./postgres-errors";
+
+test("matches an exact PostgreSQL error code", () => {
+  assert.equal(hasPostgresErrorCode({ code: "42P01" }, "42P01"), true);
+  assert.equal(hasPostgresErrorCode({ code: "42703" }, "42P01"), false);
+});
+
+test("rejects non-error values safely", () => {
+  assert.equal(hasPostgresErrorCode(null, "42P01"), false);
+  assert.equal(hasPostgresErrorCode("42P01", "42P01"), false);
+  assert.equal(hasPostgresErrorCode({}, "42P01"), false);
+});

--- a/src/lib/postgres-errors.ts
+++ b/src/lib/postgres-errors.ts
@@ -1,0 +1,13 @@
+/** Small guards for PostgreSQL errors crossing library boundaries. */
+
+export function hasPostgresErrorCode(
+  error: unknown,
+  expectedCode: string,
+): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === expectedCode
+  );
+}


### PR DESCRIPTION
## Summary
- return a neutral `schemaStatus: pending` response when migration 0014 is not installed
- show an explicit backend-rollout message instead of a red API error
- cover PostgreSQL error-code detection

## Validation
- `npm test` (56 passed)
- `npm run lint`
- `npm run build`

This is the missing follow-up from #81; the production API currently returns HTTP 500 until migration 0014 is deployed.

Signed-off-by: Sherlock <sherlock@raft.ai>