### PR TITLE
Alerting: scope Fast CI to required main-branch jobs, harden Full CI

### DIFF
--- a/alerting/CONTEXT.md
+++ b/alerting/CONTEXT.md
@@ -33,7 +33,7 @@ An immutable, versioned S3 object holding the analyzer's memory after one comple
 _Avoid_: Backup, snapshot of the database
 
 **Fast Failure Event**:
-An observation that one Fast CI job entered an eligible failure state within 30 seconds. It has no resolution lifecycle.
+An observation that one required Fast CI job on the main branch entered an eligible failure state within 30 seconds. It has no resolution lifecycle.
 _Avoid_: Incident, alert lifecycle
 
 **Main CI Job Observation**:

--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -317,6 +317,31 @@ def _pr_number(summary: str) -> int | None:
     return int(match.group("number")) if match is not None else None
 
 
+_BULLET_NAME_LINK = re.compile(r"^(?P<prefix>\s*•\s+)<https?://[^|>]+\|(?P<label>[^>]+)>")
+_BULLET_NAME_CODE = re.compile(r"^(?P<prefix>\s*•\s+)`(?P<name>[^`]+)`")
+
+
+def _plain_bullet_names(report_text: str) -> str:
+    """Unwrap links and code spans around job names at bullet starts.
+
+    The model wraps names inconsistently; Slack does not render custom emoji
+    shortcodes (":nvidia:") inside link labels or code spans, and the mangled
+    names also fail to match Buildkite job names during attribution parsing.
+    """
+    lines = []
+    for line in report_text.splitlines():
+        linked = _BULLET_NAME_LINK.match(line)
+        if linked is not None:
+            name = linked.group("label").strip().strip("`")
+            line = f"{linked.group('prefix')}{name}{line[linked.end():]}"
+        coded = _BULLET_NAME_CODE.match(line)
+        if coded is not None:
+            line = f"{coded.group('prefix')}{coded.group('name')}{line[coded.end():]}"
+        lines.append(line)
+    text = "\n".join(lines)
+    return text + "\n" if report_text.endswith("\n") else text
+
+
 def _hard_failures(jobs: list[FullCIJobOutcome]) -> set[str]:
     return {job.name for job in jobs if job.state == "failed" and not job.soft_failed}
 
@@ -462,6 +487,7 @@ def _read_outputs(
         raise AnalyzerError("analyzer wrote an empty report")
     if report_text.strip() == "SKIP":
         raise AnalyzerError("analyzer skipped a comparison the adapter deemed ready")
+    report_text = _plain_bullet_names(report_text)
     if len(report_text) > REPORT_CHAR_LIMIT:
         raise AnalyzerError(
             f"report exceeds {REPORT_CHAR_LIMIT} characters: {len(report_text)}"

--- a/alerting/assets/vllm-ci-failure-analyzer.md
+++ b/alerting/assets/vllm-ci-failure-analyzer.md
@@ -61,7 +61,9 @@ Count only hard failures in `Y failed`. Add sections for new, recurring, fixed,
 and soft failures when present. Investigation summaries must be concise. Show
 at most five bullets per section and link to the build for omitted entries.
 Keep the complete report at or below 2,800 characters without breaking Slack
-links or formatting.
+links or formatting. Write job names as plain text with their leading emoji
+shortcode (e.g. `:nvidia:`) outside any link or code span; shortcodes inside
+link labels or backticks render as literal text in Slack.
 
 ## Phase D — Update outputs
 

--- a/alerting/fast_ci.py
+++ b/alerting/fast_ci.py
@@ -226,6 +226,8 @@ def _alert_query(start_time: datetime, end_time: datetime) -> str:
         AND j.type = 'script'
         AND j.name IS NOT NULL
         AND p.name = 'CI'
+        AND b.branch = 'main'
+        AND j.soft_failed = false
         AND j.state IN ({states})
         AND j.started_at IS NOT NULL
         AND j.finished_at IS NOT NULL
@@ -318,6 +320,18 @@ def _build_number(build_url: str) -> str:
     return match.group(1) if match else "?"
 
 
+_LEADING_JOB_EMOJI = re.compile(r"^((?::[a-z0-9_+-]+:\s*)+)", re.IGNORECASE)
+
+
+def _split_job_emoji(name: str) -> tuple[str, str]:
+    """Custom emoji shortcodes are not reliably rendered inside Slack link
+    labels; keep a leading job emoji (":nvidia:") outside the linked name."""
+    match = _LEADING_JOB_EMOJI.match(name)
+    if match is None:
+        return "", name
+    return match.group(1).strip(), name[match.end() :].strip()
+
+
 def _build_message(
     events: list[FastFailureEvent],
     batch_number: int,
@@ -329,14 +343,15 @@ def _build_message(
         heading = (
             f":rotating_light: *Fast CI recovery summary* — {len(events)} "
             f"job{'s' if len(events) != 1 else ''} failed in "
-            f"{MAX_DURATION_SECONDS}s or less while notifications were unavailable"
+            f"{MAX_DURATION_SECONDS}s or less (main branch, required jobs only) "
+            "while notifications were unavailable"
         )
     else:
         suffix = f" — batch {batch_number}/{batch_count}" if batch_count > 1 else ""
         heading = (
             f":rotating_light: *Fast CI job failure alert* — {len(events)} "
             f"job{'s' if len(events) != 1 else ''} failed in "
-            f"{MAX_DURATION_SECONDS}s or less{suffix}"
+            f"{MAX_DURATION_SECONDS}s or less (main branch, required jobs only){suffix}"
         )
     lines = [
         heading,
@@ -359,7 +374,10 @@ def _build_message(
             details.append(f"by {_slack_escape(event.author)}")
         if event.soft_failed:
             details.append("_soft fail_")
-        job = _slack_link(event.job_url, event.job_name or "Unknown job")
+        job_emoji, job_name = _split_job_emoji(event.job_name or "Unknown job")
+        job = _slack_link(event.job_url, job_name)
+        if job_emoji:
+            job = f"{job_emoji} {job}"
         lines.append(f":red_circle: {job} — {' · '.join(details)}")
         if event.message:
             lines.append(f"> {_slack_escape(_one_line(event.message))}")

--- a/alerting/full_ci.py
+++ b/alerting/full_ci.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -18,6 +19,8 @@ from alerting.runtime import HandlerCompletion
 # First-ever reconciliation has no durable run to anchor a fetch window; two
 # days of runs is what an incident responder needs, not the pipeline's history.
 INITIAL_LOOKBACK = timedelta(days=2)
+
+_TRANSIENT_HTTP_STATUSES = frozenset({429, 500, 502, 503, 504})
 
 
 @dataclass(frozen=True)
@@ -118,22 +121,28 @@ class BuildkiteRestClient:
         parsed = urllib.parse.urlsplit(url)
         if parsed.scheme != "https" or parsed.netloc != "api.buildkite.com":
             raise RuntimeError("Buildkite pagination returned an untrusted URL")
-        request = urllib.request.Request(
-            url,
-            headers={
-                "Authorization": f"Bearer {self._token}",
-                "Accept": "application/json",
-                "User-Agent": "vllm-ci-alerting/1.0",
-            },
-        )
-        try:
-            with urllib.request.urlopen(request, timeout=60) as response:
-                return json.load(response)
-        except urllib.error.HTTPError as exc:
-            response_body = exc.read().decode("utf-8", errors="replace")
-            raise RuntimeError(
-                f"GET {parsed.path} failed with HTTP {exc.code}: {response_body[:1000]}"
-            ) from exc
+        for attempt in range(3):
+            request = urllib.request.Request(
+                url,
+                headers={
+                    "Authorization": f"Bearer {self._token}",
+                    "Accept": "application/json",
+                    "User-Agent": "vllm-ci-alerting/1.0",
+                },
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=60) as response:
+                    return json.load(response)
+            except urllib.error.HTTPError as exc:
+                response_body = exc.read().decode("utf-8", errors="replace")
+                # A transient error must not idle a twice-daily timer tick;
+                # the legacy pre-script retried 429s the same way.
+                if exc.code in _TRANSIENT_HTTP_STATUSES and attempt < 2:
+                    time.sleep(10)
+                    continue
+                raise RuntimeError(
+                    f"GET {parsed.path} failed with HTTP {exc.code}: {response_body[:1000]}"
+                ) from exc
 
     def list_builds(
         self, *, start_time: datetime | None, up_to: datetime

--- a/alerting/tests/test_analyzer.py
+++ b/alerting/tests/test_analyzer.py
@@ -442,6 +442,53 @@ def test_analysis_persists_conditions_report_checkpoint_and_notification() -> No
     assert "Job B" in notification.payload["text"]
 
 
+def test_wrapped_bullet_job_names_are_posted_plain_and_attributed() -> None:
+    run1 = make_run(1, RUN1_AT)
+    run2 = make_run(2, RUN2_AT)
+    harness = Harness(
+        runs=[run1, run2],
+        builds={
+            2: build_json(
+                2,
+                mostly_passing_jobs(
+                    [("Job A", "failed", False), (":nvidia: Job B", "failed", False)]
+                ),
+                scheduled_at=RUN2_AT,
+            )
+        },
+    )
+    harness.seed_analysis(run1, failed_tests=("Job A",))
+    harness.runner.on_run(
+        lambda wd: well_behaved(
+            wd,
+            report=(
+                "*Build:* fine\n"
+                "*New failures (1):*\n"
+                "• <https://buildkite.com/vllm/ci/builds/2#job-b|`:nvidia: Job B`>"
+                " — _env: disk full_\n"
+                "*Recurring failures (1):*\n"
+                "• `Job A`\n"
+            ),
+        )
+    )
+
+    result = harness.analyze()
+
+    assert result.status is ProcessStatus.COMPLETED
+    text = notification_for(harness, run2.build_id).payload["text"]
+    assert "• :nvidia: Job B — _env: disk full_" in text
+    assert "• Job A\n" in text
+    assert "<https://buildkite.com/vllm/ci/builds/2#job-b|" not in text
+    conditions = {
+        condition.job_name: condition
+        for condition in harness.store.analyses()[-1].conditions
+    }
+    # The unwrapped name matches the Buildkite job name, so the report
+    # attribution is found instead of falling back to UNKNOWN.
+    assert conditions[":nvidia: Job B"].cause is CauseCategory.INFRASTRUCTURE
+    assert conditions[":nvidia: Job B"].summary == "env: disk full"
+
+
 def test_shadow_analysis_persists_report_without_slack_delivery() -> None:
     run1 = make_run(1, RUN1_AT)
     run2 = make_run(2, RUN2_AT)

--- a/alerting/tests/test_fast_ci.py
+++ b/alerting/tests/test_fast_ci.py
@@ -1,5 +1,6 @@
 """Fast CI behavior through the scheduled-command runtime seam."""
 
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -134,8 +135,14 @@ def test_more_than_eight_failures_are_persisted_in_existing_slack_batches() -> N
     assert len(fast_ci.events()) == 10
     records = outbox.records()
     assert [record.status for record in records] == [OutboxStatus.PENDING] * 2
-    assert "8 jobs failed in 30s or less — batch 1/2" in records[0].payload["text"]
-    assert "2 jobs failed in 30s or less — batch 2/2" in records[1].payload["text"]
+    assert (
+        "8 jobs failed in 30s or less (main branch, required jobs only) — batch 1/2"
+        in records[0].payload["text"]
+    )
+    assert (
+        "2 jobs failed in 30s or less (main branch, required jobs only) — batch 2/2"
+        in records[1].payload["text"]
+    )
     assert records[0].payload["text"].count(":red_circle:") == 8
     assert records[1].payload["text"].count(":red_circle:") == 2
     assert "GPU &lt;fast&gt; 'test'" in records[0].payload["text"]
@@ -184,7 +191,8 @@ def test_stale_batches_become_one_recovery_summary_while_fresh_batch_stays_detai
     assert (
         recovery.payload["text"].splitlines()[0]
         == ":rotating_light: *Fast CI recovery summary* — "
-        "10 jobs failed in 30s or less while notifications were unavailable"
+        "10 jobs failed in 30s or less (main branch, required jobs only) "
+        "while notifications were unavailable"
     )
     assert recovery.payload["text"].count(":red_circle:") == 10
     assert "Fast CI job failure alert" in fresh.payload["text"]
@@ -386,6 +394,32 @@ def test_databricks_source_maps_fixture_to_fast_failure_event() -> None:
             pipeline="CI",
         )
     ]
+
+
+def test_databricks_query_scopes_to_main_branch_required_jobs() -> None:
+    databricks = RecordingDatabricks([])
+    source = DatabricksFastCISource(databricks)
+
+    source.fetch_failures(start_time=START - timedelta(minutes=30), end_time=START)
+
+    assert len(databricks.queries) == 1
+    assert "b.branch = 'main'" in databricks.queries[0]
+    assert "j.soft_failed = false" in databricks.queries[0]
+
+
+def test_leading_job_emoji_stays_outside_the_slack_link_label() -> None:
+    named = replace(event("job-1"), job_name=":nvidia: (L4) Distributed 2-Node")
+    source = FixtureFastCISource([named])
+    runtime, _, outbox, _ = make_runtime(source)
+
+    runtime.process_command(ScheduledCommand(command_type="fast_ci_scan", target_time=START))
+
+    text = outbox.records()[0].payload["text"]
+    assert (
+        ":red_circle: :nvidia: "
+        "<https://buildkite.com/vllm/ci/builds/123#job-1|(L4) Distributed 2-Node>"
+    ) in text
+    assert "|:nvidia:" not in text
 
 
 def test_fast_failure_event_has_no_resolution_lifecycle() -> None:

--- a/alerting/tests/test_full_ci.py
+++ b/alerting/tests/test_full_ci.py
@@ -1,12 +1,20 @@
 """Full CI ingest behavior through the scheduled-command runtime seam."""
 
+import io
+import time
+import urllib.error
+import urllib.request
 from datetime import datetime, timedelta, timezone
+from email.message import Message
 from typing import Any
+
+import pytest
 
 from alerting.commands import ScheduledCommand
 from alerting.full_ci import (
     INITIAL_LOOKBACK,
     BuildkiteFullCISource,
+    BuildkiteRestClient,
     FullCIJobOutcome,
     FullCIReconciliationHandler,
     FullCIRun,
@@ -272,3 +280,48 @@ def test_buildkite_source_maps_only_eligible_full_ci_runs_and_named_jobs() -> No
             ),
         )
     ]
+
+
+def _http_error(url: str, status: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url, status, "error", Message(), io.BytesIO(b"transient")
+    )
+
+
+def test_buildkite_client_retries_transient_http_errors(monkeypatch: Any) -> None:
+    attempts = 0
+
+    def fake_urlopen(request: Any, timeout: int = 0) -> Any:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise _http_error(request.full_url, 429)
+        return io.BytesIO(b"[]")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+    client = BuildkiteRestClient(token="token")
+
+    assert client.list_builds(start_time=None, up_to=START) == []
+    assert attempts == 3
+
+
+def test_buildkite_client_does_not_retry_permanent_http_errors(
+    monkeypatch: Any,
+) -> None:
+    attempts = 0
+
+    def fake_urlopen(request: Any, timeout: int = 0) -> Any:
+        nonlocal attempts
+        attempts += 1
+        raise _http_error(request.full_url, 400)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+    client = BuildkiteRestClient(token="token")
+
+    with pytest.raises(RuntimeError, match="HTTP 400"):
+        client.list_builds(start_time=None, up_to=START)
+    assert attempts == 1


### PR DESCRIPTION
## Summary

- **Fast CI scope**: alerts now fire only for required (non-soft-fail) jobs on `main`; PR branches and optional jobs no longer page. Heading notes the scope as `(main branch, required jobs only)`, matching the previous production alert.
- **Fast CI emoji**: a job's leading custom emoji shortcode (`:nvidia:`) is rendered outside the Slack link label — shortcodes inside link labels show as literal text.
- **Full CI retry**: the Buildkite client retries 429/5xx (3 attempts, 10s backoff), mirroring the legacy pre-script. One transient error at the 05:00 PT tick previously idled the reporter until the 19:00 PT tick (the `Type=oneshot` unit has no restart).
- **Full CI report emoji**: the analyzer model wraps bullet job names in link labels or backticks inconsistently, and Slack renders custom emoji as literal text inside either. A sanitizer at the adapter boundary unwraps them; the skill also instructs plain names. This also fixes attribution parsing, which keyed on the mangled names and silently stored `cause = UNKNOWN`.

## Test plan

- `uv run --project alerting pytest alerting/tests` — 159 passed (new tests pin the SQL predicates, the emoji label split, the retry behavior, and the report sanitizer)
- `uv run mypy` clean on all touched files
- `ruff check` clean; `ruff format` drift on `analyzer.py`/`test_analyzer.py`/`test_fast_ci.py` pre-exists at `HEAD`

## Deploy

No DB migration. Standard on-host update: fetch + checkout `main` in `/opt/alerting/source`, re-run `deploy/aws/install.sh`.