### PR TITLE
Add option to hide outlier builds (≥6h) from duration chart

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,6 +67,7 @@ export default function BuildsPage() {
   const [page, setPage] = useState(0);
   const [hideSoftFail, setHideSoftFail] = useState(false);
   const [hideOptional, setHideOptional] = useState(false);
+  const [hideOutliers, setHideOutliers] = useState(false);
   const [selectedGroups, setSelectedGroups] = useState<Set<string>>(new Set());
   const [selectedJobs, setSelectedJobs] = useState<Set<string>>(new Set());
 
@@ -212,7 +213,12 @@ export default function BuildsPage() {
         <StatCard label="Failed" value={summary.failed} color="red" />
       </div>
 
-      <BuildChart data={buildDurations} startDate={startDate} endDate={endDate} />
+      <BuildChart
+        data={buildDurations}
+        startDate={startDate}
+        endDate={endDate}
+        hideOutliers={hideOutliers}
+      />
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-4">
         <div className="flex min-w-0 gap-3">
@@ -271,6 +277,15 @@ export default function BuildsPage() {
               className="rounded border-zinc-300"
             />
             Hide optional
+          </label>
+          <label className="flex min-h-11 items-center gap-2 text-xs text-zinc-500 sm:min-h-10 dark:text-zinc-400">
+            <input
+              type="checkbox"
+              checked={hideOutliers}
+              onChange={(e) => setHideOutliers(e.target.checked)}
+              className="rounded border-zinc-300"
+            />
+            Hide outliers (≥6h)
           </label>
         </div>
       </div>

--- a/src/components/build-chart.tsx
+++ b/src/components/build-chart.tsx
@@ -26,6 +26,12 @@ export interface BuildDuration {
 
 type ChartMode = "overview" | "runs";
 
+const OUTLIER_THRESHOLD_MINS = 6 * 60;
+
+function isOutlier(build: BuildDuration): boolean {
+  return (parseInt(build.duration_mins, 10) || 0) >= OUTLIER_THRESHOLD_MINS;
+}
+
 interface RunPoint {
   index: number;
   date: string;
@@ -206,16 +212,22 @@ interface BuildChartProps {
   data: BuildDuration[];
   startDate?: string;
   endDate?: string;
+  hideOutliers?: boolean;
 }
 
-export function BuildChart({ data, startDate, endDate }: BuildChartProps) {
+export function BuildChart({ data, startDate, endDate, hideOutliers }: BuildChartProps) {
   const [mode, setMode] = useState<ChartMode>("runs");
   const rangeLabel =
     startDate && endDate ? `${startDate} — ${endDate}` : "All Time";
 
+  const filteredData = useMemo(
+    () => (hideOutliers ? data.filter((build) => !isOutlier(build)) : data),
+    [data, hideOutliers],
+  );
+
   const runData = useMemo<RunPoint[]>(
     () =>
-      data.map((build, index) => {
+      filteredData.map((build, index) => {
         const date = new Date(build.created_at);
         return {
           index,
@@ -228,12 +240,12 @@ export function BuildChart({ data, startDate, endDate }: BuildChartProps) {
           failed: isFailed(build.state),
         };
       }),
-    [data],
+    [filteredData],
   );
 
   const dailyData = useMemo<DailyPoint[]>(() => {
     const byDay = new Map<string, BuildDuration[]>();
-    for (const build of data) {
+    for (const build of filteredData) {
       const key = build.created_at.slice(0, 10);
       byDay.set(key, [...(byDay.get(key) ?? []), build]);
     }
@@ -262,7 +274,7 @@ export function BuildChart({ data, startDate, endDate }: BuildChartProps) {
           failed: builds.filter((build) => isFailed(build.state)).length,
         };
       });
-  }, [data]);
+  }, [filteredData]);
 
   if (data.length === 0) {
     return (
@@ -306,7 +318,10 @@ export function BuildChart({ data, startDate, endDate }: BuildChartProps) {
             Build Duration
           </h3>
           <p className="mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
-            {rangeLabel} · {data.length} builds
+            {rangeLabel} · {filteredData.length} builds
+            {hideOutliers && filteredData.length !== data.length && (
+              <span> ({data.length - filteredData.length} outliers hidden)</span>
+            )}
           </p>
         </div>
         <div


### PR DESCRIPTION
Adds a **Hide outliers (≥6h)** checkbox next to **Hide optional** on the Builds tab.

When enabled, builds with a duration of 6 hours or more are excluded from the Build Duration chart (both Runs and Overview modes), so long-running outliers no longer skew the Y-axis scale and the P50/P90/Peak stats. The subtitle shows how many outliers were hidden.

The builds table and summary stats are unaffected.