### PR TITLE
Deliver alerts via bot token with env-configurable channel

### DIFF
--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -37,6 +37,7 @@ from typing import Any, Protocol, cast
 from zoneinfo import ZoneInfo
 
 from alerting.commands import ScheduledCommand, SCHEMA_VERSION
+from alerting.fast_ci import slack_channel
 from alerting.full_ci import FullCIJobOutcome, FullCIRun
 from alerting.ports import (
     AlertPath,
@@ -48,10 +49,6 @@ from alerting.ports import (
 
 COMPLETENESS_THRESHOLD = 0.95
 REPORT_CHAR_LIMIT = 2800
-# Full CI reports post through a dedicated incoming webhook (the logical
-# destination name is resolved from VLLM_CI_SLACK_URL at delivery time), so
-# they land in the Full CI channel rather than the Fast CI bot channel.
-FULL_CI_SLACK_DESTINATION = "vllm-ci"
 CHECKPOINT_SCHEMA_VERSION = SCHEMA_VERSION
 PACIFIC = ZoneInfo("America/Los_Angeles")
 
@@ -649,8 +646,8 @@ class FullCIAnalysisHandler:
                     alert_ref=f"full-ci-comparison:{context.current.build_id}",
                     alert_path=AlertPath.FULL_CI,
                     delivery_mode=self._delivery_mode,
-                    destination_mode=DestinationMode.WEBHOOK,
-                    destination=FULL_CI_SLACK_DESTINATION,
+                    destination_mode=DestinationMode.BOT_TOKEN,
+                    destination=slack_channel(),
                     payload={"text": outputs.report_text},
                 ),
                 now=self._clock.now(),

--- a/alerting/fast_ci.py
+++ b/alerting/fast_ci.py
@@ -33,7 +33,7 @@ MAX_DURATION_SECONDS = 30
 SLACK_BATCH_SIZE = 8
 # Both alert paths deliver through the Slack bot token. The channel comes from
 # SLACK_CHANNEL_ID so a channel move is a secret edit, not a code change.
-ALERTS_SLACK_CHANNEL = "C0ANHBE642Y"
+ALERTS_SLACK_CHANNEL = "C0ABTNM9L5U"
 STALE_NOTIFICATION_AGE = timedelta(minutes=30)
 
 

--- a/alerting/fast_ci.py
+++ b/alerting/fast_ci.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import html
+import os
 import json
 import re
 import time
@@ -30,10 +31,15 @@ INITIAL_LOOKBACK = timedelta(minutes=30)
 SAFETY_OVERLAP = timedelta(minutes=15)
 MAX_DURATION_SECONDS = 30
 SLACK_BATCH_SIZE = 8
-# Both alert paths deliver through the vllm-ci incoming webhook; the logical
-# name is resolved from VLLM_CI_SLACK_URL at delivery time.
-SLACK_WEBHOOK_DESTINATION = "vllm-ci"
+# Both alert paths deliver through the Slack bot token. The channel comes from
+# SLACK_CHANNEL_ID so a channel move is a secret edit, not a code change.
+ALERTS_SLACK_CHANNEL = "C0ANHBE642Y"
 STALE_NOTIFICATION_AGE = timedelta(minutes=30)
+
+
+def slack_channel() -> str:
+    """The channel alert intents post to; SLACK_CHANNEL_ID wins when set."""
+    return os.environ.get("SLACK_CHANNEL_ID", ALERTS_SLACK_CHANNEL)
 
 
 class FastFailureState(StrEnum):
@@ -381,8 +387,8 @@ def _notification_batches(
                     alert_ref=delivery_id,
                     alert_path=AlertPath.FAST_CI,
                     delivery_mode=delivery_mode,
-                    destination_mode=DestinationMode.WEBHOOK,
-                    destination=SLACK_WEBHOOK_DESTINATION,
+                    destination_mode=DestinationMode.BOT_TOKEN,
+                    destination=slack_channel(),
                     payload={"text": _build_message(group, index, len(groups))},
                 ),
                 job_ids=job_ids,
@@ -403,8 +409,8 @@ def recovery_notification(
             alert_ref=delivery_id,
             alert_path=AlertPath.FAST_CI,
             delivery_mode=DeliveryMode.LIVE,
-            destination_mode=DestinationMode.WEBHOOK,
-            destination=SLACK_WEBHOOK_DESTINATION,
+            destination_mode=DestinationMode.BOT_TOKEN,
+            destination=slack_channel(),
             payload={"text": _build_message(ordered_events, 1, 1, recovery=True)},
         ),
         job_ids=tuple(event.job_id for event in ordered_events),

--- a/alerting/tests/test_analyzer.py
+++ b/alerting/tests/test_analyzer.py
@@ -437,8 +437,8 @@ def test_analysis_persists_conditions_report_checkpoint_and_notification() -> No
     memory_files = unpack_checkpoint(harness.checkpoints.objects[checkpoint.s3_uri])
     assert memory_files["MEMORY.md"] == b"# learned"
     notification = notification_for(harness, run2.build_id)
-    assert notification.destination_mode is DestinationMode.WEBHOOK
-    assert notification.destination == "vllm-ci"
+    assert notification.destination_mode is DestinationMode.BOT_TOKEN
+    assert notification.destination == "C0ANHBE642Y"
     assert "Job B" in notification.payload["text"]
 
 

--- a/alerting/tests/test_analyzer.py
+++ b/alerting/tests/test_analyzer.py
@@ -438,7 +438,7 @@ def test_analysis_persists_conditions_report_checkpoint_and_notification() -> No
     assert memory_files["MEMORY.md"] == b"# learned"
     notification = notification_for(harness, run2.build_id)
     assert notification.destination_mode is DestinationMode.BOT_TOKEN
-    assert notification.destination == "C0ANHBE642Y"
+    assert notification.destination == "C0ABTNM9L5U"
     assert "Job B" in notification.payload["text"]
 
 

--- a/alerting/tests/test_fast_ci.py
+++ b/alerting/tests/test_fast_ci.py
@@ -393,3 +393,12 @@ def test_fast_failure_event_has_no_resolution_lifecycle() -> None:
 
     assert not hasattr(stored, "status")
     assert not hasattr(stored, "resolved_at")
+
+
+def test_slack_channel_env_override_wins(monkeypatch: Any) -> None:
+    import alerting.fast_ci as fast_ci
+
+    monkeypatch.delenv("SLACK_CHANNEL_ID", raising=False)
+    assert fast_ci.slack_channel() == fast_ci.ALERTS_SLACK_CHANNEL
+    monkeypatch.setenv("SLACK_CHANNEL_ID", "C0NEWCHANNEL")
+    assert fast_ci.slack_channel() == "C0NEWCHANNEL"

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -34,11 +34,10 @@ def _required_environment(name: str) -> str:
 
 
 def _slack() -> SlackDeliveryPort:
-    # Both alert paths post through the vllm-ci incoming webhook; no bot-token
-    # destination is configured.
+    # Both alert paths post through the bot token; no webhook destinations.
     return SlackDeliveryPort(
-        bot_token=None,
-        webhook_urls={"vllm-ci": os.environ.get("VLLM_CI_SLACK_URL", "")},
+        bot_token=os.environ.get("SLACK_BOT_TOKEN"),
+        webhook_urls={},
     )
 
 


### PR DESCRIPTION
## Summary

Reverts the webhook delivery from #89: both alert paths post through `SLACK_BOT_TOKEN` again, but the channel is now `SLACK_CHANNEL_ID` from the worker secret (falling back to the previous hardcoded default) — a channel move is a secret edit, not a code change.

## Test plan
- 121 alerting tests pass (new: env override wins over the default channel), ruff + mypy clean