### PR TITLE
Make Kimi reasoning effort a CloudFormation parameter

### DIFF
--- a/deploy/aws/alerting-worker.yaml
+++ b/deploy/aws/alerting-worker.yaml
@@ -24,6 +24,14 @@ Parameters:
   GitHubReadOnlySecretArn:
     Type: String
     Description: ARN of a JSON secret containing a read-only GITHUB_TOKEN
+  KimiReasoningEffort:
+    Type: String
+    Description: Thinking effort for the Kimi analyzer
+    Default: high
+    AllowedValues:
+      - low
+      - high
+      - max
 
 Resources:
   CheckpointBucket:
@@ -147,13 +155,15 @@ Resources:
               dnf install -y git python3.12 python3.12-pip
               install -d -m 0755 /opt/alerting
               git clone --depth 1 --branch '${RepositoryRef}' '${RepositoryUrl}' /opt/alerting/source
-              /opt/alerting/source/deploy/aws/install.sh '${BucketName}' '${WorkerSecret}' '${GitHubSecret}'
+              /opt/alerting/source/deploy/aws/install.sh '${BucketName}' '${WorkerSecret}' '${GitHubSecret}' '${KimiEffort}'
             - BucketName:
                 Ref: CheckpointBucket
               WorkerSecret:
                 Ref: WorkerSecretArn
               GitHubSecret:
                 Ref: GitHubReadOnlySecretArn
+              KimiEffort:
+                Ref: KimiReasoningEffort
 
 Outputs:
   CheckpointBucketName:

--- a/deploy/aws/install.sh
+++ b/deploy/aws/install.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
-  echo "usage: install.sh CHECKPOINT_BUCKET WORKER_SECRET_ARN GITHUB_SECRET_ARN" >&2
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+  echo "usage: install.sh CHECKPOINT_BUCKET WORKER_SECRET_ARN GITHUB_SECRET_ARN [KIMI_REASONING_EFFORT]" >&2
   exit 2
 fi
 
 checkpoint_bucket=$1
 worker_secret_arn=$2
 github_secret_arn=$3
+kimi_reasoning_effort=${4:-high}
 source_root=$(cd "$(dirname "$0")/../.." && pwd)
 
 if ! id alerting >/dev/null 2>&1; then
@@ -27,8 +28,8 @@ install -m 0644 "$source_root"/deploy/aws/systemd/*.service /etc/systemd/system/
 install -m 0644 "$source_root"/deploy/aws/systemd/*.timer /etc/systemd/system/
 
 printf '%s\n%s\n' "$worker_secret_arn" "$github_secret_arn" > /etc/alerting/secret-arns
-printf 'ALERTING_CHECKPOINT_BUCKET=%s\nPATH=/usr/local/bin:/usr/bin:/bin\nDISABLE_AUTOUPDATER=1\n' \
-  "$checkpoint_bucket" > /etc/alerting/worker.env
+printf 'ALERTING_CHECKPOINT_BUCKET=%s\nKIMI_REASONING_EFFORT=%s\nPATH=/usr/local/bin:/usr/bin:/bin\nDISABLE_AUTOUPDATER=1\n' \
+  "$checkpoint_bucket" "$kimi_reasoning_effort" > /etc/alerting/worker.env
 chown root:alerting /etc/alerting/secret-arns /etc/alerting/worker.env
 chmod 0440 /etc/alerting/secret-arns /etc/alerting/worker.env
 


### PR DESCRIPTION
## Summary

- New `KimiReasoningEffort` template parameter (low|high|max, default **high**)
- UserData passes it to install.sh, which writes `KIMI_REASONING_EFFORT` into `/etc/alerting/worker.env`
- The worker already reads that env var; stack redeploys now carry analyzer effort instead of host hand-edits

## Test plan
- 15 deploy infrastructure tests pass, `bash -n` clean, template parses