### PR TITLE
Main CI alerts: fix retry-pass resolution, add hourly backstop sweep

### DIFF
--- a/alerting/CONTEXT.md
+++ b/alerting/CONTEXT.md
@@ -48,6 +48,12 @@ build resolves it. Missing, soft-failed, canceled, or older late-finishing jobs
 do not resolve an episode.
 _Avoid_: Full CI Failure Condition, automated diagnosis
 
+**Main CI Backstop Sweep**:
+An hourly re-check of every open Main CI Job Alert against the build where it
+last failed, so a retry pass the observation window moved past still resolves
+the episode within an hour. It never advances the Scan Cursor.
+_Avoid_: Re-poll, full rescan
+
 **Scan Cursor**:
 The latest durable Fast or Main CI scan target used to derive the next
 overlapping observation window.

--- a/alerting/README.md
+++ b/alerting/README.md
@@ -44,10 +44,16 @@ repository-level relationship with the dashboard is recorded in
 - `full_ci.py` — the Buildkite query adapter, Full CI run and
   job-outcome records, and chronological reconciliation handler. Analyzer
   invocation remains outside this ingest-only slice.
-- `main_ci.py` — the five-minute Buildkite main-branch poller and exact-job
+- `main_ci.py` — the two-minute Buildkite main-branch poller and exact-job
   lifecycle. It ignores soft/non-command/non-terminal jobs, protects newer
   outcomes from older builds finishing late, and resolves only on a positive
-  pass. It writes raw lifecycle and Buildkite evidence only; Sherlock's
+  pass. Retried executions are fetched alongside originals (`include_retried_jobs`),
+  retried-out executions that lack a step key inherit it from the same-named
+  job in the build, and a pass that fell behind the scan window still
+  resolves when its build is fetched. An hourly backstop sweep
+  (`main_ci_backstop`) re-checks every open alert against the build where it
+  last failed, so a retry pass missed by the windowed poller resolves within
+  an hour. It writes raw lifecycle and Buildkite evidence only; Sherlock's
   diagnosis remains in Slack.
 - `analyzer.py` — the Full CI analyzer compatibility adapter. It materializes
   the working files the bundled analyzer instructions expect (summary, full
@@ -134,9 +140,11 @@ enabling the new path, and preserves Postgres and S3 baselines on rollback.
 - `FastCIScanHandler` registers as `fast_ci_scan`,
   `FullCIReconciliationHandler` registers as `full_ci_reconcile`, and
   `FullCIAnalysisHandler` registers as `full_ci_analyze`, while
-  `MainCIReconciliationHandler` registers as `main_ci_reconcile` and
+  `MainCIReconciliationHandler` registers as `main_ci_reconcile`,
+  `MainCIBackstopHandler` registers as `main_ci_backstop`, and
   `MainCIAnalysisHandler` registers as `main_ci_analyze`. Workers expose them
-  as the `fast-ci`, `full-ci`, `full-ci-analyze`, `main-ci`, and
+  as the `fast-ci`, `full-ci`, `full-ci-analyze`, `main-ci`,
+  `main-ci-backstop`, and
   `main-ci-analyze` consumers so the
   long-running LLM analysis never blocks ingest. The Main CI analysis consumer
   writes only the `alerting_main_ci_job_analysis` sidecar table; the

--- a/alerting/control.py
+++ b/alerting/control.py
@@ -37,10 +37,12 @@ _UNITS = {
     AlertPath.FAST_CI: (("alerting-fast-ci.timer", "alerting-fast-ci.service"),),
     AlertPath.FULL_CI: (("alerting-full-ci.timer", "alerting-full-ci.service"),),
     # The analysis sidecar follows the Main CI control: disabling the path
-    # stops both its lifecycle reconciliation and its AI analysis.
+    # stops both its lifecycle reconciliation and its AI analysis. The hourly
+    # backstop sweep follows the same control.
     AlertPath.MAIN_CI: (
         ("alerting-main-ci.timer", "alerting-main-ci.service"),
         ("alerting-main-ci-analysis.timer", "alerting-main-ci-analysis.service"),
+        ("alerting-main-ci-backstop.timer", "alerting-main-ci-backstop.service"),
     ),
 }
 _MODE_FILES = {

--- a/alerting/full_ci.py
+++ b/alerting/full_ci.py
@@ -172,13 +172,15 @@ class BuildkiteRestClient:
 
         The two bounded queries avoid re-downloading days of large build
         matrices while still catching jobs from an older build that becomes
-        terminal between polling ticks.
+        terminal between polling ticks. Retried executions are included so
+        both the original failure and a retry pass of the same step are
+        visible; downstream ordering then picks the newest outcome.
         """
         common: dict[str, str | int | list[str]] = {
             "branch": "main",
             "created_from": _iso8601(observed_from - timedelta(days=2)),
             "created_to": _iso8601(up_to),
-            "include_retried_jobs": "false",
+            "include_retried_jobs": "true",
             "per_page": 100,
         }
         active = self._list_build_pages(
@@ -218,8 +220,13 @@ class BuildkiteRestClient:
             url = str(next_url) if next_url else None
         return jobs
 
-    def get_build(self, build_number: int) -> dict[str, Any]:
-        payload = self._get_json(f"{self._BUILDS_URL}/{build_number}")
+    def get_build(
+        self, build_number: int, *, include_retried_jobs: bool = False
+    ) -> dict[str, Any]:
+        url = f"{self._BUILDS_URL}/{build_number}"
+        if include_retried_jobs:
+            url += "?include_retried_jobs=true"
+        payload = self._get_json(url)
         if not isinstance(payload, dict):
             raise RuntimeError("Buildkite build response was not an object")
         return cast(dict[str, Any], payload)

--- a/alerting/main_ci.py
+++ b/alerting/main_ci.py
@@ -54,6 +54,14 @@ class MainCIJobObservation:
 
 
 @dataclass(frozen=True)
+class MainCIOpenAlertRef:
+    """An open alert's job identity and the build where it last failed."""
+
+    job_key: str
+    build_number: int
+
+
+@dataclass(frozen=True)
 class MainCIJobAlert:
     """One open-or-resolved failure episode for a logical main CI job."""
 
@@ -98,6 +106,69 @@ def _parse_datetime(value: Any) -> datetime:
     return parsed
 
 
+def build_job_observations(build: dict[str, Any]) -> list[MainCIJobObservation]:
+    """Map one build's embedded jobs into tracked terminal outcomes.
+
+    Retried-out executions can come back from the Buildkite API without
+    ``step_key``. Jobs that do carry one first contribute a per-build
+    name → step-key map, and same-named executions missing the key inherit
+    it, so every execution of a step shares the alert's job key.
+    """
+    jobs = build.get("jobs")
+    if not isinstance(jobs, list):
+        return []
+    name_to_step_key: dict[str, str] = {}
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        name = str(job.get("name") or "").strip()
+        step_key = str(job.get("step_key") or "").strip()
+        if name and step_key and name not in name_to_step_key:
+            name_to_step_key[name] = step_key
+    build_id = str(build["id"])
+    build_number = int(build["number"])
+    build_url = str(build.get("web_url") or "")
+    commit_sha = str(build.get("commit") or "")
+    observations: list[MainCIJobObservation] = []
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        name = str(job.get("name") or "").strip()
+        state = str(job.get("state") or "")
+        finished_value = job.get("finished_at")
+        if (
+            not name
+            or job.get("type") != "script"
+            or bool(job.get("soft_failed"))
+            or state not in TRACKED_STATES
+            or finished_value is None
+        ):
+            continue
+        finished_at = _parse_datetime(finished_value)
+        job_id = str(job["id"])
+        step_key = str(job.get("step_key") or "").strip() or name_to_step_key.get(
+            name, ""
+        )
+        # Matrix expansions share a configured step key. Include the
+        # rendered job name so one matrix cell cannot resolve another.
+        job_key = f"step:{step_key}|name:{name}" if step_key else f"name:{name}"
+        observations.append(
+            MainCIJobObservation(
+                job_key=job_key,
+                job_id=job_id,
+                job_name=name,
+                job_url=str(job.get("web_url") or f"{build_url}#{job_id}"),
+                state=state,
+                finished_at=finished_at,
+                build_id=build_id,
+                build_number=build_number,
+                build_url=build_url,
+                commit_sha=commit_sha,
+            )
+        )
+    return observations
+
+
 class BuildkiteMainCISource:
     """Map recently active or finished main builds into terminal outcomes."""
 
@@ -111,51 +182,41 @@ class BuildkiteMainCISource:
             observed_from=start_time,
             up_to=end_time,
         )
-        observations: list[MainCIJobObservation] = []
-        for build in builds:
-            build_id = str(build["id"])
-            build_number = int(build["number"])
-            build_url = str(build.get("web_url") or "")
-            commit_sha = str(build.get("commit") or "")
-            jobs = build.get("jobs")
-            if not isinstance(jobs, list):
-                continue
-            for job in jobs:
-                if not isinstance(job, dict):
-                    continue
-                name = str(job.get("name") or "").strip()
-                state = str(job.get("state") or "")
-                finished_value = job.get("finished_at")
-                if (
-                    not name
-                    or job.get("type") != "script"
-                    or bool(job.get("soft_failed"))
-                    or state not in TRACKED_STATES
-                    or finished_value is None
-                ):
-                    continue
-                finished_at = _parse_datetime(finished_value)
-                if finished_at < start_time or finished_at > end_time:
-                    continue
-                job_id = str(job["id"])
-                step_key = str(job.get("step_key") or "").strip()
-                # Matrix expansions share a configured step key. Include the
-                # rendered job name so one matrix cell cannot resolve another.
-                job_key = f"step:{step_key}|name:{name}" if step_key else f"name:{name}"
-                observations.append(
-                    MainCIJobObservation(
-                        job_key=job_key,
-                        job_id=job_id,
-                        job_name=name,
-                        job_url=str(job.get("web_url") or f"{build_url}#{job_id}"),
-                        state=state,
-                        finished_at=finished_at,
-                        build_id=build_id,
-                        build_number=build_number,
-                        build_url=build_url,
-                        commit_sha=commit_sha,
-                    )
-                )
+        candidates = [
+            observation
+            for build in builds
+            for observation in build_job_observations(build)
+        ]
+        observations = [
+            observation
+            for observation in candidates
+            if start_time <= observation.finished_at <= end_time
+        ]
+        # Resolution lookahead: a retry pass can finish before the scan
+        # window (a worker gap hides it while it is observable, and the
+        # window then moves past its finished_at). When a job key's newest
+        # in-window outcome is a failure but a fetched build holds a newer
+        # passing execution of the same key, include that pass even though
+        # it is outside the window. The commit-time order guard still
+        # prevents this older-looking data from overwriting newer outcomes.
+        newest_candidate: dict[str, MainCIJobObservation] = {}
+        for observation in candidates:
+            current = newest_candidate.get(observation.job_key)
+            if current is None or observation.order > current.order:
+                newest_candidate[observation.job_key] = observation
+        newest_in_window: dict[str, MainCIJobObservation] = {}
+        for observation in observations:
+            current = newest_in_window.get(observation.job_key)
+            if current is None or observation.order > current.order:
+                newest_in_window[observation.job_key] = observation
+        for job_key, in_window in newest_in_window.items():
+            candidate = newest_candidate[job_key]
+            if (
+                in_window.failed
+                and not candidate.failed
+                and candidate.order > in_window.order
+            ):
+                observations.append(candidate)
         return ordered_unique_observations(observations)
 
 
@@ -178,6 +239,71 @@ class MainCIStore(Protocol):
     ) -> None:
         """Atomically reconcile outcomes, advance the cursor, and complete."""
         ...
+
+
+class MainCIBackstopBuildPort(Protocol):
+    def get_build(
+        self, build_number: int, *, include_retried_jobs: bool
+    ) -> dict[str, Any]: ...
+
+
+class MainCIBackstopStore(MainCIStore, Protocol):
+    def open_main_ci_alert_builds(self) -> list[MainCIOpenAlertRef]: ...
+
+
+class MainCIBackstopHandler:
+    """Hourly sweep that re-checks open alerts against their failure build.
+
+    The windowed poller can permanently miss a retry pass when a worker gap
+    lets the scan window move past the pass's finished_at. This sweep fetches
+    each open alert's last-failure build directly and feeds the newest
+    terminal execution of the alert's job key through the normal
+    reconciliation path, so a missed pass resolves within an hour.
+    """
+
+    def __init__(
+        self,
+        *,
+        builds: MainCIBackstopBuildPort,
+        store: MainCIBackstopStore,
+        clock: Clock,
+    ) -> None:
+        self._builds = builds
+        self._store = store
+        self._clock = clock
+
+    def __call__(self, command: ScheduledCommand) -> HandlerCompletion:
+        refs = self._store.open_main_ci_alert_builds()
+        job_keys_by_build: dict[int, set[str]] = {}
+        for ref in refs:
+            job_keys_by_build.setdefault(ref.build_number, set()).add(ref.job_key)
+        observations: list[MainCIJobObservation] = []
+        for build_number in sorted(job_keys_by_build):
+            build = self._builds.get_build(
+                build_number, include_retried_jobs=True
+            )
+            candidates = build_job_observations(build)
+            for job_key in job_keys_by_build[build_number]:
+                executions = [
+                    candidate
+                    for candidate in candidates
+                    if candidate.job_key == job_key
+                ]
+                if executions:
+                    observations.append(
+                        max(executions, key=lambda item: item.order)
+                    )
+        # The sweep only re-checks known alerts; it must not advance the
+        # poller's scan cursor, or a poller outage covered by the sweep would
+        # skip failures that fell into the gap.
+        cursor = self._store.main_ci_scan_cursor()
+        self._store.commit_main_ci_scan(
+            command=command,
+            observations=observations,
+            scanned_through=cursor if cursor is not None else command.target_time,
+            now=self._clock.now(),
+        )
+        return HandlerCompletion.TRANSACTIONAL
 
 
 class MainCIReconciliationHandler:

--- a/alerting/memory.py
+++ b/alerting/memory.py
@@ -38,6 +38,7 @@ from alerting.full_ci import (
 from alerting.main_ci import (
     MainCIJobAlert,
     MainCIJobObservation,
+    MainCIOpenAlertRef,
     ordered_unique_observations,
 )
 from alerting.main_ci_analysis import MainCIAnalysisTarget, MainCIJobAnalysis
@@ -521,6 +522,17 @@ class InMemoryMainCIStore:
 
     def alerts(self) -> list[MainCIJobAlert]:
         return list(self._alerts)
+
+    def open_main_ci_alert_builds(self) -> list[MainCIOpenAlertRef]:
+        refs = {
+            (alert.job_key, alert.last_failure.build_number)
+            for alert in self._alerts
+            if alert.resolved_at is None
+        }
+        return [
+            MainCIOpenAlertRef(job_key=job_key, build_number=build_number)
+            for job_key, build_number in sorted(refs)
+        ]
 
     def state(self, job_key: str) -> MainCIJobObservation | None:
         return self._states.get(job_key)

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -33,7 +33,11 @@ from alerting.full_ci import (
     FullCIRun,
     ordered_unique_runs,
 )
-from alerting.main_ci import MainCIJobObservation, ordered_unique_observations
+from alerting.main_ci import (
+    MainCIJobObservation,
+    MainCIOpenAlertRef,
+    ordered_unique_observations,
+)
 from alerting.main_ci_analysis import (
     MainCIAnalysisRunner,
     MainCIAnalysisTarget,
@@ -1029,6 +1033,21 @@ class PostgresAlertStore:
                 if completed.rowcount != 1:
                     raise RuntimeError("Main CI execution was not running at commit")
 
+    def open_main_ci_alert_builds(self) -> list[MainCIOpenAlertRef]:
+        with self._connection_factory() as connection:
+            rows = connection.execute(
+                """
+                SELECT DISTINCT job_key, last_failure_build_number
+                FROM alerting_main_ci_job_alerts
+                WHERE status = 'open'
+                ORDER BY job_key
+                """
+            ).fetchall()
+        return [
+            MainCIOpenAlertRef(job_key=row[0], build_number=int(row[1]))
+            for row in rows
+        ]
+
     def pending_main_ci_analyses(self, *, limit: int) -> list[MainCIAnalysisTarget]:
         with self._connection_factory() as connection:
             rows = connection.execute(
@@ -1581,6 +1600,33 @@ def build_main_ci_runtime(
         slack=slack,
         clock=clock,
         handlers={"main_ci_reconcile": handler},
+        alert_path=AlertPath.MAIN_CI,
+    )
+
+
+def build_main_ci_backstop_runtime(
+    *,
+    database_url: str,
+    buildkite_token: str,
+    slack: SlackPort,
+    clock: Clock,
+) -> AlertingRuntime:
+    """Wire the hourly Main CI retry-resolution backstop into the runtime."""
+    from alerting.full_ci import BuildkiteRestClient
+    from alerting.main_ci import MainCIBackstopHandler
+
+    store = PostgresAlertStore.from_database_url(database_url)
+    handler = MainCIBackstopHandler(
+        builds=BuildkiteRestClient(token=buildkite_token),
+        store=store,
+        clock=clock,
+    )
+    return AlertingRuntime(
+        executions=store,
+        outbox=store,
+        slack=slack,
+        clock=clock,
+        handlers={"main_ci_backstop": handler},
         alert_path=AlertPath.MAIN_CI,
     )
 

--- a/alerting/tests/test_control.py
+++ b/alerting/tests/test_control.py
@@ -67,11 +67,13 @@ def test_reconcile_controls_defaults_missing_path_to_shadow_and_disables_one_pat
         "alerting-full-ci.timer",
         "alerting-main-ci.timer",
         "alerting-main-ci-analysis.timer",
+        "alerting-main-ci-backstop.timer",
     ]
     assert units.stopped == [
         "alerting-full-ci.service",
         "alerting-main-ci.service",
         "alerting-main-ci-analysis.service",
+        "alerting-main-ci-backstop.service",
     ]
 
 
@@ -109,4 +111,5 @@ def test_main_ci_live_control_enables_its_independent_timers(tmp_path: Path) -> 
     assert units.enabled == [
         "alerting-main-ci.timer",
         "alerting-main-ci-analysis.timer",
+        "alerting-main-ci-backstop.timer",
     ]

--- a/alerting/tests/test_main_ci.py
+++ b/alerting/tests/test_main_ci.py
@@ -9,6 +9,7 @@ from alerting.main_ci import (
     INITIAL_LOOKBACK,
     SAFETY_OVERLAP,
     BuildkiteMainCISource,
+    MainCIBackstopHandler,
     MainCIJobObservation,
     MainCIReconciliationHandler,
 )
@@ -276,5 +277,324 @@ def test_buildkite_client_unions_active_and_recently_finished_builds() -> None:
     assert client.queries[1]["finished_from"] == "2026-08-29T09:30:00Z"
     for query in client.queries:
         assert query["branch"] == "main"
-        assert query["include_retried_jobs"] == "false"
+        assert query["include_retried_jobs"] == "true"
         assert "exclude_jobs" not in query
+
+
+def buildkite_job(
+    *,
+    job_id: str,
+    state: str,
+    finished_at: datetime | None,
+    name: str = "GPU correctness",
+    step_key: str | None = "gpu-test",
+) -> dict[str, Any]:
+    job: dict[str, Any] = {
+        "id": job_id,
+        "name": name,
+        "type": "script",
+        "state": state,
+        "soft_failed": False,
+        "finished_at": (
+            finished_at.isoformat().replace("+00:00", "Z") if finished_at else None
+        ),
+    }
+    if step_key is not None:
+        job["step_key"] = step_key
+    return job
+
+
+def buildkite_build(number: int, jobs: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "id": f"build-{number}",
+        "number": number,
+        "web_url": f"https://buildkite.com/vllm/ci/builds/{number}",
+        "commit": f"commit-{number}",
+        "jobs": jobs,
+    }
+
+
+def source_runtime_for(
+    buildkite: RecordingBuildkite,
+) -> tuple[AlertingRuntime, InMemoryMainCIStore, FixedClock]:
+    clock = FixedClock(START)
+    executions = InMemoryAutomationExecutionStore()
+    store = InMemoryMainCIStore(executions=executions)
+    runtime = AlertingRuntime(
+        executions=executions,
+        outbox=InMemoryOutboxStore(),
+        slack=RecordingSlackPort(),
+        clock=clock,
+        handlers={
+            "main_ci_reconcile": MainCIReconciliationHandler(
+                source=BuildkiteMainCISource(buildkite),
+                store=store,
+                clock=clock,
+            )
+        },
+    )
+    return runtime, store, clock
+
+
+def test_retry_pass_inside_window_resolves_original_failure() -> None:
+    failure = buildkite_job(
+        job_id="orig", state="failed", finished_at=START - timedelta(hours=3)
+    )
+    buildkite = RecordingBuildkite([buildkite_build(300, [failure])])
+    runtime, store, _ = source_runtime_for(buildkite)
+    key = "step:gpu-test|name:GPU correctness"
+
+    reconcile(runtime, START - timedelta(hours=2, minutes=55))
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("open", 1)
+    ]
+    # Advance the cursor so the original failure falls outside the window.
+    reconcile(runtime, START - timedelta(hours=2, minutes=20))
+
+    buildkite.builds[0]["jobs"].append(
+        buildkite_job(
+            job_id="retry", state="passed", finished_at=START - timedelta(minutes=5)
+        )
+    )
+    reconcile(runtime, START)
+
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("resolved", 1)
+    ]
+    resolution = store.alerts()[0].resolution
+    assert resolution is not None
+    assert resolution.job_id == "retry"
+    state = store.state(key)
+    assert state is not None
+    assert state.job_id == "retry"
+
+
+def test_retry_pass_outside_window_still_resolves_when_build_is_fetched() -> None:
+    original = buildkite_job(
+        job_id="orig", state="failed", finished_at=START - timedelta(hours=3)
+    )
+    buildkite = RecordingBuildkite([buildkite_build(300, [original])])
+    runtime, store, _ = source_runtime_for(buildkite)
+
+    reconcile(runtime, START - timedelta(hours=2, minutes=55))
+    assert [alert.status for alert in store.alerts()] == ["open"]
+    # The build drops out of the fetched set while the retry passes, so the
+    # pass's finished_at ends up behind the scan window.
+    buildkite.builds = []
+    reconcile(runtime, START - timedelta(hours=1))
+
+    buildkite.builds = [
+        buildkite_build(
+            300,
+            [
+                original,
+                buildkite_job(
+                    job_id="retry",
+                    state="passed",
+                    finished_at=START - timedelta(hours=2, minutes=45),
+                ),
+            ],
+        ),
+        # An older build's late failure must not win over the newer pass.
+        buildkite_build(
+            299,
+            [
+                buildkite_job(
+                    job_id="old",
+                    state="failed",
+                    finished_at=START + timedelta(minutes=10),
+                )
+            ],
+        ),
+    ]
+    reconcile(runtime, START + timedelta(minutes=30))
+
+    assert [alert.status for alert in store.alerts()] == ["resolved"]
+    resolution = store.alerts()[0].resolution
+    assert resolution is not None
+    assert resolution.job_id == "retry"
+
+
+def test_retry_execution_without_step_key_resolves_original_alert() -> None:
+    buildkite = RecordingBuildkite(
+        [
+            buildkite_build(
+                300,
+                [
+                    buildkite_job(
+                        job_id="orig",
+                        state="failed",
+                        finished_at=START - timedelta(hours=3),
+                    )
+                ],
+            )
+        ]
+    )
+    runtime, store, _ = source_runtime_for(buildkite)
+
+    reconcile(runtime, START - timedelta(hours=2, minutes=55))
+    assert [alert.status for alert in store.alerts()] == ["open"]
+
+    buildkite.builds[0]["jobs"].append(
+        buildkite_job(
+            job_id="retry",
+            state="passed",
+            finished_at=START - timedelta(minutes=5),
+            step_key=None,
+        )
+    )
+    reconcile(runtime, START)
+
+    assert [alert.status for alert in store.alerts()] == ["resolved"]
+    resolution = store.alerts()[0].resolution
+    assert resolution is not None
+    assert resolution.job_id == "retry"
+    # The retried execution inherits the step key instead of opening a
+    # parallel "name:..." identity.
+    assert store.state("step:gpu-test|name:GPU correctness") is not None
+    assert store.state("name:GPU correctness") is None
+
+
+def test_newer_failure_wins_over_older_pass() -> None:
+    source = FixtureSource()
+    runtime, store, _ = runtime_for(source)
+    source.observations = [
+        observation(build_number=101, state="failed", minutes=1, job_id="newer")
+    ]
+    reconcile(runtime, START + timedelta(minutes=2))
+    assert [alert.status for alert in store.alerts()] == ["open"]
+
+    # An older build's pass finishing late must not resolve the newer failure.
+    source.observations.append(
+        observation(build_number=100, state="passed", minutes=3, job_id="older")
+    )
+    reconcile(runtime, START + timedelta(minutes=4))
+
+    assert [alert.status for alert in store.alerts()] == ["open"]
+    state = store.state("step:gpu-test|name:GPU correctness")
+    assert state is not None
+    assert state.job_id == "newer"
+
+
+class FixtureBuilds:
+    def __init__(self, builds: dict[int, dict[str, Any]]) -> None:
+        self.builds = builds
+        self.calls: list[tuple[int, bool]] = []
+
+    def get_build(
+        self, build_number: int, *, include_retried_jobs: bool
+    ) -> dict[str, Any]:
+        self.calls.append((build_number, include_retried_jobs))
+        return self.builds[build_number]
+
+
+def combined_runtime_for(
+    source: FixtureSource, builds: FixtureBuilds
+) -> tuple[AlertingRuntime, InMemoryMainCIStore, FixedClock]:
+    clock = FixedClock(START)
+    executions = InMemoryAutomationExecutionStore()
+    store = InMemoryMainCIStore(executions=executions)
+    runtime = AlertingRuntime(
+        executions=executions,
+        outbox=InMemoryOutboxStore(),
+        slack=RecordingSlackPort(),
+        clock=clock,
+        handlers={
+            "main_ci_reconcile": MainCIReconciliationHandler(
+                source=source, store=store, clock=clock
+            ),
+            "main_ci_backstop": MainCIBackstopHandler(
+                builds=builds, store=store, clock=clock
+            ),
+        },
+    )
+    return runtime, store, clock
+
+
+def backstop(runtime: AlertingRuntime, target: datetime) -> None:
+    result = runtime.process_command(
+        ScheduledCommand(command_type="main_ci_backstop", target_time=target)
+    )
+    assert result.status is ProcessStatus.COMPLETED
+
+
+def open_alert(runtime: AlertingRuntime, source: FixtureSource) -> None:
+    source.observations = [
+        observation(
+            build_number=300, state="failed", minutes=-180, job_id="orig"
+        )
+    ]
+    reconcile(runtime, START - timedelta(hours=2, minutes=55))
+
+
+def test_backstop_resolves_open_alert_whose_retried_job_now_passes() -> None:
+    source = FixtureSource()
+    builds = FixtureBuilds({})
+    runtime, store, _ = combined_runtime_for(source, builds)
+    open_alert(runtime, source)
+    assert [alert.status for alert in store.alerts()] == ["open"]
+    cursor = store.main_ci_scan_cursor()
+
+    builds.builds[300] = buildkite_build(
+        300,
+        [
+            buildkite_job(
+                job_id="orig", state="failed", finished_at=START - timedelta(hours=3)
+            ),
+            buildkite_job(
+                job_id="retry",
+                state="passed",
+                finished_at=START - timedelta(hours=1),
+            ),
+        ],
+    )
+    backstop(runtime, START + timedelta(hours=2))
+
+    alert = store.alerts()[0]
+    assert alert.status == "resolved"
+    assert alert.resolution is not None
+    assert alert.resolution.job_id == "retry"
+    assert builds.calls == [(300, True)]
+    # The sweep must not advance the poller's scan cursor.
+    assert store.main_ci_scan_cursor() == cursor
+
+
+def test_backstop_leaves_still_failing_alert_open() -> None:
+    source = FixtureSource()
+    builds = FixtureBuilds({})
+    runtime, store, _ = combined_runtime_for(source, builds)
+    open_alert(runtime, source)
+
+    builds.builds[300] = buildkite_build(
+        300,
+        [
+            buildkite_job(
+                job_id="orig", state="failed", finished_at=START - timedelta(hours=3)
+            )
+        ],
+    )
+    backstop(runtime, START + timedelta(hours=2))
+
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("open", 1)
+    ]
+
+
+def test_backstop_ignores_resolved_alerts() -> None:
+    source = FixtureSource()
+    builds = FixtureBuilds({})
+    runtime, store, _ = combined_runtime_for(source, builds)
+    open_alert(runtime, source)
+    source.observations.append(
+        observation(build_number=300, state="passed", minutes=-170, job_id="retry")
+    )
+    reconcile(runtime, START - timedelta(hours=2, minutes=45))
+    assert [alert.status for alert in store.alerts()] == ["resolved"]
+
+    backstop(runtime, START + timedelta(hours=2))
+
+    assert builds.calls == []
+    alert = store.alerts()[0]
+    assert alert.status == "resolved"
+    assert alert.resolution is not None
+    assert alert.resolution.job_id == "retry"

--- a/alerting/tests/test_postgres_main_ci.py
+++ b/alerting/tests/test_postgres_main_ci.py
@@ -1,0 +1,50 @@
+"""Postgres Main CI store queries through the connection seam."""
+
+from typing import Any
+
+from alerting.postgres import PostgresAlertStore
+
+
+class Result:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return self._rows
+
+
+class RecordingConnection:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self.rows = rows
+        self.statements: list[str] = []
+
+    def __enter__(self) -> "RecordingConnection":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] = ()) -> Result:
+        self.statements.append(" ".join(sql.split()))
+        return Result(self.rows)
+
+
+def test_open_main_ci_alert_builds_reads_distinct_open_alert_builds() -> None:
+    connection = RecordingConnection(
+        [("step:gpu|name:GPU correctness", 86297), ("name:Other job", 86297)]
+    )
+    store = PostgresAlertStore(lambda: connection)
+
+    refs = store.open_main_ci_alert_builds()
+
+    assert [(ref.job_key, ref.build_number) for ref in refs] == [
+        ("step:gpu|name:GPU correctness", 86297),
+        ("name:Other job", 86297),
+    ]
+    assert len(connection.statements) == 1
+    statement = connection.statements[0]
+    assert statement.startswith(
+        "SELECT DISTINCT job_key, last_failure_build_number"
+        " FROM alerting_main_ci_job_alerts"
+    )
+    assert "WHERE status = 'open'" in statement

--- a/alerting/tests/test_worker.py
+++ b/alerting/tests/test_worker.py
@@ -93,3 +93,15 @@ def test_main_ci_analysis_timer_uses_its_sidecar_command(
 
     assert worker.main(["main-ci-analyze"]) == 0
     assert [command.command_type for command in runtime.commands] == ["main_ci_analyze"]
+
+
+def test_main_ci_backstop_timer_uses_its_sweep_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = RecordingRuntime()
+    monkeypatch.setattr(worker, "_runtime", lambda *args: runtime)
+
+    assert worker.main(["main-ci-backstop"]) == 0
+    assert [command.command_type for command in runtime.commands] == [
+        "main_ci_backstop"
+    ]

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -14,6 +14,7 @@ from alerting.postgres import (
     build_full_ci_analysis_runtime,
     build_full_ci_runtime,
     build_main_ci_analysis_runtime,
+    build_main_ci_backstop_runtime,
     build_main_ci_runtime,
 )
 from alerting.runtime import AlertingRuntime, ProcessStatus
@@ -98,6 +99,13 @@ def _runtime(
             slack=_slack(),
             clock=clock,
         )
+    if consumer == "main-ci-backstop":
+        return build_main_ci_backstop_runtime(
+            database_url=database_url,
+            buildkite_token=_required_environment("BUILDKITE_TOKEN"),
+            slack=_slack(),
+            clock=clock,
+        )
     if consumer == "main-ci-analyze":
         return build_main_ci_analysis_runtime(
             database_url=database_url,
@@ -125,6 +133,7 @@ def scheduled_command(consumer: str, target_time: datetime) -> ScheduledCommand:
         "full-ci": "full_ci_reconcile",
         "full-ci-analyze": "full_ci_analyze",
         "main-ci": "main_ci_reconcile",
+        "main-ci-backstop": "main_ci_backstop",
         "main-ci-analyze": "main_ci_analyze",
     }
     try:
@@ -142,6 +151,7 @@ def main(arguments: Sequence[str] | None = None) -> int:
         "full-ci",
         "full-ci-analyze",
         "main-ci",
+        "main-ci-backstop",
         "main-ci-analyze",
     }:
         return 2

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -56,7 +56,7 @@ All three paths start in shadow mode. Durable controls live at
 but workers run as the non-login `alerting` user. Shadow runs persist source
 observations and rendered Slack payloads without leasing them for delivery.
 Main CI currently writes dashboard lifecycle only and renders no Slack payload;
-its mode still controls the independent five-minute timer.
+its mode still controls the independent two-minute timer.
 
 Run the repeatable operator wizard from the repository root:
 
@@ -77,8 +77,9 @@ Stop all alert timers before a scheduled tick, wait through the tick, then
 start the timers again. `Persistent=true` and `OnBootSec` start reconciliation,
 while the Postgres cursors and processed-run history recover missed Fast, Full,
 or Main CI observations. Each path has a separate timer and service — Main CI
-has two, one for lifecycle reconciliation and one for AI analysis — so a long
-Full CI execution cannot occupy either frequent poller.
+has three: one for lifecycle reconciliation, one for AI analysis, and one
+hourly backstop sweep that resolves retry passes the poller's window missed —
+so a long Full CI execution cannot occupy either frequent poller.
 
 For instance replacement and stack recreation, see
 [disaster-recovery.md](disaster-recovery.md).

--- a/deploy/aws/bin/run-worker
+++ b/deploy/aws/bin/run-worker
@@ -6,7 +6,7 @@ credentials_path="/run/alerting/${consumer}.env"
 case "$consumer" in
   fast-ci) alert_path=fast-ci ;;
   full-ci|full-ci-analyze) alert_path=full-ci ;;
-  main-ci|main-ci-analyze) alert_path=main-ci ;;
+  main-ci|main-ci-analyze|main-ci-backstop) alert_path=main-ci ;;
   *) echo "unknown consumer: $consumer" >&2; exit 2 ;;
 esac
 mode_path="/run/alerting/${alert_path}.mode"

--- a/deploy/aws/systemd/alerting-main-ci-backstop.service
+++ b/deploy/aws/systemd/alerting-main-ci-backstop.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Re-check open Main CI alerts against their failure builds
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=alerting
+Group=alerting
+ExecStart=/opt/alerting/bin/run-worker main-ci-backstop
+StandardOutput=null
+StandardError=null
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+TimeoutStartSec=10min

--- a/deploy/aws/systemd/alerting-main-ci-backstop.timer
+++ b/deploy/aws/systemd/alerting-main-ci-backstop.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Hourly backstop sweep for Main CI retry resolutions missed by the poller
+
+[Timer]
+OnBootSec=3min
+OnCalendar=*-*-* *:17:00 UTC
+Persistent=true
+AccuracySec=30s
+RandomizedDelaySec=0
+Unit=alerting-main-ci-backstop.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/aws/systemd/alerting-main-ci.timer
+++ b/deploy/aws/systemd/alerting-main-ci.timer
@@ -1,9 +1,9 @@
 [Unit]
-Description=Schedule Main CI job alert reconciliation every five minutes
+Description=Schedule Main CI job alert reconciliation every two minutes
 
 [Timer]
 OnBootSec=2min
-OnCalendar=*-*-* *:00/5:00 UTC
+OnCalendar=*-*-* *:00/2:00 UTC
 Persistent=true
 AccuracySec=30s
 RandomizedDelaySec=0

--- a/deploy/aws/tests/test_alerting_worker_infrastructure.py
+++ b/deploy/aws/tests/test_alerting_worker_infrastructure.py
@@ -58,12 +58,27 @@ def test_fast_ci_timer_uses_pacific_wall_clock_every_fifteen_minutes() -> None:
     assert "Persistent=true" in timer
 
 
-def test_main_ci_timer_polls_every_five_minutes_and_recovers_after_downtime() -> None:
+def test_main_ci_timer_polls_every_two_minutes_and_recovers_after_downtime() -> None:
     timer = read("systemd/alerting-main-ci.timer")
 
-    assert "OnCalendar=*-*-* *:00/5:00 UTC" in timer
+    assert "OnCalendar=*-*-* *:00/2:00 UTC" in timer
     assert "OnBootSec=" in timer
     assert "Persistent=true" in timer
+
+
+def test_main_ci_backstop_timer_runs_hourly_off_the_hour_mark() -> None:
+    timer = read("systemd/alerting-main-ci-backstop.timer")
+    service = read("systemd/alerting-main-ci-backstop.service")
+
+    assert "OnCalendar=*-*-* *:17:00 UTC" in timer
+    assert "OnBootSec=" in timer
+    assert "Persistent=true" in timer
+    assert "Unit=alerting-main-ci-backstop.service" in timer
+    assert "run-worker main-ci-backstop" in service
+    assert "StandardOutput=null" in service
+    assert "StandardError=null" in service
+    for sensitive_name in ("DATABASE_URL", "TOKEN", "PASSWORD"):
+        assert sensitive_name not in service + timer
 
 
 def test_main_ci_analysis_timer_runs_every_ten_minutes() -> None:
@@ -204,6 +219,7 @@ def test_retention_timer_prunes_daily_without_sensitive_data() -> None:
         ("full-ci", "full_ci_reconcile"),
         ("fast-ci", "fast_ci_scan"),
         ("main-ci", "main_ci_reconcile"),
+        ("main-ci-backstop", "main_ci_backstop"),
         ("main-ci-analyze", "main_ci_analyze"),
     ],
 )


### PR DESCRIPTION
## Root cause

A job in build 86297 failed, was retried, and passed — but its Main CI failure alert stayed open. Two compounding causes:

1. **Observability window**: the per-job `finished_at >= scan_window_start` filter meant a retry pass was only observable for ~35 minutes after it happened. Any worker downtime or gap longer than that (e.g. an instance replacement) missed the pass permanently.
2. **Retry `step_key` mapping**: retried-out executions can come back from the Buildkite API without `step_key`, producing a different job key (`name:X` vs `step:k|name:X`), so the pass never matched the open alert.

## What changed

**Retry-pass resolution (poller)**
- `list_job_builds` now queries with `include_retried_jobs=true`, so both the original failure and the retry pass of a step are visible and ordering picks the newest.
- `build_job_observations` builds a per-build job-name → step-key map so retry executions missing `step_key` share the alert's job key (`name:X` fallback retained for steps with no key anywhere).
- `fetch_observations` keeps the window filter for processing, but for any job key whose newest in-window outcome is a failure it also considers the newest execution of that key from the fetched builds regardless of `finished_at` — a pass that finished before the window still resolves. The `(build_number, finished_at, job_id)` order guard in `commit_main_ci_scan` is unchanged and still blocks stale data.
- `alerting-main-ci.timer` now polls every 2 minutes instead of 5.

**Hourly backstop sweep (eventual consistency)**
- New `main_ci_backstop` command / `main-ci-backstop` consumer: for every OPEN Main CI alert, fetches its `last_failure_build_number` build directly (single-build GET, `include_retried_jobs=true`) and feeds the newest execution of the alert's job key through `commit_main_ci_scan`, so any pass missed by the windowed poller resolves within an hour. The sweep deliberately does not advance the poller's scan cursor.
- New systemd units `alerting-main-ci-backstop.{service,timer}` (hourly at *:17 UTC, same hardening as other units); covered by the existing Main CI S3 control path and `run-worker` mapping.
- Needs only `DATABASE_URL` + `BUILDKITE_TOKEN`.

## Testing

CI checks on this PR are expected to queue indefinitely — the repo's self-hosted runners are currently down. All tests were run locally:

- `alerting/`: `uv run pytest tests/` — **151 passed** (incl. new tests: retry pass inside window resolves; retry pass outside the window still resolves when the build is fetched; retry execution missing `step_key` resolves the original alert; newer failure still wins over an older pass; backstop resolves/stays-open/leaves-resolved-untouched; backstop does not advance the scan cursor)
- `alerting/`: `uv run ruff check .` — clean
- `alerting/`: `uv run mypy ...` — only the 3 pre-existing boto3-stub errors already on main
- `deploy/aws/tests/`: **19 passed** (updated cadence + new backstop unit assertions)

No schema changes; no AWS deployment in this PR.