### PR TITLE
Deliver both alert paths through the vllm-ci webhook

### DIFF
--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -37,7 +37,6 @@ from typing import Any, Protocol, cast
 from zoneinfo import ZoneInfo
 
 from alerting.commands import ScheduledCommand, SCHEMA_VERSION
-from alerting.fast_ci import FAST_CI_SLACK_CHANNEL
 from alerting.full_ci import FullCIJobOutcome, FullCIRun
 from alerting.ports import (
     AlertPath,
@@ -49,9 +48,10 @@ from alerting.ports import (
 
 COMPLETENESS_THRESHOLD = 0.95
 REPORT_CHAR_LIMIT = 2800
-# Full CI reports post through the Slack bot token to the same channel Fast CI
-# uses; no separate webhook destination.
-FULL_CI_SLACK_DESTINATION = FAST_CI_SLACK_CHANNEL
+# Full CI reports post through a dedicated incoming webhook (the logical
+# destination name is resolved from VLLM_CI_SLACK_URL at delivery time), so
+# they land in the Full CI channel rather than the Fast CI bot channel.
+FULL_CI_SLACK_DESTINATION = "vllm-ci"
 CHECKPOINT_SCHEMA_VERSION = SCHEMA_VERSION
 PACIFIC = ZoneInfo("America/Los_Angeles")
 
@@ -649,7 +649,7 @@ class FullCIAnalysisHandler:
                     alert_ref=f"full-ci-comparison:{context.current.build_id}",
                     alert_path=AlertPath.FULL_CI,
                     delivery_mode=self._delivery_mode,
-                    destination_mode=DestinationMode.BOT_TOKEN,
+                    destination_mode=DestinationMode.WEBHOOK,
                     destination=FULL_CI_SLACK_DESTINATION,
                     payload={"text": outputs.report_text},
                 ),

--- a/alerting/fast_ci.py
+++ b/alerting/fast_ci.py
@@ -30,7 +30,9 @@ INITIAL_LOOKBACK = timedelta(minutes=30)
 SAFETY_OVERLAP = timedelta(minutes=15)
 MAX_DURATION_SECONDS = 30
 SLACK_BATCH_SIZE = 8
-FAST_CI_SLACK_CHANNEL = "C0ANHBE642Y"
+# Both alert paths deliver through the vllm-ci incoming webhook; the logical
+# name is resolved from VLLM_CI_SLACK_URL at delivery time.
+SLACK_WEBHOOK_DESTINATION = "vllm-ci"
 STALE_NOTIFICATION_AGE = timedelta(minutes=30)
 
 
@@ -379,8 +381,8 @@ def _notification_batches(
                     alert_ref=delivery_id,
                     alert_path=AlertPath.FAST_CI,
                     delivery_mode=delivery_mode,
-                    destination_mode=DestinationMode.BOT_TOKEN,
-                    destination=FAST_CI_SLACK_CHANNEL,
+                    destination_mode=DestinationMode.WEBHOOK,
+                    destination=SLACK_WEBHOOK_DESTINATION,
                     payload={"text": _build_message(group, index, len(groups))},
                 ),
                 job_ids=job_ids,
@@ -401,8 +403,8 @@ def recovery_notification(
             alert_ref=delivery_id,
             alert_path=AlertPath.FAST_CI,
             delivery_mode=DeliveryMode.LIVE,
-            destination_mode=DestinationMode.BOT_TOKEN,
-            destination=FAST_CI_SLACK_CHANNEL,
+            destination_mode=DestinationMode.WEBHOOK,
+            destination=SLACK_WEBHOOK_DESTINATION,
             payload={"text": _build_message(ordered_events, 1, 1, recovery=True)},
         ),
         job_ids=tuple(event.job_id for event in ordered_events),

--- a/alerting/tests/test_analyzer.py
+++ b/alerting/tests/test_analyzer.py
@@ -437,8 +437,8 @@ def test_analysis_persists_conditions_report_checkpoint_and_notification() -> No
     memory_files = unpack_checkpoint(harness.checkpoints.objects[checkpoint.s3_uri])
     assert memory_files["MEMORY.md"] == b"# learned"
     notification = notification_for(harness, run2.build_id)
-    assert notification.destination_mode is DestinationMode.BOT_TOKEN
-    assert notification.destination == "C0ANHBE642Y"
+    assert notification.destination_mode is DestinationMode.WEBHOOK
+    assert notification.destination == "vllm-ci"
     assert "Job B" in notification.payload["text"]
 
 

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -34,10 +34,11 @@ def _required_environment(name: str) -> str:
 
 
 def _slack() -> SlackDeliveryPort:
-    # Both alert paths post through the bot token; no webhook destinations.
+    # Both alert paths post through the vllm-ci incoming webhook; no bot-token
+    # destination is configured.
     return SlackDeliveryPort(
-        bot_token=os.environ.get("SLACK_BOT_TOKEN"),
-        webhook_urls={},
+        bot_token=None,
+        webhook_urls={"vllm-ci": os.environ.get("VLLM_CI_SLACK_URL", "")},
     )
 
 


### PR DESCRIPTION
## Summary

The bot-token channel (`C0ANHBE642Y`) was the wrong destination. Fast CI batches, recovery summaries, and Full CI reports now all deliver via the `vllm-ci` incoming webhook resolved from `VLLM_CI_SLACK_URL` (in the worker secret). `SLACK_BOT_TOKEN` and the hardcoded channel ID are no longer read.

## Test plan
- 120 alerting tests pass, ruff + mypy clean