### PR TITLE
Main CI analyzer: independent max reasoning effort with longer timeout

### DIFF
--- a/alerting/tests/test_worker.py
+++ b/alerting/tests/test_worker.py
@@ -105,3 +105,97 @@ def test_main_ci_backstop_timer_uses_its_sweep_command(
     assert [command.command_type for command in runtime.commands] == [
         "main_ci_backstop"
     ]
+
+
+def _set_analysis_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://example.invalid/alerting")
+    monkeypatch.setenv("BUILDKITE_TOKEN", "bk-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "gh-token")
+    monkeypatch.setenv("KIMI_API_KEY", "kimi-key")
+    monkeypatch.setenv("ALERTING_CHECKPOINT_BUCKET", "checkpoint-bucket")
+
+
+def _capture_main_ci_analysis_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def fake_build(**kwargs: object) -> RecordingRuntime:
+        captured.update(kwargs)
+        return RecordingRuntime()
+
+    monkeypatch.setattr(worker, "build_main_ci_analysis_runtime", fake_build)
+    return captured
+
+
+def _capture_full_ci_analysis_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def fake_build(**kwargs: object) -> RecordingRuntime:
+        captured.update(kwargs)
+        return RecordingRuntime()
+
+    monkeypatch.setattr(worker, "build_full_ci_analysis_runtime", fake_build)
+    return captured
+
+
+def test_main_ci_analysis_defaults_to_max_effort_and_longer_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_analysis_environment(monkeypatch)
+    for name in (
+        "KIMI_MAIN_CI_REASONING_EFFORT",
+        "KIMI_MAIN_CI_TIMEOUT_SECONDS",
+        "KIMI_TIMEOUT_SECONDS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    # The shared worker env must not leak into the Main CI analyzer.
+    monkeypatch.setenv("KIMI_REASONING_EFFORT", "high")
+    captured = _capture_main_ci_analysis_kwargs(monkeypatch)
+
+    worker._runtime("main-ci-analyze", worker.SystemClock(), DeliveryMode.SHADOW)
+
+    assert captured["kimi_reasoning_effort"] == "max"
+    assert captured["kimi_timeout_seconds"] == 1200
+
+
+def test_main_ci_analysis_honors_dedicated_env_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_analysis_environment(monkeypatch)
+    monkeypatch.setenv("KIMI_MAIN_CI_REASONING_EFFORT", "low")
+    monkeypatch.setenv("KIMI_MAIN_CI_TIMEOUT_SECONDS", "300")
+    captured = _capture_main_ci_analysis_kwargs(monkeypatch)
+
+    worker._runtime("main-ci-analyze", worker.SystemClock(), DeliveryMode.SHADOW)
+
+    assert captured["kimi_reasoning_effort"] == "low"
+    assert captured["kimi_timeout_seconds"] == 300
+
+
+def test_full_ci_analysis_still_uses_shared_kimi_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_analysis_environment(monkeypatch)
+    monkeypatch.delenv("KIMI_REASONING_EFFORT", raising=False)
+    monkeypatch.delenv("KIMI_TIMEOUT_SECONDS", raising=False)
+    # Main-CI-specific overrides must not affect the Full CI analyzer.
+    monkeypatch.setenv("KIMI_MAIN_CI_REASONING_EFFORT", "low")
+    monkeypatch.setenv("KIMI_MAIN_CI_TIMEOUT_SECONDS", "300")
+    captured = _capture_full_ci_analysis_kwargs(monkeypatch)
+
+    worker._runtime("full-ci-analyze", worker.SystemClock(), DeliveryMode.SHADOW)
+
+    assert captured["kimi_reasoning_effort"] == "low"
+    assert captured["kimi_timeout_seconds"] == 3600
+
+    monkeypatch.setenv("KIMI_REASONING_EFFORT", "high")
+    monkeypatch.setenv("KIMI_TIMEOUT_SECONDS", "900")
+    captured.clear()
+
+    worker._runtime("full-ci-analyze", worker.SystemClock(), DeliveryMode.SHADOW)
+
+    assert captured["kimi_reasoning_effort"] == "high"
+    assert captured["kimi_timeout_seconds"] == 900

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -116,8 +116,17 @@ def _runtime(
                 "KIMI_BASE_URL", "https://api2.inferact.dev/v1"
             ),
             kimi_model=os.environ.get("KIMI_MODEL", "moonshotai/Kimi-K3"),
-            kimi_timeout_seconds=int(os.environ.get("KIMI_TIMEOUT_SECONDS", "600")),
-            kimi_reasoning_effort=os.environ.get("KIMI_REASONING_EFFORT", "low"),
+            # Main CI analysis is intentionally independent of the shared
+            # KIMI_REASONING_EFFORT / KIMI_TIMEOUT_SECONDS so it can run
+            # hotter (max reasoning, longer budget) than the Full CI analyzer.
+            # The 10-minute timer cadence and 30-minute execution lease still
+            # fence the larger timeout.
+            kimi_timeout_seconds=int(
+                os.environ.get("KIMI_MAIN_CI_TIMEOUT_SECONDS", "1200")
+            ),
+            kimi_reasoning_effort=os.environ.get(
+                "KIMI_MAIN_CI_REASONING_EFFORT", "max"
+            ),
             slack=_slack(),
             clock=clock,
         )

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -29,6 +29,17 @@ The Full CI analyzer calls the Kimi API using `KIMI_API_KEY` from
 `WorkerSecretArn`, with a bundled read-only analyzer definition and the stack
 checkpoint bucket. It does not receive a GitHub write credential.
 
+Two stack parameters tune the Kimi analyzers and are written to
+`/etc/alerting/worker.env` by `install.sh`:
+
+- `KimiReasoningEffort` (default `high`) sets `KIMI_REASONING_EFFORT`, the
+  shared effort used by the Full CI analyzer.
+- `KimiMainCIReasoningEffort` (default `max`) sets
+  `KIMI_MAIN_CI_REASONING_EFFORT`, used only by the Main CI failure analyzer.
+  It is intentionally independent — Main CI does not fall back to
+  `KIMI_REASONING_EFFORT` — so it can run hotter than Full CI, together with
+  its longer default timeout (`KIMI_MAIN_CI_TIMEOUT_SECONDS`, 1200s).
+
 ## Deploy
 
 ```bash
@@ -45,6 +56,13 @@ aws cloudformation deploy \
 
 `RepositoryRef` defaults to `main`; set it to the reviewed deployment branch
 when validating before merge.
+
+**Gotcha:** a stack update that only changes UserData (including parameter
+changes such as `KimiMainCIReasoningEffort`) makes CloudFormation stop/start
+the instance **without** re-running provisioning — cloud-init runs UserData
+only once per instance, so `/etc/alerting/worker.env` is not rewritten. Any
+parameter or environment change requires a real instance replacement (see
+[disaster-recovery.md](disaster-recovery.md)).
 
 ## Shadow, cutover, and rollback
 

--- a/deploy/aws/alerting-worker.yaml
+++ b/deploy/aws/alerting-worker.yaml
@@ -26,8 +26,18 @@ Parameters:
     Description: ARN of a JSON secret containing a read-only GITHUB_TOKEN
   KimiReasoningEffort:
     Type: String
-    Description: Thinking effort for the Kimi analyzer
+    Description: Thinking effort for the Full CI Kimi analyzer
     Default: high
+    AllowedValues:
+      - low
+      - high
+      - max
+  KimiMainCIReasoningEffort:
+    Type: String
+    Description: >-
+      Thinking effort for the Main CI failure analyzer; independent of
+      KimiReasoningEffort so Main CI can run hotter than Full CI
+    Default: max
     AllowedValues:
       - low
       - high
@@ -155,7 +165,7 @@ Resources:
               dnf install -y git python3.12 python3.12-pip
               install -d -m 0755 /opt/alerting
               git clone --depth 1 --branch '${RepositoryRef}' '${RepositoryUrl}' /opt/alerting/source
-              /opt/alerting/source/deploy/aws/install.sh '${BucketName}' '${WorkerSecret}' '${GitHubSecret}' '${KimiEffort}'
+              /opt/alerting/source/deploy/aws/install.sh '${BucketName}' '${WorkerSecret}' '${GitHubSecret}' '${KimiEffort}' '${KimiMainCIEffort}'
             - BucketName:
                 Ref: CheckpointBucket
               WorkerSecret:
@@ -164,6 +174,8 @@ Resources:
                 Ref: GitHubReadOnlySecretArn
               KimiEffort:
                 Ref: KimiReasoningEffort
+              KimiMainCIEffort:
+                Ref: KimiMainCIReasoningEffort
 
 Outputs:
   CheckpointBucketName:

--- a/deploy/aws/disaster-recovery.md
+++ b/deploy/aws/disaster-recovery.md
@@ -17,6 +17,14 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_IAM
 ```
 
+Note: a stack update whose only effect is a UserData change (including
+parameter changes such as `KimiMainCIReasoningEffort`) merely stop/starts the
+instance. cloud-init runs UserData once per instance, so provisioning does
+**not** re-run and `/etc/alerting/worker.env` keeps its old values. To apply a
+parameter or environment change you must replace the instance — e.g. redeploy
+with an AMI/`InstanceType` change, or terminate the instance and redeploy so
+CloudFormation recreates it.
+
 The bucket, role, and secrets are reused (`DeletionPolicy: Retain`). After
 boot:
 

--- a/deploy/aws/install.sh
+++ b/deploy/aws/install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
-  echo "usage: install.sh CHECKPOINT_BUCKET WORKER_SECRET_ARN GITHUB_SECRET_ARN [KIMI_REASONING_EFFORT]" >&2
+if [ "$#" -lt 3 ] || [ "$#" -gt 5 ]; then
+  echo "usage: install.sh CHECKPOINT_BUCKET WORKER_SECRET_ARN GITHUB_SECRET_ARN [KIMI_REASONING_EFFORT] [KIMI_MAIN_CI_REASONING_EFFORT]" >&2
   exit 2
 fi
 
@@ -10,6 +10,7 @@ checkpoint_bucket=$1
 worker_secret_arn=$2
 github_secret_arn=$3
 kimi_reasoning_effort=${4:-high}
+kimi_main_ci_reasoning_effort=${5:-max}
 source_root=$(cd "$(dirname "$0")/../.." && pwd)
 
 if ! id alerting >/dev/null 2>&1; then
@@ -28,8 +29,8 @@ install -m 0644 "$source_root"/deploy/aws/systemd/*.service /etc/systemd/system/
 install -m 0644 "$source_root"/deploy/aws/systemd/*.timer /etc/systemd/system/
 
 printf '%s\n%s\n' "$worker_secret_arn" "$github_secret_arn" > /etc/alerting/secret-arns
-printf 'ALERTING_CHECKPOINT_BUCKET=%s\nKIMI_REASONING_EFFORT=%s\nPATH=/usr/local/bin:/usr/bin:/bin\nDISABLE_AUTOUPDATER=1\n' \
-  "$checkpoint_bucket" "$kimi_reasoning_effort" > /etc/alerting/worker.env
+printf 'ALERTING_CHECKPOINT_BUCKET=%s\nKIMI_REASONING_EFFORT=%s\nKIMI_MAIN_CI_REASONING_EFFORT=%s\nPATH=/usr/local/bin:/usr/bin:/bin\nDISABLE_AUTOUPDATER=1\n' \
+  "$checkpoint_bucket" "$kimi_reasoning_effort" "$kimi_main_ci_reasoning_effort" > /etc/alerting/worker.env
 chown root:alerting /etc/alerting/secret-arns /etc/alerting/worker.env
 chmod 0440 /etc/alerting/secret-arns /etc/alerting/worker.env
 

--- a/deploy/aws/tests/test_alerting_worker_infrastructure.py
+++ b/deploy/aws/tests/test_alerting_worker_infrastructure.py
@@ -163,6 +163,17 @@ def test_installation_creates_a_non_login_user_and_s3_controlled_timers() -> Non
     assert "systemctl enable --now alerting-main-ci.timer" not in installer
 
 
+def test_main_ci_kimi_effort_is_an_independent_deploy_knob() -> None:
+    template = read("alerting-worker.yaml")
+    installer = read("install.sh")
+
+    assert "KimiMainCIReasoningEffort:" in template
+    assert "KimiMainCIEffort:" in template
+    assert "Ref: KimiMainCIReasoningEffort" in template
+    assert "KIMI_MAIN_CI_REASONING_EFFORT" in installer
+    assert installer.count("KIMI_MAIN_CI_REASONING_EFFORT") == 2
+
+
 def test_s3_control_reconciles_each_path_without_cloudwatch_or_sqs() -> None:
     service = read("systemd/alerting-control.service")
     timer = read("systemd/alerting-control.timer")


### PR DESCRIPTION
## What

The `main-ci-analyze` consumer now reads two dedicated env vars instead of the shared Kimi knobs:

- `KIMI_MAIN_CI_REASONING_EFFORT` — default `max`, deliberately **not** falling back to `KIMI_REASONING_EFFORT` (which stays `high` on the worker and keeps governing the Full CI analyzer). Main CI is intentionally independent so it can run hotter than Full CI.
- `KIMI_MAIN_CI_TIMEOUT_SECONDS` — default `1200` (up from the shared 600). Max reasoning on 200K-char logs needs the headroom; the 10-minute timer cadence and 30-minute execution lease still fence it.

The Full CI consumer is unchanged.

## Deploy

- New `KimiMainCIReasoningEffort` CloudFormation parameter (`low|high|max`, default `max`), threaded through UserData → `install.sh` → `KIMI_MAIN_CI_REASONING_EFFORT` in `/etc/alerting/worker.env`.
- Docs updated (`deploy/aws/README.md`, `deploy/aws/disaster-recovery.md`), including today's gotcha: a UserData-only stack update (including parameter changes) makes CloudFormation stop/start the instance **without** re-running provisioning (cloud-init runs once per instance), so `worker.env` is not rewritten — parameter/env changes require a real instance replacement. **Applying this change to the live worker requires an instance replacement, not just a stack update.**

## Testing

⚠️ The repo's self-hosted CI runners are currently down, so PR checks queue forever. Verified locally instead:

- `uv run --extra dev pytest tests/` in `alerting/` — 154 passed (includes new tests for the Main CI defaults, overrides, and Full CI isolation)
- `uv run --extra dev ruff check` — clean
- `pytest deploy/aws/tests/` — 20 passed (includes new template/install.sh threading test)
- `mypy worker.py` — clean (the 3 boto3-stub errors elsewhere are pre-existing on main)
- `bash -n install.sh` and YAML parse of `alerting-worker.yaml` — clean

Merging despite the queued (not failing) checks per the runner-outage policy.