### PR TITLE
Alerts: scannable Full CI comparisons, pagination, and keyword filter

### DIFF
--- a/src/app/alerts/alerts-content.tsx
+++ b/src/app/alerts/alerts-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { FastCIAlerts } from "@/components/fast-ci-alerts";
@@ -11,6 +11,7 @@ import {
   type FastFailureEvent,
 } from "@/lib/alerts-fast-ci";
 import {
+  filterFullCiComparisonViews,
   viewFullCiComparisons,
   type FullCiComparison,
 } from "@/lib/alerts-full-ci";
@@ -109,7 +110,13 @@ function AlertSection({
   );
 }
 
-function FullCISection({ timeWindow }: { timeWindow: AlertTimeWindow }) {
+function FullCISection({
+  timeWindow,
+  query,
+}: {
+  timeWindow: AlertTimeWindow;
+  query: string;
+}) {
   const { data, isLoading, error } = useSWR<FullCIAlertsResponse>(
     "/api/alerts/full-ci",
     fetcher,
@@ -118,12 +125,15 @@ function FullCISection({ timeWindow }: { timeWindow: AlertTimeWindow }) {
 
   const comparisons = useMemo(() => {
     const cutoff = alertWindowCutoff(timeWindow);
-    return viewFullCiComparisons(
-      (data?.comparisons ?? []).filter((comparison) =>
-        withinAlertWindow(comparison.currentRun.scheduledAt, cutoff),
+    return filterFullCiComparisonViews(
+      viewFullCiComparisons(
+        (data?.comparisons ?? []).filter((comparison) =>
+          withinAlertWindow(comparison.currentRun.scheduledAt, cutoff),
+        ),
       ),
+      query,
     );
-  }, [data, timeWindow]);
+  }, [data, timeWindow, query]);
 
   return (
     <AlertSection
@@ -135,7 +145,14 @@ function FullCISection({ timeWindow }: { timeWindow: AlertTimeWindow }) {
       isLoading={isLoading}
       failed={Boolean(error || data?.error)}
     >
-      <FullCIAlerts comparisons={comparisons} />
+      <FullCIAlerts
+        comparisons={comparisons}
+        emptyMessage={
+          query.trim() === ""
+            ? "No Full CI comparisons have been analyzed yet."
+            : `No Full CI comparisons match "${query.trim()}".`
+        }
+      />
     </AlertSection>
   );
 }
@@ -215,6 +232,9 @@ export default function AlertsContent() {
     ? windowParam
     : "7d";
   const showSoftFailed = searchParams.get("soft") === "show";
+  // Typing is per-keystroke, so the query stays in component state rather than
+  // the URL the other controls navigate through.
+  const [fullCiQuery, setFullCiQuery] = useState("");
 
   const navigate = (
     nextTab: AlertTab,
@@ -318,6 +338,30 @@ export default function AlertsContent() {
             Show soft failed
           </button>
         )}
+        {tab === "full-ci" && (
+          <div className="relative w-full min-w-56 sm:ml-auto sm:w-72">
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 16 16"
+              className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-400 dark:text-zinc-500"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.8}
+              strokeLinecap="round"
+            >
+              <circle cx="7" cy="7" r="4.5" />
+              <path d="M10.5 10.5 14 14" />
+            </svg>
+            <input
+              type="search"
+              value={fullCiQuery}
+              onChange={(event) => setFullCiQuery(event.target.value)}
+              placeholder="Filter by job, cause, PR, or commit"
+              aria-label="Filter Full CI comparisons"
+              className="dashboard-control w-full rounded-full border border-zinc-300 bg-white py-1.5 pl-8 pr-3 text-xs text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-950 focus:outline-none dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-100 dark:focus:border-zinc-50"
+            />
+          </div>
+        )}
       </div>
 
       {tab === "main-ci" ? (
@@ -325,7 +369,7 @@ export default function AlertsContent() {
       ) : tab === "fast-ci" ? (
         <FastCISection timeWindow={timeWindow} showSoftFailed={showSoftFailed} />
       ) : (
-        <FullCISection timeWindow={timeWindow} />
+        <FullCISection timeWindow={timeWindow} query={fullCiQuery} />
       )}
     </div>
   );

--- a/src/components/alert-pagination.tsx
+++ b/src/components/alert-pagination.tsx
@@ -1,0 +1,46 @@
+/**
+ * Shared pager for the alert lists. Both feeds can run to hundreds of cards in
+ * a busy week, and both page them ten at a time.
+ */
+export function AlertPagination({
+  currentPage,
+  pageCount,
+  total,
+  unit,
+  onPageChange,
+}: {
+  currentPage: number;
+  pageCount: number;
+  total: number;
+  unit: { one: string; many: string };
+  onPageChange: (page: number) => void;
+}) {
+  if (pageCount <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-between text-xs text-zinc-500 dark:text-zinc-400">
+      <span>
+        Page {currentPage + 1} of {pageCount} · {total}{" "}
+        {total === 1 ? unit.one : unit.many}
+      </span>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={currentPage === 0}
+          onClick={() => onPageChange(currentPage - 1)}
+          className="dashboard-control rounded-full border border-zinc-300 px-3 py-1.5 font-semibold disabled:opacity-40 dark:border-zinc-700"
+        >
+          Previous
+        </button>
+        <button
+          type="button"
+          disabled={currentPage >= pageCount - 1}
+          onClick={() => onPageChange(currentPage + 1)}
+          className="dashboard-control rounded-full border border-zinc-300 px-3 py-1.5 font-semibold disabled:opacity-40 dark:border-zinc-700"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/fast-ci-alerts.tsx
+++ b/src/components/fast-ci-alerts.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { NotificationBadge } from "@/components/alert-notification-badge";
+import { AlertPagination } from "@/components/alert-pagination";
 import { JobName } from "@/components/job-name";
 import { type FastFailureGroup } from "@/lib/alerts-fast-ci";
 import {
@@ -131,32 +132,13 @@ export function FastCIAlerts({
       {pageGroups.map((group) => (
         <GroupCard key={group.key} group={group} />
       ))}
-      {pageCount > 1 && (
-        <div className="flex items-center justify-between text-xs text-zinc-500 dark:text-zinc-400">
-          <span>
-            Page {currentPage + 1} of {pageCount} · {groups.length}{" "}
-            {groups.length === 1 ? "group" : "groups"}
-          </span>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              disabled={currentPage === 0}
-              onClick={() => setPage(currentPage - 1)}
-              className="dashboard-control rounded-full border border-zinc-300 px-3 py-1.5 font-semibold disabled:opacity-40 dark:border-zinc-700"
-            >
-              Previous
-            </button>
-            <button
-              type="button"
-              disabled={currentPage >= pageCount - 1}
-              onClick={() => setPage(currentPage + 1)}
-              className="dashboard-control rounded-full border border-zinc-300 px-3 py-1.5 font-semibold disabled:opacity-40 dark:border-zinc-700"
-            >
-              Next
-            </button>
-          </div>
-        </div>
-      )}
+      <AlertPagination
+        currentPage={currentPage}
+        pageCount={pageCount}
+        total={groups.length}
+        unit={{ one: "group", many: "groups" }}
+        onPageChange={setPage}
+      />
     </div>
   );
 }

--- a/src/components/full-ci-alerts.test.ts
+++ b/src/components/full-ci-alerts.test.ts
@@ -199,3 +199,42 @@ test("a comparison shows how far its Slack notification got", () => {
 
   assert.match(markup, /Slack dead-lettered/);
 });
+
+test("the commit subject links the pull request it merged", () => {
+  const markup = render(
+    [
+      comparisonRow({
+        current_message: "[Bugfix] Bound cache_salt length (#54353)",
+      }),
+    ],
+    [conditionRow()],
+  );
+
+  assert.match(
+    markup,
+    /href="https:\/\/github\.com\/vllm-project\/vllm\/pull\/54353"/,
+  );
+  assert.match(markup, /Bound cache_salt length/);
+});
+
+test("a comparison header counts each lifecycle it classified", () => {
+  const markup = render(
+    [comparisonRow()],
+    [
+      conditionRow({ job_name: "New job", lifecycle: "new" }),
+      conditionRow({ job_name: "Old job", lifecycle: "recurring" }),
+      conditionRow({ job_name: "Other old job", lifecycle: "recurring" }),
+      conditionRow({ job_name: "Recovered job", lifecycle: "fixed" }),
+    ],
+  );
+
+  assert.match(markup, /1 new/);
+  assert.match(markup, /2 recurring/);
+  assert.match(markup, /1 fixed/);
+});
+
+test("a failed run is marked as failed rather than described in passing text", () => {
+  const markup = render([comparisonRow()], [conditionRow()]);
+
+  assert.match(markup, /text-red-600[^"]*"><svg/);
+});

--- a/src/components/full-ci-alerts.tsx
+++ b/src/components/full-ci-alerts.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { NotificationBadge } from "@/components/alert-notification-badge";
+import { AlertPagination } from "@/components/alert-pagination";
 import { JobName } from "@/components/job-name";
 import {
   CAUSE_LABELS,
@@ -10,7 +12,11 @@ import {
   type FullCiRun,
   type PullRequestRef,
 } from "@/lib/alerts-full-ci";
-import { commitUrl, formatAlertDateTime } from "@/lib/alerts-shared";
+import {
+  commitUrl,
+  formatAlertDateTime,
+  pullRequestUrl,
+} from "@/lib/alerts-shared";
 
 const LIFECYCLE_CLASSES: Record<FullCiLifecycle, string> = {
   new: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
@@ -24,6 +30,49 @@ const LIFECYCLE_CLASSES: Record<FullCiLifecycle, string> = {
 function outcomeLabel(outcome: FullCiJobOutcome | null): string {
   if (outcome === null) return "did not run";
   return outcome.softFailed ? `${outcome.state} (soft failed)` : outcome.state;
+}
+
+/** A failed run is the reason the card exists, so it is marked, not narrated. */
+function RunState({ state }: { state: string }) {
+  const failed = state.toLowerCase() === "failed";
+  if (!failed) {
+    return <span className="text-zinc-500 dark:text-zinc-400">{state}</span>;
+  }
+  // An inline-flex wrapper would take its own baseline and lift the whole
+  // phrase off the line it sits in, so the icon is an inline box aligned to
+  // the surrounding text instead.
+  return (
+    <span className="font-medium text-red-600 dark:text-red-400">
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        className="mr-1 inline h-3 w-3 align-[-0.1em]"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2.2}
+        strokeLinecap="round"
+      >
+        <path d="M4 4l8 8M12 4l-8 8" />
+      </svg>
+      {state}
+    </span>
+  );
+}
+
+/**
+ * vLLM commit subjects end in the pull request they merged. That trailing
+ * "(#12345)" is the link a reader wants, but the subject line is truncated, so
+ * the number is lifted out and shown beside the commit instead of being the
+ * first thing an ellipsis eats.
+ */
+function splitCommitSubject(message: string): {
+  subject: string;
+  prNumber: string | null;
+} {
+  const subject = message.split("\n", 1)[0];
+  const match = subject.match(/^(.*?)\s*\(#(\d+)\)\s*$/);
+  if (match === null) return { subject, prNumber: null };
+  return { subject: match[1], prNumber: match[2] };
 }
 
 function PullRequestLink({
@@ -72,7 +121,7 @@ function RunSummary({ label, run }: { label: string; run: FullCiRun }) {
         {run.commitSha.slice(0, 7)}
       </a>
       <span className="text-zinc-500 dark:text-zinc-400">
-        {run.state} · {formatAlertDateTime(run.scheduledAt)}
+        <RunState state={run.state} /> · {formatAlertDateTime(run.scheduledAt)}
       </span>
     </span>
   );
@@ -139,7 +188,7 @@ function ConditionSection({
 }) {
   return (
     <section>
-      <h3 className="border-b border-zinc-100 px-4 py-2 text-[11px] font-bold uppercase tracking-[0.08em] text-zinc-500 sm:px-5 dark:border-zinc-800/60 dark:text-zinc-400">
+      <h3 className="border-b border-zinc-100 px-4 py-2 text-[11px] font-bold uppercase tracking-[0.08em] text-zinc-600 sm:px-5 dark:border-zinc-800/60 dark:text-zinc-300">
         {title}
       </h3>
       {conditions.length === 0 ? (
@@ -161,7 +210,53 @@ function ConditionSection({
   );
 }
 
+/**
+ * The split a responder reads first: how many conditions are new, how many
+ * carried over, and how many this comparison saw pass again, against the
+ * baseline build they are all measured from. Zero counts are left out rather
+ * than shown as noise.
+ */
+function ConditionSummary({
+  comparison,
+}: {
+  comparison: FullCiComparisonView;
+}) {
+  const counts = [
+    {
+      lifecycle: "new" as FullCiLifecycle,
+      count: comparison.ongoing.filter((c) => c.lifecycle === "new").length,
+    },
+    {
+      lifecycle: "recurring" as FullCiLifecycle,
+      count: comparison.ongoing.filter((c) => c.lifecycle === "recurring")
+        .length,
+    },
+    { lifecycle: "fixed" as FullCiLifecycle, count: comparison.fixed.length },
+  ].filter((entry) => entry.count > 0);
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+      {counts.length === 0 ? (
+        <span className="text-zinc-500 dark:text-zinc-400">
+          No failure conditions
+        </span>
+      ) : (
+        counts.map(({ lifecycle, count }) => (
+          <span
+            key={lifecycle}
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${LIFECYCLE_CLASSES[lifecycle]}`}
+          >
+            {count} {LIFECYCLE_LABELS[lifecycle].toLowerCase()}
+            {lifecycle === "fixed" ? "" : count === 1 ? " failure" : " failures"}
+          </span>
+        ))
+      )}
+    </div>
+  );
+}
+
 function ComparisonCard({ comparison }: { comparison: FullCiComparisonView }) {
+  const commit = splitCommitSubject(comparison.currentRun.message);
   const builds: ComparedBuilds = {
     previousBuildNumber: comparison.previousRun.buildNumber,
     currentBuildNumber: comparison.currentRun.buildNumber,
@@ -169,9 +264,36 @@ function ComparisonCard({ comparison }: { comparison: FullCiComparisonView }) {
 
   return (
     <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
-      <div className="border-b border-zinc-200 px-4 py-3 sm:px-5 dark:border-zinc-800">
-        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm">
-          <RunSummary label="Current" run={comparison.currentRun} />
+      <div className="border-b border-zinc-200 bg-zinc-50 px-4 py-3 sm:px-5 dark:border-zinc-800 dark:bg-zinc-900/40">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <h2 className="flex flex-wrap items-baseline gap-x-2 text-base font-semibold tracking-tight text-zinc-950 dark:text-zinc-50">
+            <a
+              href={comparison.currentRun.buildUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="hover:underline"
+            >
+              build {comparison.currentRun.buildNumber}
+            </a>
+            <a
+              href={commitUrl(comparison.currentRun.commitSha)}
+              target="_blank"
+              rel="noreferrer"
+              className="font-mono text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {comparison.currentRun.commitSha.slice(0, 7)}
+            </a>
+            {commit.prNumber !== null && (
+              <a
+                href={pullRequestUrl(commit.prNumber) ?? undefined}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
+              >
+                #{commit.prNumber}
+              </a>
+            )}
+          </h2>
           {comparison.isLatest && (
             <span className="inline-flex shrink-0 items-center rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
               Latest comparison
@@ -182,15 +304,18 @@ function ComparisonCard({ comparison }: { comparison: FullCiComparisonView }) {
             className="ml-auto"
           />
         </div>
-        <div className="mt-1 flex flex-wrap items-baseline gap-x-3 gap-y-1 text-xs">
-          <RunSummary label="Baseline" run={comparison.previousRun} />
-          <span className="ml-auto shrink-0 text-zinc-500 dark:text-zinc-400">
-            analyzed {formatAlertDateTime(comparison.analyzedAt)}
-          </span>
-        </div>
-        <p className="mt-1 w-full truncate text-xs text-zinc-500 dark:text-zinc-400">
-          {comparison.currentRun.message}
+        <p className="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
+          <RunState state={comparison.currentRun.state} /> ·{" "}
+          {formatAlertDateTime(comparison.currentRun.scheduledAt)} · analyzed{" "}
+          {formatAlertDateTime(comparison.analyzedAt)}
         </p>
+        <p className="mt-1 w-full truncate text-xs text-zinc-500 dark:text-zinc-400">
+          {commit.subject}
+        </p>
+        <ConditionSummary comparison={comparison} />
+        <div className="mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1 text-xs">
+          <RunSummary label="Baseline" run={comparison.previousRun} />
+        </div>
       </div>
 
       <ConditionSection
@@ -215,27 +340,47 @@ function ComparisonCard({ comparison }: { comparison: FullCiComparisonView }) {
  * condition is shown against the two runs it was classified from; the
  * analyzer's raw report, cache, and memory checkpoints are never rendered.
  */
+const PAGE_SIZE = 10;
+
 export function FullCIAlerts({
   comparisons,
+  emptyMessage = "No Full CI comparisons have been analyzed yet.",
 }: {
   comparisons: FullCiComparisonView[];
+  emptyMessage?: string;
 }) {
+  const [page, setPage] = useState(0);
+
   if (comparisons.length === 0) {
     return (
       <div className="flex h-48 items-center justify-center rounded-xl border border-dashed border-zinc-300 text-sm text-zinc-400 dark:border-zinc-700">
-        No Full CI comparisons have been analyzed yet.
+        {emptyMessage}
       </div>
     );
   }
 
+  const pageCount = Math.ceil(comparisons.length / PAGE_SIZE);
+  const currentPage = Math.min(page, pageCount - 1);
+  const pageComparisons = comparisons.slice(
+    currentPage * PAGE_SIZE,
+    (currentPage + 1) * PAGE_SIZE,
+  );
+
   return (
-    <div className="space-y-3">
-      {comparisons.map((comparison) => (
+    <div className="space-y-4">
+      {pageComparisons.map((comparison) => (
         <ComparisonCard
           key={comparison.currentRun.buildkiteBuildId}
           comparison={comparison}
         />
       ))}
+      <AlertPagination
+        currentPage={currentPage}
+        pageCount={pageCount}
+        total={comparisons.length}
+        unit={{ one: "comparison", many: "comparisons" }}
+        onPageChange={setPage}
+      />
     </div>
   );
 }

--- a/src/lib/alerts-full-ci.test.ts
+++ b/src/lib/alerts-full-ci.test.ts
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildUrlForNumber,
+  filterFullCiComparisonViews,
   toFullCiComparisons,
   viewFullCiComparisons,
   type FullCiComparisonRow,
+  type FullCiComparisonView,
   type FullCiConditionRow,
 } from "./alerts-full-ci";
 
@@ -242,5 +244,58 @@ test("build numbers resolve to Buildkite builds", () => {
   assert.equal(
     buildUrlForNumber(9001),
     "https://buildkite.com/vllm/ci/builds/9001",
+  );
+});
+
+function view(): FullCiComparisonView {
+  const [comparison] = viewFullCiComparisons(
+    toFullCiComparisons(
+      [comparisonRow()],
+      [
+        conditionRow({ job_name: "GPU memory profiling test" }),
+        conditionRow({
+          job_name: "Async engine test",
+          lifecycle: "fixed",
+          summary: "passes again after the revert",
+        }),
+      ],
+    ),
+  );
+  return comparison;
+}
+
+test("an empty query leaves every comparison untouched", () => {
+  assert.deepEqual(filterFullCiComparisonViews([view()], "   "), [view()]);
+});
+
+test("a query keeps only the conditions whose job name matches", () => {
+  const [filtered] = filterFullCiComparisonViews([view()], "gpu");
+
+  assert.deepEqual(
+    filtered.ongoing.map((condition) => condition.jobName),
+    ["GPU memory profiling test"],
+  );
+  assert.deepEqual(filtered.fixed, []);
+});
+
+test("a query matching nothing in a comparison drops the comparison", () => {
+  assert.deepEqual(filterFullCiComparisonViews([view()], "rocm"), []);
+});
+
+test("a query naming the comparison itself keeps all of its conditions", () => {
+  const [filtered] = filterFullCiComparisonViews([view()], "9002");
+
+  assert.equal(filtered.ongoing.length, 1);
+  assert.equal(filtered.fixed.length, 1);
+});
+
+test("a query matches a condition summary and its culprit pull request", () => {
+  assert.equal(
+    filterFullCiComparisonViews([view()], "async output processor").length,
+    1,
+  );
+  assert.equal(
+    filterFullCiComparisonViews([view()], "Rework async output").length,
+    1,
   );
 });

--- a/src/lib/alerts-full-ci.ts
+++ b/src/lib/alerts-full-ci.ts
@@ -237,3 +237,53 @@ export function viewFullCiComparisons(
         .sort((a, b) => a.jobName.localeCompare(b.jobName)),
     }));
 }
+
+function conditionMatches(
+  condition: FullCiFailureCondition,
+  needle: string,
+): boolean {
+  return [
+    condition.jobName,
+    condition.summary,
+    LIFECYCLE_LABELS[condition.lifecycle],
+    CAUSE_LABELS[condition.cause],
+    condition.culpritPr?.title,
+    condition.fixingPr?.title,
+  ].some((field) => field?.toLowerCase().includes(needle));
+}
+
+function runMatches(run: FullCiRun, needle: string): boolean {
+  return [String(run.buildNumber), run.commitSha, run.message].some((field) =>
+    field.toLowerCase().includes(needle),
+  );
+}
+
+/**
+ * Keyword filter over the rendered comparisons. A comparison whose own build,
+ * commit, or commit message matches is kept whole, since the query names the
+ * comparison itself rather than anything inside it. Otherwise the query is read
+ * as naming failure conditions, so the card keeps only its matching rows and
+ * drops out entirely when none match.
+ */
+export function filterFullCiComparisonViews(
+  views: readonly FullCiComparisonView[],
+  query: string,
+): FullCiComparisonView[] {
+  const needle = query.trim().toLowerCase();
+  if (needle === "") return [...views];
+
+  return views.flatMap((view) => {
+    if (
+      runMatches(view.currentRun, needle) ||
+      runMatches(view.previousRun, needle)
+    ) {
+      return [view];
+    }
+
+    const ongoing = view.ongoing.filter((c) => conditionMatches(c, needle));
+    const fixed = view.fixed.filter((c) => conditionMatches(c, needle));
+    if (ongoing.length === 0 && fixed.length === 0) return [];
+
+    return [{ ...view, ongoing, fixed }];
+  });
+}


### PR DESCRIPTION
The Full CI feed rendered every comparison at once, and every line inside a card carried the same size and weight, so nothing marked where one comparison ended and the next began.

## Hierarchy

- Each card opens with a tinted header band whose heading is the build the comparison is about, at a size and weight nothing else on the card uses.
- The run state, schedule, and analysis time collapse onto one muted line; the baseline drops below the commit subject as the subordinate reference it is.
- A row of lifecycle counts gives the split a responder reads first — `1 new failure`, `11 recurring failures`, `2 fixed` — coloured with the same palette the rows use, and omitted when a count is zero.
- A failed run is marked with a red cross instead of being described in the same grey prose as everything around it.

## Pagination

The list pages ten comparisons at a time, matching Fast CI. Both feeds now share one `AlertPagination` component rather than repeating the markup.

## Keyword filter

A search box on the Full CI tab narrows the feed. A query matching a comparison's own build, commit, or commit message keeps that comparison whole, since the query names the card rather than anything in it; otherwise the query is read as naming failure conditions, so a card keeps only its matching rows and drops out when none match. The query lives in component state rather than the URL, because a per-keystroke navigation would re-render the page on every character.

## Commit subjects

Where a commit subject ends in the pull request it merged, that number is lifted out and shown beside the commit rather than left at the end of a line that truncates. Scheduled runs, whose Buildkite message is `Full CI run - nightly`, carry no pull request and show none.

## Verification

`tsc --noEmit` clean, `eslint` clean, `npm test` passes (62 tests, 8 new covering the keyword filter, the lifecycle counts, the pull request link, and the failed-run marking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)