### PR TITLE
Record the pull request a Full CI run's commit merged

### DIFF
--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -177,6 +177,10 @@ class CompletedAnalysis:
     suspicious_prs: tuple[SuspiciousPR, ...]
     conditions: tuple[FailureCondition, ...]
     checkpoint: CheckpointRef
+    """The pull request the analyzed run's head commit merged, when GitHub
+    reaches one. Resolved anyway to write the report, so recording it costs no
+    extra request and lets readers name the change a run carried."""
+    commit_pull_request: PullRequestRef | None = None
 
 
 @dataclass(frozen=True)
@@ -605,11 +609,12 @@ class FullCIAnalysisHandler:
         commit_sha = str(build.get("commit") or context.current.commit_sha)
         with tempfile.TemporaryDirectory(prefix="full-ci-analysis-") as tmp:
             workdir = Path(tmp)
+            commit_pull_request = self._github.pull_for_commit(commit_sha)
             summary = _build_summary(
                 build=build,
                 jobs=jobs,
                 cache=cache,
-                pr=self._github.pull_for_commit(commit_sha),
+                pr=commit_pull_request,
                 now=self._clock.now(),
             )
             _materialize_workdir(
@@ -637,6 +642,7 @@ class FullCIAnalysisHandler:
                     suspicious_prs=outputs.suspicious_prs,
                     conditions=conditions,
                     checkpoint=checkpoint,
+                    commit_pull_request=commit_pull_request,
                 ),
                 notification=NotificationIntent(
                     delivery_id=f"full-ci:{context.current.build_id}",

--- a/alerting/backfill.py
+++ b/alerting/backfill.py
@@ -1,0 +1,91 @@
+"""Backfill the pull request a Full CI run's head commit merged.
+
+The analyzer resolves that pull request against GitHub to write its report, and
+records it on the run from now on. Runs analyzed before the run table carried
+those columns keep a null there permanently, because an analysis never runs
+twice for the same build. This one-off command fills them in, using the same
+lookup the analyzer uses, so the dashboard can name the change every historical
+run carried.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections.abc import Sequence
+from typing import Protocol
+
+from alerting.analyzer import GitHubRestClient, PullRequestRef
+from alerting.postgres import PostgresAlertStore
+
+
+class BackfillStore(Protocol):
+    def runs_missing_commit_pull_request(
+        self, *, limit: int
+    ) -> list[tuple[str, str]]: ...
+
+    def record_commit_pull_request(
+        self, *, build_id: str, number: int, url: str, title: str
+    ) -> None: ...
+
+
+class GitHubLookup(Protocol):
+    def pull_for_commit(self, commit_sha: str) -> PullRequestRef | None: ...
+
+
+def backfill(
+    *, store: BackfillStore, github: GitHubLookup, limit: int
+) -> tuple[int, int]:
+    """Returns how many runs were resolved and how many reached no pull request.
+
+    A commit reachable by no pull request is a real state, not a failure, so it
+    is counted and left null rather than retried into an invented value.
+    """
+    resolved = 0
+    unreachable = 0
+    for build_id, commit_sha in store.runs_missing_commit_pull_request(limit=limit):
+        pull = github.pull_for_commit(commit_sha)
+        if pull is None:
+            unreachable += 1
+            continue
+        store.record_commit_pull_request(
+            build_id=build_id,
+            number=pull.number,
+            url=pull.url,
+            title=pull.title,
+        )
+        resolved += 1
+    return resolved, unreachable
+
+
+def _required_environment(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve missing Full CI commit pull requests from GitHub"
+    )
+    parser.add_argument("--limit", type=int, default=100)
+    args = parser.parse_args(arguments)
+    if args.limit < 1:
+        print("--limit must be positive", file=sys.stderr)
+        return 2
+
+    resolved, unreachable = backfill(
+        store=PostgresAlertStore.from_database_url(
+            _required_environment("DATABASE_URL")
+        ),
+        github=GitHubRestClient(token=_required_environment("GITHUB_TOKEN")),
+        limit=args.limit,
+    )
+    print(f"resolved {resolved} runs, {unreachable} reached no pull request")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -379,6 +379,42 @@ class PostgresAlertStore:
             ).fetchall()
         return [self._outbox_record(row) for row in rows]
 
+    def runs_missing_commit_pull_request(
+        self, *, limit: int
+    ) -> list[tuple[str, str]]:
+        """Analyzed runs whose commit was never resolved to a pull request.
+
+        Rows analyzed before the run carried those columns keep a null there
+        forever, since an analysis never runs twice for the same build.
+        """
+        with self._connection_factory() as connection:
+            rows = connection.execute(
+                """
+                SELECT buildkite_build_id, commit_sha
+                FROM alerting_full_ci_runs
+                WHERE commit_pr_number IS NULL
+                ORDER BY scheduled_at DESC
+                LIMIT %s
+                """,
+                (limit,),
+            ).fetchall()
+        return [(str(row[0]), str(row[1])) for row in rows]
+
+    def record_commit_pull_request(
+        self, *, build_id: str, number: int, url: str, title: str
+    ) -> None:
+        with self._connection_factory() as connection:
+            connection.execute(
+                """
+                UPDATE alerting_full_ci_runs
+                SET commit_pr_number = %s,
+                    commit_pr_url = %s,
+                    commit_pr_title = %s
+                WHERE buildkite_build_id = %s
+                """,
+                (number, url, title, build_id),
+            )
+
     def archive_pending_live(self, *, alert_path: AlertPath) -> int:
         with self._connection_factory() as connection:
             result = connection.execute(
@@ -1230,6 +1266,25 @@ class PostgresAlertStore:
                 ).fetchone()
                 if inserted is None:
                     return  # already committed by an earlier attempt
+                if analysis.commit_pull_request is not None:
+                    # The run row is written at ingest, before anything has
+                    # asked GitHub what its commit belongs to, so the pull
+                    # request lands here where the answer already exists.
+                    connection.execute(
+                        """
+                        UPDATE alerting_full_ci_runs
+                        SET commit_pr_number = %s,
+                            commit_pr_url = %s,
+                            commit_pr_title = %s
+                        WHERE buildkite_build_id = %s
+                        """,
+                        (
+                            analysis.commit_pull_request.number,
+                            analysis.commit_pull_request.url,
+                            analysis.commit_pull_request.title,
+                            analysis.current_build_id,
+                        ),
+                    )
                 if analysis.conditions:
                     _executemany(connection,
                         """

--- a/alerting/tests/test_backfill.py
+++ b/alerting/tests/test_backfill.py
@@ -1,0 +1,78 @@
+"""Backfill of Full CI commit pull requests through its public seam."""
+
+from __future__ import annotations
+
+from alerting import backfill
+from alerting.analyzer import PullRequestRef
+
+
+class FakeStore:
+    def __init__(self, runs: list[tuple[str, str]]) -> None:
+        self.runs = runs
+        self.recorded: list[tuple[str, int, str, str]] = []
+
+    def runs_missing_commit_pull_request(self, *, limit: int) -> list[tuple[str, str]]:
+        return self.runs[:limit]
+
+    def record_commit_pull_request(
+        self, *, build_id: str, number: int, url: str, title: str
+    ) -> None:
+        self.recorded.append((build_id, number, url, title))
+
+
+class FakeGitHub:
+    def __init__(self, pulls: dict[str, PullRequestRef]) -> None:
+        self.pulls = pulls
+        self.asked: list[str] = []
+
+    def pull_for_commit(self, commit_sha: str) -> PullRequestRef | None:
+        self.asked.append(commit_sha)
+        return self.pulls.get(commit_sha)
+
+
+def test_a_resolved_commit_records_its_pull_request() -> None:
+    store = FakeStore([("build-101", "commit-101")])
+    github = FakeGitHub(
+        {
+            "commit-101": PullRequestRef(
+                number=54353,
+                url="https://github.com/vllm-project/vllm/pull/54353",
+                title="[Bugfix] Bound cache_salt length",
+            )
+        }
+    )
+
+    resolved, unreachable = backfill.backfill(store=store, github=github, limit=10)
+
+    assert (resolved, unreachable) == (1, 0)
+    assert store.recorded == [
+        (
+            "build-101",
+            54353,
+            "https://github.com/vllm-project/vllm/pull/54353",
+            "[Bugfix] Bound cache_salt length",
+        )
+    ]
+
+
+def test_a_commit_reachable_by_no_pull_request_is_counted_not_invented() -> None:
+    store = FakeStore([("build-100", "commit-100")])
+    github = FakeGitHub({})
+
+    resolved, unreachable = backfill.backfill(store=store, github=github, limit=10)
+
+    assert (resolved, unreachable) == (0, 1)
+    assert store.recorded == []
+
+
+def test_the_limit_bounds_how_many_commits_are_asked_about() -> None:
+    store = FakeStore([(f"build-{n}", f"commit-{n}") for n in range(10)])
+    github = FakeGitHub({})
+
+    backfill.backfill(store=store, github=github, limit=3)
+
+    assert github.asked == ["commit-0", "commit-1", "commit-2"]
+
+
+def test_a_non_positive_limit_is_rejected_before_any_lookup() -> None:
+    assert backfill.main(["--limit", "0"]) == 2

--- a/alerting/tests/test_postgres_analyzer.py
+++ b/alerting/tests/test_postgres_analyzer.py
@@ -17,6 +17,7 @@ from alerting.analyzer import (
     CheckpointRef,
     FailureLifecycle,
     FullCIAnalysisHandler,
+    PullRequestRef,
     pack_checkpoint,
     unpack_checkpoint,
 )
@@ -77,6 +78,9 @@ def _run_row(build_number: int, scheduled_at: datetime) -> tuple[Any, ...]:
         f"commit-{build_number}",
         "Full CI run - nightly",
         "passed",
+        None,
+        None,
+        None,
     )
 
 
@@ -246,6 +250,11 @@ class FakePostgresConnection:
             assert self.transaction_depth == 1
             self.state["checkpoints"].append(params)
             return Result(rowcount=1)
+        if statement.startswith("UPDATE alerting_full_ci_runs"):
+            assert self.transaction_depth == 1
+            run = self.state["runs"][params[3]]
+            self.state["runs"][params[3]] = (*run[:6], params[0], params[1], params[2])
+            return Result(rowcount=1)
         if statement.startswith("INSERT INTO alerting_notification_outbox"):
             assert self.transaction_depth == 1
             delivery_id = params[0]
@@ -329,8 +338,13 @@ class FakeCheckpoints:
 
 
 class FakeGitHub:
-    def pull_for_commit(self, commit_sha: str) -> None:
-        return None
+    """No pull request by default; a test that wants one sets `pull`."""
+
+    def __init__(self, pull: PullRequestRef | None = None) -> None:
+        self.pull = pull
+
+    def pull_for_commit(self, commit_sha: str) -> PullRequestRef | None:
+        return self.pull
 
     def find_merged_revert(self, pr_number: int) -> None:
         return None
@@ -338,6 +352,7 @@ class FakeGitHub:
 
 def make_harness(
     connection: FakePostgresConnection,
+    pull: PullRequestRef | None = None,
 ) -> tuple[AlertingRuntime, FakeCheckpoints]:
     checkpoints = FakeCheckpoints()
     checkpoints.add("s3://test-checkpoints/seed.tar.gz", {"MEMORY.md": b"# seed\n"})
@@ -374,7 +389,7 @@ def make_harness(
                 builds=FakeBuildPort(build),
                 runner=WellBehavedRunner(),
                 checkpoints=checkpoints,
-                github=FakeGitHub(),
+                github=FakeGitHub(pull),
                 clock=clock,
             )
         },
@@ -479,3 +494,38 @@ def test_postgres_first_comparison_uses_imported_failure_baseline() -> None:
 
     condition = connection.state["conditions"][("build-101", "Job A")]
     assert condition[2] == FailureLifecycle.RECURRING.value
+
+
+def test_analysis_records_the_pull_request_its_commit_merged() -> None:
+    """The GitHub lookup the report needs is kept, not thrown away.
+
+    Slack names the change a run carried because the analyzer resolves the head
+    commit against GitHub. Recording that answer on the run is what lets the
+    dashboard name it too, without a second request from anywhere else.
+    """
+    connection = FakePostgresConnection()
+    runtime, _ = make_harness(
+        connection,
+        pull=PullRequestRef(
+            number=54353,
+            url="https://github.com/vllm-project/vllm/pull/54353",
+            title="[Bugfix] Bound cache_salt length",
+        ),
+    )
+
+    runtime.process_command(analyze_command())
+
+    assert connection.state["runs"]["build-101"][6:] == (
+        54353,
+        "https://github.com/vllm-project/vllm/pull/54353",
+        "[Bugfix] Bound cache_salt length",
+    )
+
+
+def test_a_commit_reachable_by_no_pull_request_records_none() -> None:
+    connection = FakePostgresConnection()
+    runtime, _ = make_harness(connection)
+
+    runtime.process_command(analyze_command())
+
+    assert connection.state["runs"]["build-101"][6:] == (None, None, None)

--- a/migrations/sql/0015_full_ci_commit_pull_request.sql
+++ b/migrations/sql/0015_full_ci_commit_pull_request.sql
@@ -1,0 +1,9 @@
+-- The pull request a Full CI run's head commit merged. The analyzer already
+-- resolves it against GitHub to write its report, but until now nothing kept
+-- it, so the dashboard could link a run's commit without naming the change it
+-- carried. Nullable throughout: a commit reachable by no pull request is a
+-- real state, not missing data.
+ALTER TABLE alerting_full_ci_runs
+    ADD COLUMN IF NOT EXISTS commit_pr_number bigint,
+    ADD COLUMN IF NOT EXISTS commit_pr_url    text,
+    ADD COLUMN IF NOT EXISTS commit_pr_title  text;

--- a/src/app/api/alerts/full-ci/route.ts
+++ b/src/app/api/alerts/full-ci/route.ts
@@ -26,11 +26,17 @@ export async function GET() {
              cur.commit_sha    AS current_commit_sha,
              cur.message       AS current_message,
              cur.state         AS current_state,
+             cur.commit_pr_number AS current_commit_pr_number,
+             cur.commit_pr_url    AS current_commit_pr_url,
+             cur.commit_pr_title  AS current_commit_pr_title,
              prev.build_number AS previous_build_number,
              prev.scheduled_at AS previous_scheduled_at,
              prev.commit_sha   AS previous_commit_sha,
              prev.message      AS previous_message,
              prev.state        AS previous_state,
+             prev.commit_pr_number AS previous_commit_pr_number,
+             prev.commit_pr_url    AS previous_commit_pr_url,
+             prev.commit_pr_title  AS previous_commit_pr_title,
              -- The analyzer writes one outbox row per comparison under this
              -- deterministic delivery_id, which is the outbox primary key.
              (SELECT o.status

--- a/src/components/full-ci-alerts.test.ts
+++ b/src/components/full-ci-alerts.test.ts
@@ -20,12 +20,18 @@ function comparisonRow(
     current_commit_sha: "bbbbbbb0000000000000000000000000000000000",
     current_message: "Second run",
     current_state: "failed",
+    current_commit_pr_number: null,
+    current_commit_pr_url: null,
+    current_commit_pr_title: null,
     previous_build_id: "build-1",
     previous_build_number: 9001,
     previous_scheduled_at: new Date("2026-08-27T06:00:00.000Z"),
     previous_commit_sha: "aaaaaaa0000000000000000000000000000000000",
     previous_message: "First run",
     previous_state: "failed",
+    previous_commit_pr_number: null,
+    previous_commit_pr_url: null,
+    previous_commit_pr_title: null,
     analyzed_at: new Date("2026-08-27T22:00:00.000Z"),
     notification_status: "delivered",
     ...overrides,
@@ -237,4 +243,28 @@ test("a failed run is marked as failed rather than described in passing text", (
   const markup = render([comparisonRow()], [conditionRow()]);
 
   assert.match(markup, /text-red-600[^"]*"><svg/);
+});
+
+test("a run names the change it carried from the pull request the analyzer recorded", () => {
+  const markup = render(
+    [
+      comparisonRow({
+        current_message: "Full CI run - nightly",
+        current_commit_pr_number: 54353,
+        current_commit_pr_url:
+          "https://github.com/vllm-project/vllm/pull/54353",
+        current_commit_pr_title:
+          "[Bugfix] Bound cache_salt length to prevent DoS",
+      }),
+    ],
+    [conditionRow()],
+  );
+
+  assert.match(
+    markup,
+    /href="https:\/\/github\.com\/vllm-project\/vllm\/pull\/54353"/,
+  );
+  assert.match(markup, /#54353/);
+  assert.match(markup, /Bound cache_salt length to prevent DoS/);
+  assert.doesNotMatch(markup, /Full CI run - nightly/);
 });

--- a/src/components/full-ci-alerts.tsx
+++ b/src/components/full-ci-alerts.tsx
@@ -60,19 +60,28 @@ function RunState({ state }: { state: string }) {
 }
 
 /**
- * vLLM commit subjects end in the pull request they merged. That trailing
- * "(#12345)" is the link a reader wants, but the subject line is truncated, so
- * the number is lifted out and shown beside the commit instead of being the
- * first thing an ellipsis eats.
+ * What a run's commit actually changed. A scheduled run's Buildkite message
+ * says only "Full CI run - nightly", so the pull request the analyzer resolved
+ * for the head commit is the description worth showing; where no pull request
+ * was recorded, a message ending in the "(#12345)" it merged is the next best
+ * source, and the bare message is the fallback.
  */
-function splitCommitSubject(message: string): {
+function commitDescription(run: FullCiRun): {
   subject: string;
-  prNumber: string | null;
+  pr: PullRequestRef | null;
 } {
-  const subject = message.split("\n", 1)[0];
+  if (run.commitPullRequest !== null) {
+    return { subject: run.commitPullRequest.title, pr: run.commitPullRequest };
+  }
+
+  const subject = run.message.split("\n", 1)[0];
   const match = subject.match(/^(.*?)\s*\(#(\d+)\)\s*$/);
-  if (match === null) return { subject, prNumber: null };
-  return { subject: match[1], prNumber: match[2] };
+  if (match === null) return { subject, pr: null };
+
+  const number = Number(match[2]);
+  const url = pullRequestUrl(match[2]);
+  if (url === null) return { subject: match[1], pr: null };
+  return { subject: match[1], pr: { number, url, title: match[1] } };
 }
 
 function PullRequestLink({
@@ -256,7 +265,7 @@ function ConditionSummary({
 }
 
 function ComparisonCard({ comparison }: { comparison: FullCiComparisonView }) {
-  const commit = splitCommitSubject(comparison.currentRun.message);
+  const commit = commitDescription(comparison.currentRun);
   const builds: ComparedBuilds = {
     previousBuildNumber: comparison.previousRun.buildNumber,
     currentBuildNumber: comparison.currentRun.buildNumber,
@@ -283,14 +292,14 @@ function ComparisonCard({ comparison }: { comparison: FullCiComparisonView }) {
             >
               {comparison.currentRun.commitSha.slice(0, 7)}
             </a>
-            {commit.prNumber !== null && (
+            {commit.pr !== null && (
               <a
-                href={pullRequestUrl(commit.prNumber) ?? undefined}
+                href={commit.pr.url}
                 target="_blank"
                 rel="noreferrer"
                 className="text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
               >
-                #{commit.prNumber}
+                #{commit.pr.number}
               </a>
             )}
           </h2>

--- a/src/lib/alerts-full-ci.test.ts
+++ b/src/lib/alerts-full-ci.test.ts
@@ -20,12 +20,18 @@ function comparisonRow(
     current_commit_sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
     current_message: "Second run",
     current_state: "failed",
+    current_commit_pr_number: null,
+    current_commit_pr_url: null,
+    current_commit_pr_title: null,
     previous_build_id: "build-1",
     previous_build_number: 9001,
     previous_scheduled_at: new Date("2026-08-27T06:00:00.000Z"),
     previous_commit_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     previous_message: "First run",
     previous_state: "failed",
+    previous_commit_pr_number: null,
+    previous_commit_pr_url: null,
+    previous_commit_pr_title: null,
     analyzed_at: new Date("2026-08-27T22:00:00.000Z"),
     notification_status: "delivered",
     ...overrides,
@@ -66,6 +72,7 @@ test("a comparison exposes both of its runs so the baseline is auditable", () =>
     message: "Second run",
     state: "failed",
     buildUrl: "https://buildkite.com/vllm/ci/builds/9002",
+    commitPullRequest: null,
   });
   assert.deepEqual(comparison.previousRun, {
     buildkiteBuildId: "build-1",
@@ -75,6 +82,7 @@ test("a comparison exposes both of its runs so the baseline is auditable", () =>
     message: "First run",
     state: "failed",
     buildUrl: "https://buildkite.com/vllm/ci/builds/9001",
+    commitPullRequest: null,
   });
 });
 
@@ -298,4 +306,25 @@ test("a query matches a condition summary and its culprit pull request", () => {
     filterFullCiComparisonViews([view()], "Rework async output").length,
     1,
   );
+});
+
+test("a recorded commit pull request reaches the run it belongs to", () => {
+  const [comparison] = toFullCiComparisons(
+    [
+      comparisonRow({
+        current_commit_pr_number: 54353,
+        current_commit_pr_url:
+          "https://github.com/vllm-project/vllm/pull/54353",
+        current_commit_pr_title: "[Bugfix] Bound cache_salt length",
+      }),
+    ],
+    [conditionRow()],
+  );
+
+  assert.deepEqual(comparison.currentRun.commitPullRequest, {
+    number: 54353,
+    url: "https://github.com/vllm-project/vllm/pull/54353",
+    title: "[Bugfix] Bound cache_salt length",
+  });
+  assert.equal(comparison.previousRun.commitPullRequest, null);
 });

--- a/src/lib/alerts-full-ci.ts
+++ b/src/lib/alerts-full-ci.ts
@@ -49,6 +49,12 @@ export interface FullCiRun {
   message: string;
   state: string;
   buildUrl: string;
+  /**
+   * The pull request this run's head commit merged, as the analyzer resolved
+   * it against GitHub. Null for a commit no pull request reaches, and for runs
+   * analyzed before that answer was recorded.
+   */
+  commitPullRequest: PullRequestRef | null;
 }
 
 /** How one job actually ended in one run, or null when it did not run at all. */
@@ -94,12 +100,18 @@ export interface FullCiComparisonRow {
   current_commit_sha: string;
   current_message: string;
   current_state: string;
+  current_commit_pr_number: number | null;
+  current_commit_pr_url: string | null;
+  current_commit_pr_title: string | null;
   previous_build_id: string;
   previous_build_number: number;
   previous_scheduled_at: Date;
   previous_commit_sha: string;
   previous_message: string;
   previous_state: string;
+  previous_commit_pr_number: number | null;
+  previous_commit_pr_url: string | null;
+  previous_commit_pr_title: string | null;
   analyzed_at: Date;
   notification_status: NotificationStatus | null;
 }
@@ -181,6 +193,11 @@ export function toFullCiComparisons(
       message: row.current_message,
       state: row.current_state,
       buildUrl: buildUrlForNumber(row.current_build_number),
+      commitPullRequest: toPullRequest(
+        row.current_commit_pr_number,
+        row.current_commit_pr_url,
+        row.current_commit_pr_title,
+      ),
     },
     previousRun: {
       buildkiteBuildId: row.previous_build_id,
@@ -190,6 +207,11 @@ export function toFullCiComparisons(
       message: row.previous_message,
       state: row.previous_state,
       buildUrl: buildUrlForNumber(row.previous_build_number),
+      commitPullRequest: toPullRequest(
+        row.previous_commit_pr_number,
+        row.previous_commit_pr_url,
+        row.previous_commit_pr_title,
+      ),
     },
     analyzedAt: row.analyzed_at.toISOString(),
     notificationStatus: row.notification_status,


### PR DESCRIPTION
Stacked on #86 — review that one first; this PR's base retargets to `main` once #86 merges.

## Why the card was blank

Slack names the change a Full CI run carried (`1dc464d4 / [Bugfix] Bound cache_salt length … (#54353)`) because the analyzer asks GitHub which pull request contains the run's head commit before writing its report — `GitHubRestClient.pull_for_commit`, folded into the summary as `pr_number` / `pr_title` / `pr_url` (`alerting/analyzer.py`).

Nothing kept that answer. The dashboard reads Postgres alone, where `alerting_full_ci_runs.message` is the **Buildkite build message** — for a scheduled run, literally `Full CI run - nightly` — so the card could link the commit but never name it.

## What changes

- **Migration `0015`** adds `commit_pr_number`, `commit_pr_url`, `commit_pr_title` to `alerting_full_ci_runs`, all nullable: a commit reachable by no pull request is a real state, not missing data.
- **The analyzer keeps what it already fetched.** The resolved pull request travels with `CompletedAnalysis` and is written onto the run row inside the same transaction. No extra GitHub request.
- **`python -m alerting.backfill`** fills historical rows, which would otherwise stay null forever because an analysis never runs twice for the same build. It counts commits that reach no pull request instead of inventing one, and `--limit` bounds a run.
- **API and card**: both compared runs carry `commitPullRequest`. The header reads `build 86198 · 1dc464d · #54353` and the subject line shows the pull request title instead of `Full CI run - nightly`. Where nothing was recorded, a message ending in the `(#12345)` it merged is still read for one; the bare message stays the fallback.

## Deploy order

The migration must run before this application code, since the query selects columns that would not otherwise exist. After deploying, run the backfill once on the worker host (it needs `DATABASE_URL` and `GITHUB_TOKEN`) to populate existing comparisons.

## Verification

`pytest` 119 passed (alerting, 4 new), `pytest` 24 passed (migrations), `mypy` clean for the touched files, `ruff` clean, `tsc --noEmit` clean, `eslint` clean, `npm test` 64 passed (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)