### PR TITLE
Discover CI groups from build YAML automatically

### DIFF
--- a/src/app/api/builds/groups/route.ts
+++ b/src/app/api/builds/groups/route.ts
@@ -7,7 +7,7 @@ import {
   isFailedJobState,
   type GroupStatus,
 } from "@/lib/test-groups";
-import { ensureTestAreaMapping } from "@/lib/test-areas";
+import { getTestAreaMappingForCommit } from "@/lib/test-areas";
 
 const TTL = 30_000;
 const CDN_CACHE = { maxAge: 60, staleWhileRevalidate: 3_600 };
@@ -49,8 +49,6 @@ export async function GET(request: NextRequest) {
     const cached = getCached(cacheKey);
     if (cached) return cachedJson(cached, CDN_CACHE);
 
-    await ensureTestAreaMapping();
-
     const idList = buildIds.map((id) => `'${escapeSql(id)}'`).join(",");
     const jobs = await queryDatabricks(`
       SELECT
@@ -58,8 +56,12 @@ export async function GET(request: NextRequest) {
         j.name,
         j.state,
         j.web_url,
-        j.started_at
+        j.started_at,
+        b.commit AS commit_sha,
+        b.branch
       FROM vllm_data_warehouse.buildkite.build_job AS j
+      INNER JOIN vllm_data_warehouse.buildkite.build AS b
+        ON j.build_id = b.id
       WHERE j.build_id IN (${idList})
         AND j._fivetran_deleted = false
         AND j.type = 'script'
@@ -73,10 +75,20 @@ export async function GET(request: NextRequest) {
     const startedJobCountsByBuild = Object.fromEntries(
       buildIds.map((buildId) => [buildId, 0]),
     ) as Record<string, number>;
+    const refsByBuild = new Map<
+      string,
+      { commit: string | null; branch: string | null }
+    >();
     for (const job of jobs) {
       const row = job as Record<string, string | null>;
       const buildId = row.build_id;
       if (!buildId || !row.name || !row.state) continue;
+      if (!refsByBuild.has(buildId)) {
+        refsByBuild.set(buildId, {
+          commit: row.commit_sha,
+          branch: row.branch,
+        });
+      }
       if (row.started_at) {
         startedJobCountsByBuild[buildId] += 1;
       }
@@ -91,8 +103,35 @@ export async function GET(request: NextRequest) {
 
     const groupedByBuild = new Map<string, GroupStatus[]>();
     const jobToGroup = new Map<string, string>();
+    const mappingsByCommit = new Map<
+      string,
+      ReturnType<typeof getTestAreaMappingForCommit>
+    >();
+    for (const ref of refsByBuild.values()) {
+      const mappingKey = `${ref.branch ?? ""}:${ref.commit ?? ""}`;
+      if (!mappingsByCommit.has(mappingKey)) {
+        mappingsByCommit.set(
+          mappingKey,
+          getTestAreaMappingForCommit(ref.commit, ref.branch),
+        );
+      }
+    }
     for (const buildId of buildIds) {
-      const groups = aggregateJobsByGroup(jobsByBuild.get(buildId) ?? []);
+      const ref = refsByBuild.get(buildId);
+      const mappingKey = `${ref?.branch ?? ""}:${ref?.commit ?? ""}`;
+      let mappingPromise = mappingsByCommit.get(mappingKey);
+      if (!mappingPromise) {
+        mappingPromise = getTestAreaMappingForCommit(
+          ref?.commit,
+          ref?.branch,
+        );
+        mappingsByCommit.set(mappingKey, mappingPromise);
+      }
+      const mapping = await mappingPromise;
+      const groups = aggregateJobsByGroup(
+        jobsByBuild.get(buildId) ?? [],
+        mapping,
+      );
       groupedByBuild.set(buildId, groups);
       for (const group of groups) {
         for (const job of group.jobs) {

--- a/src/app/api/builds/jobs/route.ts
+++ b/src/app/api/builds/jobs/route.ts
@@ -3,7 +3,7 @@ import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
 import { cachedJson } from "@/lib/api-response";
 import { aggregateJobsByGroup, type JobInfo } from "@/lib/test-groups";
-import { ensureTestAreaMapping } from "@/lib/test-areas";
+import { getTestAreaMappingForCommit } from "@/lib/test-areas";
 
 const TTL = 30_000;
 const CDN_CACHE = { maxAge: 60, staleWhileRevalidate: 3_600 };
@@ -42,16 +42,18 @@ export async function GET(request: NextRequest) {
     const cached = getCached(cacheKey);
     if (cached) return cachedJson(cached, CDN_CACHE);
 
-    await ensureTestAreaMapping();
-
     const idList = buildIds.map((id) => `'${escapeSql(id)}'`).join(",");
     const jobs = await queryDatabricks(`
       SELECT
         j.build_id,
         j.name,
         j.state,
-        j.web_url
+        j.web_url,
+        b.commit AS commit_sha,
+        b.branch
       FROM vllm_data_warehouse.buildkite.build_job AS j
+      INNER JOIN vllm_data_warehouse.buildkite.build AS b
+        ON j.build_id = b.id
       WHERE j.build_id IN (${idList})
         AND j._fivetran_deleted = false
         AND j.type = 'script'
@@ -62,21 +64,59 @@ export async function GET(request: NextRequest) {
       string,
       { name: string; state: string; web_url?: string }[]
     >();
+    const refsByBuild = new Map<
+      string,
+      { commit: string | null; branch: string | null }
+    >();
     for (const job of jobs) {
-      const row = job as Record<string, string>;
+      const row = job as Record<string, string | null>;
+      if (!row.build_id || !row.name || !row.state) continue;
+      if (!refsByBuild.has(row.build_id)) {
+        refsByBuild.set(row.build_id, {
+          commit: row.commit_sha,
+          branch: row.branch,
+        });
+      }
       const buildJobs = rawJobsByBuild.get(row.build_id) ?? [];
       buildJobs.push({
         name: row.name,
         state: row.state,
-        web_url: row.web_url,
+        web_url: row.web_url ?? undefined,
       });
       rawJobsByBuild.set(row.build_id, buildJobs);
     }
 
     const groupSet = new Set(groups);
     const jobsByBuild: Record<string, Record<string, JobInfo[]>> = {};
+    const mappingsByCommit = new Map<
+      string,
+      ReturnType<typeof getTestAreaMappingForCommit>
+    >();
+    for (const ref of refsByBuild.values()) {
+      const mappingKey = `${ref.branch ?? ""}:${ref.commit ?? ""}`;
+      if (!mappingsByCommit.has(mappingKey)) {
+        mappingsByCommit.set(
+          mappingKey,
+          getTestAreaMappingForCommit(ref.commit, ref.branch),
+        );
+      }
+    }
     for (const buildId of buildIds) {
-      const grouped = aggregateJobsByGroup(rawJobsByBuild.get(buildId) ?? []);
+      const ref = refsByBuild.get(buildId);
+      const mappingKey = `${ref?.branch ?? ""}:${ref?.commit ?? ""}`;
+      let mappingPromise = mappingsByCommit.get(mappingKey);
+      if (!mappingPromise) {
+        mappingPromise = getTestAreaMappingForCommit(
+          ref?.commit,
+          ref?.branch,
+        );
+        mappingsByCommit.set(mappingKey, mappingPromise);
+      }
+      const mapping = await mappingPromise;
+      const grouped = aggregateJobsByGroup(
+        rawJobsByBuild.get(buildId) ?? [],
+        mapping,
+      );
       jobsByBuild[buildId] = Object.fromEntries(
         grouped
           .filter((group) => groupSet.has(group.group))

--- a/src/app/api/builds/summary/route.ts
+++ b/src/app/api/builds/summary/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { aggregateJobsByGroup, resolveGroupsToJobConditions } from "@/lib/test-groups";
-import { ensureTestAreaMapping } from "@/lib/test-areas";
+import {
+  ensureTestAreaMapping,
+  getTestAreaMappingForCommit,
+} from "@/lib/test-areas";
 import { getCached, setCache } from "@/lib/api-cache";
 
 const MAX_PER_PAGE = 30;
@@ -270,9 +273,25 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    const buildsWithGroups = builds.map((b) => {
+    const mappingsByCommit = new Map<
+      string,
+      ReturnType<typeof getTestAreaMappingForCommit>
+    >();
+    for (const build of builds) {
+      const mappingKey = `${build.branch}:${build.commit_sha}`;
+      if (!mappingsByCommit.has(mappingKey)) {
+        mappingsByCommit.set(
+          mappingKey,
+          getTestAreaMappingForCommit(build.commit_sha, build.branch),
+        );
+      }
+    }
+    const buildsWithGroups = await Promise.all(builds.map(async (b) => {
       const buildJobs = jobsByBuild.get(b.id) ?? [];
-      const testGroups = aggregateJobsByGroup(buildJobs);
+      const mapping = await mappingsByCommit.get(
+        `${b.branch}:${b.commit_sha}`,
+      )!;
+      const testGroups = aggregateJobsByGroup(buildJobs, mapping);
       let prNumber = b.pr_number;
       if (!prNumber && b.message) {
         const match = b.message.match(/\(#(\d+)\)/);
@@ -282,7 +301,7 @@ export async function GET(request: NextRequest) {
         ? buildJobs.filter((j) => jobNames.some((n) => j.name === n))
         : undefined;
       return { ...b, pr_number: prNumber, testGroups, matchedJobs };
-    });
+    }));
 
     const counts = countResult[0] ?? { total: "0", passed: "0", failed: "0" };
     const total = parseInt(counts.total, 10);

--- a/src/lib/test-areas.ts
+++ b/src/lib/test-areas.ts
@@ -18,15 +18,41 @@ export interface TestAreaMapping {
 }
 
 const CACHE_TTL = 60 * 60 * 1000; // 1 hour
+const COMMIT_CACHE_LIMIT = 100;
 
 const GITHUB_RAW_BASE =
-  "https://raw.githubusercontent.com/vllm-project/vllm/main/.buildkite/test_areas";
-const GITHUB_API_URL =
-  "https://api.github.com/repos/vllm-project/vllm/contents/.buildkite/test_areas";
+  "https://raw.githubusercontent.com/vllm-project/vllm";
+const GITHUB_API_BASE =
+  "https://api.github.com/repos/vllm-project/vllm";
+const MAIN_REF = "main";
+const CI_CONFIG_PATTERN = /^\.buildkite\/ci_config(?:_[^/]+)?\.ya?ml$/;
+const YAML_PATTERN = /\.ya?ml$/;
 
-// Pipeline groups that are not defined in .buildkite/test_areas.  Keep these
-// local rather than relying on the remote test-area refresh: that endpoint
-// intentionally only describes the main CUDA test matrix.
+interface GitTreeEntry {
+  path: string;
+  type: string;
+}
+
+interface CiConfig {
+  job_dirs?: unknown;
+}
+
+interface CompareFile {
+  filename: string;
+  status: string;
+}
+
+function githubHeaders(): HeadersInit {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+  };
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+// Fallback labels for cold starts and GitHub outages. Live discovery replaces
+// these from every job directory named by .buildkite/ci_config*.yaml.
 const PIPELINE_GROUP_DATA: [string, string[]][] = [
   ["Abuild", [
     ":docker: Build image",
@@ -194,7 +220,12 @@ function buildMapping(areas: { group: string; labels: string[] }[]): TestAreaMap
       if (label.includes("%N")) {
         const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         const pattern = escaped.replace("%N", "\\d+");
-        patterns.push({ regex: new RegExp(`^${pattern}$`), group: area.group });
+        const regex = new RegExp(`^${pattern}$`);
+        const existing = patterns.findIndex(
+          (candidate) => candidate.regex.source === regex.source,
+        );
+        if (existing >= 0) patterns.splice(existing, 1);
+        patterns.push({ regex, group: area.group });
       } else {
         jobToGroup.set(label, area.group);
       }
@@ -224,38 +255,161 @@ export function buildTestAreaMapping(areas: TestArea[]): TestAreaMapping {
 const STATIC_MAPPING = buildTestAreaMapping([]);
 
 let cachedMapping: TestAreaMapping = STATIC_MAPPING;
+let cachedAreas: TestArea[] = [];
 let cacheExpiry = 0;
 let refreshPromise: Promise<void> | null = null;
+const commitMappings = new Map<
+  string,
+  { mapping: TestAreaMapping; expiresAt: number }
+>();
 
-async function fetchTestAreas(): Promise<TestArea[]> {
-  const listRes = await fetch(GITHUB_API_URL, {
-    headers: { Accept: "application/vnd.github.v3+json" },
-  });
-  if (!listRes.ok) {
-    throw new Error(`GitHub API error: ${listRes.status}`);
+function rawUrl(ref: string, path: string): string {
+  const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+  return `${GITHUB_RAW_BASE}/${encodeURIComponent(ref)}/${encodedPath}`;
+}
+
+function parseTestArea(value: unknown): TestArea | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as { group?: unknown; steps?: unknown };
+  if (typeof candidate.group !== "string" || !candidate.group.trim()) {
+    return null;
   }
-  const files = (await listRes.json()) as { name: string }[];
-  const yamlFiles = files
-    .filter((f) => f.name.endsWith(".yaml"))
-    .map((f) => f.name);
+  if (!Array.isArray(candidate.steps)) return null;
 
-  const areas: TestArea[] = [];
-  const results = await Promise.allSettled(
-    yamlFiles.map(async (name) => {
-      const res = await fetch(`${GITHUB_RAW_BASE}/${name}`);
-      if (!res.ok) return null;
-      const text = await res.text();
-      return yaml.load(text) as TestArea;
-    })
+  const steps = candidate.steps.filter(
+    (step): step is TestStep =>
+      !!step &&
+      typeof step === "object" &&
+      typeof (step as { label?: unknown }).label === "string",
   );
+  if (steps.length === 0) return null;
+  return { group: candidate.group, steps };
+}
 
-  for (const result of results) {
-    if (result.status === "fulfilled" && result.value?.group && result.value?.steps) {
-      areas.push(result.value);
+async function fetchYaml(ref: string, path: string): Promise<unknown> {
+  const response = await fetch(rawUrl(ref, path));
+  if (!response.ok) {
+    throw new Error(`GitHub raw error for ${path}: ${response.status}`);
+  }
+  return yaml.load(await response.text());
+}
+
+async function fetchAreas(
+  ref: string,
+  paths: string[],
+): Promise<TestArea[]> {
+  const results = await Promise.allSettled(
+    paths.map(async (path) => parseTestArea(await fetchYaml(ref, path))),
+  );
+  const failures = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map((failure) => failure.reason),
+      `Failed to read ${failures.length} Buildkite YAML file(s) at ${ref}`,
+    );
+  }
+  return results.flatMap((result) =>
+    result.status === "fulfilled" && result.value ? [result.value] : [],
+  );
+}
+
+export function discoverGroupYamlPaths(
+  entries: GitTreeEntry[],
+  configs: CiConfig[],
+): string[] {
+  const jobDirs = new Set<string>();
+  for (const config of configs) {
+    if (!Array.isArray(config.job_dirs)) continue;
+    for (const value of config.job_dirs) {
+      if (typeof value === "string" && value.startsWith(".buildkite/")) {
+        jobDirs.add(value.replace(/\/$/, ""));
+      }
     }
   }
 
-  return areas;
+  return entries
+    .filter(
+      (entry) =>
+        entry.type === "blob" &&
+        YAML_PATTERN.test(entry.path) &&
+        [...jobDirs].some(
+          (directory) =>
+            entry.path === directory || entry.path.startsWith(`${directory}/`),
+        ),
+    )
+    .map((entry) => entry.path)
+    .sort();
+}
+
+async function fetchTestAreas(): Promise<TestArea[]> {
+  const treeResponse = await fetch(
+    `${GITHUB_API_BASE}/git/trees/${MAIN_REF}?recursive=1`,
+    { headers: githubHeaders() },
+  );
+  if (!treeResponse.ok) {
+    throw new Error(`GitHub tree error: ${treeResponse.status}`);
+  }
+  const tree = (await treeResponse.json()) as {
+    tree?: GitTreeEntry[];
+    truncated?: boolean;
+  };
+  if (!tree.tree || tree.truncated) {
+    throw new Error("GitHub returned an incomplete repository tree");
+  }
+
+  const configPaths = tree.tree
+    .filter(
+      (entry) => entry.type === "blob" && CI_CONFIG_PATTERN.test(entry.path),
+    )
+    .map((entry) => entry.path);
+  const configResults = await Promise.allSettled(
+    configPaths.map((path) => fetchYaml(MAIN_REF, path)),
+  );
+  const configFailures = configResults.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (configFailures.length > 0) {
+    throw new AggregateError(
+      configFailures.map((failure) => failure.reason),
+      "Failed to read Buildkite CI configuration",
+    );
+  }
+  const configs = configResults.flatMap((result) =>
+    result.status === "fulfilled" &&
+    result.value &&
+    typeof result.value === "object"
+      ? [result.value as CiConfig]
+      : [],
+  );
+  const groupPaths = discoverGroupYamlPaths(tree.tree, configs);
+  if (groupPaths.length === 0) {
+    throw new Error("No configured Buildkite group YAML files found");
+  }
+  return fetchAreas(MAIN_REF, groupPaths);
+}
+
+async function fetchChangedTestAreas(commit: string): Promise<TestArea[]> {
+  const compareResponse = await fetch(
+    `${GITHUB_API_BASE}/compare/${MAIN_REF}...${encodeURIComponent(commit)}`,
+    { headers: githubHeaders() },
+  );
+  if (!compareResponse.ok) {
+    throw new Error(`GitHub compare error: ${compareResponse.status}`);
+  }
+  const comparison = (await compareResponse.json()) as {
+    files?: CompareFile[];
+  };
+  const changedYamlPaths = (comparison.files ?? [])
+    .filter(
+      (file) =>
+        file.status !== "removed" &&
+        file.filename.startsWith(".buildkite/") &&
+        YAML_PATTERN.test(file.filename),
+    )
+    .map((file) => file.filename);
+  return fetchAreas(commit, changedYamlPaths);
 }
 
 function refreshMapping(): Promise<void> {
@@ -264,8 +418,10 @@ function refreshMapping(): Promise<void> {
   refreshPromise = (async () => {
     try {
       const areas = await fetchTestAreas();
+      cachedAreas = areas;
       cachedMapping = buildTestAreaMapping(areas);
       cacheExpiry = Date.now() + CACHE_TTL;
+      commitMappings.clear();
     } catch (error) {
       console.error("Failed to refresh test areas from GitHub:", error);
       // Keep using existing mapping (static or previously fetched)
@@ -292,4 +448,40 @@ export async function ensureTestAreaMapping(): Promise<TestAreaMapping> {
     await refreshMapping();
   }
   return cachedMapping;
+}
+
+export async function getTestAreaMappingForCommit(
+  commit: string | null | undefined,
+  branch: string | null | undefined,
+): Promise<TestAreaMapping> {
+  const mainMapping = await ensureTestAreaMapping();
+  if (
+    !commit ||
+    branch === MAIN_REF ||
+    !/^[0-9a-f]{7,64}$/i.test(commit)
+  ) {
+    return mainMapping;
+  }
+
+  const cached = commitMappings.get(commit);
+  if (cached && cached.expiresAt > Date.now()) return cached.mapping;
+
+  let mapping = mainMapping;
+  let ttl = CACHE_TTL;
+  try {
+    const changedAreas = await fetchChangedTestAreas(commit);
+    if (changedAreas.length > 0) {
+      mapping = buildTestAreaMapping([...cachedAreas, ...changedAreas]);
+    }
+  } catch (error) {
+    console.error(`Failed to refresh test areas for commit ${commit}:`, error);
+    ttl = 5 * 60 * 1000;
+  }
+
+  commitMappings.set(commit, { mapping, expiresAt: Date.now() + ttl });
+  if (commitMappings.size > COMMIT_CACHE_LIMIT) {
+    const oldest = commitMappings.keys().next().value;
+    if (oldest) commitMappings.delete(oldest);
+  }
+  return mapping;
 }

--- a/src/lib/test-groups.test.ts
+++ b/src/lib/test-groups.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { getTestGroup } from "./test-groups";
-import { buildTestAreaMapping } from "./test-areas";
+import {
+  buildTestAreaMapping,
+  discoverGroupYamlPaths,
+} from "./test-areas";
 
 const mapping = buildTestAreaMapping([
   {
@@ -11,6 +14,14 @@ const mapping = buildTestAreaMapping([
       {
         label:
           ":nvidia: (H200) Language Models (Extended Pooling) Shard %N",
+      },
+    ],
+  },
+  {
+    group: "Model Runner V2",
+    steps: [
+      {
+        label: ":nvidia: (H200 MIG 35GB) Model Runner V2 Spec Decode %N",
       },
     ],
   },
@@ -47,5 +58,46 @@ test("groups explicit and legacy AMD mirror labels", () => {
       mapping,
     ),
     "Hardware-AMD Tests",
+  );
+});
+
+test("groups a test area that exists only in a branch commit", () => {
+  assert.equal(
+    getTestGroup(
+      ":nvidia: (H200 MIG 35GB) Model Runner V2 Spec Decode 4",
+      mapping,
+    ),
+    "Model Runner V2",
+  );
+});
+
+test("discovers group YAML recursively from every configured job directory", () => {
+  assert.deepEqual(
+    discoverGroupYamlPaths(
+      [
+        { path: ".buildkite/test_areas/engine.yaml", type: "blob" },
+        {
+          path: ".buildkite/hardware_tests/intel_xpu_ci/test-intel.yaml",
+          type: "blob",
+        },
+        { path: ".buildkite/image_build/image_build.yaml", type: "blob" },
+        { path: ".buildkite/lm-eval-harness/model.yaml", type: "blob" },
+        { path: ".buildkite/test_areas/archive", type: "tree" },
+      ],
+      [
+        {
+          job_dirs: [
+            ".buildkite/image_build",
+            ".buildkite/test_areas",
+            ".buildkite/hardware_tests",
+          ],
+        },
+      ],
+    ),
+    [
+      ".buildkite/hardware_tests/intel_xpu_ci/test-intel.yaml",
+      ".buildkite/image_build/image_build.yaml",
+      ".buildkite/test_areas/engine.yaml",
+    ],
   );
 });

--- a/src/lib/test-groups.ts
+++ b/src/lib/test-groups.ts
@@ -103,10 +103,9 @@ export function resolveGroupsToJobConditions(groups: string[]): { exactNames: st
 }
 
 export function aggregateJobsByGroup(
-  jobs: { name: string; state: string; web_url?: string }[]
+  jobs: { name: string; state: string; web_url?: string }[],
+  mapping: TestAreaMapping = getTestAreaMapping(),
 ): GroupStatus[] {
-  const mapping = getTestAreaMapping();
-
   const groupMap = new Map<
     string,
     { passed: number; failed: number; running: number; blocked: number; total: number; jobs: JobInfo[] }


### PR DESCRIPTION
## Summary

- discover group YAML recursively from every `job_dirs` entry in `.buildkite/ci_config*.yaml`
- resolve non-main builds against YAML changed in that build's commit, so PR-only groups appear before merge
- apply the same commit-aware mapping to group summaries, expanded jobs, and the text/JSON summary API
- retain the existing static inventory only as an outage/cold-start fallback

## Audit

Current `vllm/main` has 58 group YAML files across four configured job directories, defining 47 groups. The dashboard previously refreshed only `.buildkite/test_areas`, leaving these Intel groups dependent on manual updates and absent from the inventory:

- Engine Intel
- Kernels Intel
- LoRA Intel
- Miscellaneous Intel
- Model Executor Intel
- Model Runner V2 Intel
- Samplers Intel

The reported `model_runner_v2.yaml` case is a separate branch-awareness gap: build 86580 uses commit `87cb1d6`, where the YAML exists, while the file is absent from current `main`. The existing dashboard therefore reports only `Abuild` for that build. With this change, all eight Model Runner V2 jobs in the build resolve under `Model Runner V2`, including the four sharded Spec Decode jobs.

## Validation

- `npm test` (45 tests)
- `npm run lint`
- `npm run build`
- live GitHub discovery audit: all 47 groups from the configured YAML files are present
- commit-specific check against `87cb1d6`: `Model Runner V2 Spec Decode 4` resolves to `Model Runner V2`
