### PR TITLE
Fix wait times for Kubernetes queues

### DIFF
--- a/src/lib/buildkite-agent-query.test.ts
+++ b/src/lib/buildkite-agent-query.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { queueKeyFromAgentQueryRules } from "./buildkite-agent-query";
+
+test("queueKeyFromAgentQueryRules extracts the Kubernetes queue tag", () => {
+  assert.equal(
+    queueKeyFromAgentQueryRules(["docker=true", "queue=l4-k8s"]),
+    "l4-k8s",
+  );
+});
+
+test("queueKeyFromAgentQueryRules ignores missing and unrelated rules", () => {
+  assert.equal(queueKeyFromAgentQueryRules(undefined), null);
+  assert.equal(queueKeyFromAgentQueryRules(["docker=true", "queue="]), null);
+  assert.equal(queueKeyFromAgentQueryRules(["notqueue=l4-k8s"]), null);
+});

--- a/src/lib/buildkite-agent-query.ts
+++ b/src/lib/buildkite-agent-query.ts
@@ -1,0 +1,11 @@
+export function queueKeyFromAgentQueryRules(
+  rules: readonly string[] | null | undefined,
+): string | null {
+  for (const rule of rules ?? []) {
+    const match = /^queue=(.+)$/.exec(rule.trim());
+    if (!match) continue;
+    const value = match[1].trim();
+    if (value) return value;
+  }
+  return null;
+}

--- a/src/lib/buildkite-queue-jobs.ts
+++ b/src/lib/buildkite-queue-jobs.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from "next/cache";
+import { queueKeyFromAgentQueryRules } from "@/lib/buildkite-agent-query";
 
 const GRAPHQL_ENDPOINT = "https://graphql.buildkite.com/v1";
 const REST_ENDPOINT = "https://api.buildkite.com/v2";
@@ -30,6 +31,7 @@ interface GraphQLResponse {
             runnableAt?: string | null;
             priority?: { number?: number };
             clusterQueue?: { id?: string } | null;
+            agentQueryRules?: string[] | null;
           };
         }>;
       };
@@ -395,6 +397,7 @@ async function graphqlQueueJobs(
                       runnableAt
                       priority { number }
                       clusterQueue { id }
+                      agentQueryRules
                     }
                   }
                 }
@@ -437,7 +440,13 @@ async function graphqlQueueJobs(
 
     for (const { node } of connection.edges) {
       if (!node.uuid || !node.url || !node.scheduledAt) continue;
-      if (clusterQueue && node.clusterQueue?.id !== clusterQueue.queueId) continue;
+      if (
+        clusterQueue &&
+        node.clusterQueue?.id !== clusterQueue.queueId &&
+        queueKeyFromAgentQueryRules(node.agentQueryRules) !== queue
+      ) {
+        continue;
+      }
       jobs.push({
         uuid: node.uuid,
         label: node.label ?? null,

--- a/src/lib/buildkite-queue-metrics.test.ts
+++ b/src/lib/buildkite-queue-metrics.test.ts
@@ -111,3 +111,47 @@ test("aggregateQueueSnapshots keeps Buildkite counts and groups waits by queue",
     },
   ]);
 });
+
+test("aggregateQueueSnapshots maps Kubernetes jobs by their queue agent rule", () => {
+  const snapshots = aggregateQueueSnapshots(
+    [
+      {
+        id: "l4-cluster-queue",
+        key: "l4-k8s",
+        metrics: {
+          connectedAgentsCount: 35,
+          runningJobsCount: 35,
+          waitingJobsCount: 2,
+        },
+      },
+    ],
+    [
+      {
+        clusterQueueId: null,
+        queueKey: "l4-k8s",
+        runnableAt: new Date(NOW.getTime() - 30 * 1000).toISOString(),
+      },
+      {
+        clusterQueueId: null,
+        queueKey: "l4-k8s",
+        runnableAt: new Date(NOW.getTime() - 90 * 1000).toISOString(),
+      },
+    ],
+    NOW,
+  );
+
+  assert.deepEqual(snapshots, [
+    {
+      queue: "l4-k8s",
+      polledAt: NOW.toISOString(),
+      connectedAgents: 35,
+      runningJobs: 35,
+      waitingJobs: 2,
+      p50: 30,
+      p90: 90,
+      p95: 90,
+      p99: 90,
+      sampleSize: 2,
+    },
+  ]);
+});

--- a/src/lib/buildkite-queue-metrics.ts
+++ b/src/lib/buildkite-queue-metrics.ts
@@ -1,3 +1,5 @@
+import { queueKeyFromAgentQueryRules } from "@/lib/buildkite-agent-query";
+
 const GRAPHQL_ENDPOINT = "https://graphql.buildkite.com/v1";
 const PAGE_SIZE = 100;
 
@@ -67,6 +69,7 @@ interface ScheduledJobsConnection {
     node: {
       runnableAt: string | null;
       clusterQueue: { id: string } | null;
+      agentQueryRules: string[] | null;
     };
   }>;
 }
@@ -83,6 +86,7 @@ interface GraphQLResponse<T> {
 interface ScheduledQueueJob {
   runnableAt: string | null;
   clusterQueueId: string | null;
+  queueKey?: string | null;
 }
 
 async function graphqlRequest<T>(
@@ -147,11 +151,17 @@ export function aggregateQueueSnapshots(
   now: Date,
 ): BuildkiteQueueSnapshot[] {
   const jobsByQueue = new Map<string, Array<string | null>>();
+  const jobsByQueueKey = new Map<string, Array<string | null>>();
   for (const job of jobs) {
-    if (!job.clusterQueueId) continue;
-    const queueJobs = jobsByQueue.get(job.clusterQueueId) ?? [];
-    queueJobs.push(job.runnableAt);
-    jobsByQueue.set(job.clusterQueueId, queueJobs);
+    if (job.clusterQueueId) {
+      const queueJobs = jobsByQueue.get(job.clusterQueueId) ?? [];
+      queueJobs.push(job.runnableAt);
+      jobsByQueue.set(job.clusterQueueId, queueJobs);
+    } else if (job.queueKey) {
+      const queueJobs = jobsByQueueKey.get(job.queueKey) ?? [];
+      queueJobs.push(job.runnableAt);
+      jobsByQueueKey.set(job.queueKey, queueJobs);
+    }
   }
 
   const queuesByKey = new Map<string, {
@@ -177,7 +187,10 @@ export function aggregateQueueSnapshots(
 
   return [...queuesByKey.entries()]
     .map(([queue, aggregate]) => {
-      const runnableAtValues = aggregate.ids.flatMap((id) => jobsByQueue.get(id) ?? []);
+      const runnableAtValues = [
+        ...aggregate.ids.flatMap((id) => jobsByQueue.get(id) ?? []),
+        ...(jobsByQueueKey.get(queue) ?? []),
+      ];
       const wait = calculateWaitPercentiles(runnableAtValues, now);
       return {
         queue,
@@ -305,6 +318,7 @@ async function fetchScheduledJobs(token: string, organization: string): Promise<
                   ... on JobTypeCommand {
                     runnableAt
                     clusterQueue { id }
+                    agentQueryRules
                   }
                 }
               }
@@ -322,6 +336,7 @@ async function fetchScheduledJobs(token: string, organization: string): Promise<
       ...connection.edges.map(({ node }) => ({
         runnableAt: node.runnableAt,
         clusterQueueId: node.clusterQueue?.id ?? null,
+        queueKey: queueKeyFromAgentQueryRules(node.agentQueryRules),
       })),
     );
     after = connection.pageInfo.hasNextPage ? connection.pageInfo.endCursor : null;


### PR DESCRIPTION
## Summary

- read `queue=` from Buildkite scheduled-job agent query rules when `clusterQueue` is null
- use that fallback for queue wait percentiles and the live waiting-job list
- retain cluster queue IDs as the preferred mapping for ordinary queues

## Why

Buildkite's cluster metrics correctly report scheduled counts for Kubernetes queues such as `l4-k8s`, but scheduled Kubernetes jobs carry their queue in `agentQueryRules` before an agent assignment. The dashboard joined wait samples only through `clusterQueue.id`, so it stored the count while leaving P50/P90/P95/P99 null and returned an empty job list.

## Validation

- `npm test` (46 tests)
- `npm run lint`
- `npm run build`
