### PR TITLE
Main CI analysis: 1000-char summary, truncate over-limit, require PR hunt

### DIFF
--- a/alerting/assets/vllm-main-ci-job-analyzer.md
+++ b/alerting/assets/vllm-main-ci-job-analyzer.md
@@ -40,7 +40,7 @@ commentary — with exactly these keys:
 {
   "classification": "infra | flaky | code | test | unknown",
   "confidence": "high | medium | low",
-  "summary": "one to three sentences naming the root cause and error",
+  "summary": "one or two sentences naming the root cause",
   "evidence_urls": ["https://... build, job, log, or PR links you relied on"],
   "recommended_action": "the single most useful next step for an on-call",
   "suspected_fix_prs": [
@@ -58,9 +58,27 @@ commentary — with exactly these keys:
 - `confidence`: `high` only when the log shows the failing line and the cause
   is unambiguous; `medium` when the evidence points one way but is incomplete;
   `low` otherwise. `unknown` classifications should carry `low` confidence.
+- `summary`: short and concise — one or two sentences naming the root cause;
+  hard cap 1000 characters.
 - `evidence_urls`: only URLs you actually read; an empty array is valid.
-- `suspected_fix_prs`: merged or open PRs that plausibly fix this failure; an
-  empty array is valid. Never invent PR numbers.
-- Keep `summary` under 500 characters and `recommended_action` under 300.
+- `suspected_fix_prs`: merged or open PRs that plausibly fix this failure.
+  Never invent PR numbers. For `code` and `test` classifications you MUST try
+  to identify the concrete introducing PR and/or an open fix PR before leaving
+  this array empty:
+  - `context.json` carries the failure commit SHA and, when known, the merged
+    PR it belongs to — that PR is the prime suspect for a `code` regression.
+  - Use the GitHub API via `curl` with an
+    `Authorization: Bearer $GITHUB_TOKEN` header to dig further, for example:
+    - the commit's associated PRs
+      (`/repos/vllm-project/vllm/commits/<sha>/pulls` with
+      `Accept: application/vnd.github+json`),
+    - recent commits touching the failing test or source file
+      (`/repos/vllm-project/vllm/commits?path=<file>`),
+    - open PRs mentioning the failing test or error
+      (`/search/issues?q=repo:vllm-project/vllm+is:pr+is:open+<term>`).
+  - An empty array is allowed ONLY after this search genuinely finds nothing.
+- `recommended_action`: the single most useful next step, under 300
+  characters. When you identified a culprit PR, say so concretely (e.g.
+  "revert #NNN" or "merge #NNN").
 
 Write only `analysis.json`. Do not modify `context.json` or `job_log.txt`.

--- a/alerting/main_ci_analysis.py
+++ b/alerting/main_ci_analysis.py
@@ -42,7 +42,7 @@ ANALYSIS_FILE = Path("analysis.json")
 # latency; a slow tick is fenced by the execution lease either way.
 ANALYSES_PER_TICK = 5
 JOB_LOG_CHAR_LIMIT = 200_000
-SUMMARY_CHAR_LIMIT = 500
+SUMMARY_CHAR_LIMIT = 1000
 ACTION_CHAR_LIMIT = 300
 
 CLASSIFICATIONS = frozenset({"infra", "flaky", "code", "test", "unknown"})
@@ -187,8 +187,10 @@ def _require_string(payload: dict[str, Any], key: str, limit: int) -> str:
     value = payload.get(key)
     if not isinstance(value, str) or not value.strip():
         raise AnalyzerError(f"analysis {key} is missing or not a string")
+    # Over-limit prose is truncated, not rejected: a good analysis of a big
+    # failure must not be discarded just because the model ran long.
     if len(value) > limit:
-        raise AnalyzerError(f"analysis {key} exceeds {limit} characters")
+        value = value[: limit - 1] + "…"
     return value
 
 

--- a/alerting/tests/test_main_ci_analysis.py
+++ b/alerting/tests/test_main_ci_analysis.py
@@ -13,7 +13,9 @@ from alerting.analyzer import AnalyzerError, PullRequestRef
 from alerting.commands import ScheduledCommand
 from alerting.main_ci import MainCIJobObservation
 from alerting.main_ci_analysis import (
+    ACTION_CHAR_LIMIT,
     ANALYSES_PER_TICK,
+    SUMMARY_CHAR_LIMIT,
     MainCIAnalysisHandler,
     MainCIAnalysisTarget,
     MainCIJobAnalysis,
@@ -365,8 +367,6 @@ def test_read_analysis_accepts_the_valid_schema(tmp_path: Path) -> None:
         {"classification": "broken"},
         {"confidence": "certain"},
         {"summary": ""},
-        {"summary": "x" * 501},
-        {"recommended_action": "x" * 301},
         {"evidence_urls": "not-a-list"},
         {"evidence_urls": [42]},
         {"suspected_fix_prs": [{"number": 1}]},
@@ -384,6 +384,42 @@ def test_read_analysis_rejects_out_of_schema_output(
             target=_target(),
             model_version="model",
         )
+
+
+@pytest.mark.parametrize(
+    ("key", "limit"),
+    [
+        ("summary", SUMMARY_CHAR_LIMIT),
+        ("recommended_action", ACTION_CHAR_LIMIT),
+    ],
+)
+def test_read_analysis_truncates_over_limit_strings(
+    tmp_path: Path, key: str, limit: int
+) -> None:
+    over_limit = "x" * (limit + 50)
+    payload = {**VALID_PAYLOAD, key: over_limit}
+
+    analysis = read_analysis(
+        _write_payload(tmp_path, payload),
+        target=_target(),
+        model_version="model",
+    )
+
+    value = getattr(analysis, key)
+    assert len(value) == limit
+    assert value == "x" * (limit - 1) + "…"
+
+
+def test_read_analysis_accepts_summary_up_to_the_limit(tmp_path: Path) -> None:
+    payload = {**VALID_PAYLOAD, "summary": "x" * SUMMARY_CHAR_LIMIT}
+
+    analysis = read_analysis(
+        _write_payload(tmp_path, payload),
+        target=_target(),
+        model_version="model",
+    )
+
+    assert analysis.summary == "x" * SUMMARY_CHAR_LIMIT
 
 
 def test_read_analysis_requires_the_output_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

1. `read_analysis` hard-rejected summaries over 500 chars, silently discarding good analyses of big failures (observed: "analysis summary exceeds 500 characters").
2. `recommended_action`/`suspected_fix_prs` rarely named a revert/fix PR even for code regressions — the asset said an empty array is valid, so the model skipped the PR hunt.

## Changes

- `alerting/main_ci_analysis.py`: `SUMMARY_CHAR_LIMIT` 500 → 1000; over-limit `summary`/`recommended_action` are truncated (limit-1 + ellipsis) instead of raising `AnalyzerError`. All other validation stays strict.
- `alerting/assets/vllm-main-ci-job-analyzer.md`: summary is one or two sentences with a 1000-char hard cap; for `code`/`test` classifications the model MUST hunt for the introducing/fix PR via the GitHub API (associated PRs for the commit, commits on the failing file, open-PR search) before leaving `suspected_fix_prs` empty, and name it concretely in `recommended_action` ("revert #NNN"). "Never invent PR numbers" kept.
- Tests: over-limit strings truncate rather than reject; boundary (exactly 1000) accepted; invalid classification still rejected.

## Testing

- `uv run pytest tests/` — 142 passed
- `uv run ruff check` — clean