### PR TITLE
Main CI: fix active-build state filter, widen hourly sweep

### DIFF
--- a/alerting/CONTEXT.md
+++ b/alerting/CONTEXT.md
@@ -49,9 +49,12 @@ do not resolve an episode.
 _Avoid_: Full CI Failure Condition, automated diagnosis
 
 **Main CI Backstop Sweep**:
-An hourly re-check of every open Main CI Job Alert against the build where it
-last failed, so a retry pass the observation window moved past still resolves
-the episode within an hour. It never advances the Scan Cursor.
+An hourly reconciliation of every active main build and every build finished
+in the last 48 hours with no per-job observation window — opening episodes
+the poller's window missed entirely — plus a re-check of every open Main CI
+Job Alert against the build where it last failed, so a retry pass the
+observation window moved past still resolves the episode within an hour. It
+never advances the Scan Cursor.
 _Avoid_: Re-poll, full rescan
 
 **Scan Cursor**:

--- a/alerting/README.md
+++ b/alerting/README.md
@@ -51,10 +51,15 @@ repository-level relationship with the dashboard is recorded in
   retried-out executions that lack a step key inherit it from the same-named
   job in the build, and a pass that fell behind the scan window still
   resolves when its build is fetched. An hourly backstop sweep
-  (`main_ci_backstop`) re-checks every open alert against the build where it
-  last failed, so a retry pass missed by the windowed poller resolves within
-  an hour. It writes raw lifecycle and Buildkite evidence only; Sherlock's
-  diagnosis remains in Slack.
+  (`main_ci_backstop`) additionally reconciles every active build and every
+  build finished in the last 48 hours with no per-job window — so a failure
+  the poller missed entirely (a job that failed long before its build
+  finished) still opens an alert within an hour — and re-checks every open
+  alert against the build where it last failed, so a retry pass missed by
+  the windowed poller resolves within an hour. The sweep never advances the
+  poller's scan cursor; the outcome order guard keeps reprocessing
+  idempotent. It writes raw lifecycle and Buildkite evidence only;
+  Sherlock's diagnosis remains in Slack.
 - `analyzer.py` — the Full CI analyzer compatibility adapter. It materializes
   the working files the bundled analyzer instructions expect (summary, full
   build data, previous-failure cache, agent memory hydrated from the latest

--- a/alerting/full_ci.py
+++ b/alerting/full_ci.py
@@ -195,7 +195,16 @@ class BuildkiteRestClient:
         active = self._list_build_pages(
             {
                 **common,
-                "state": ["creating", "scheduled", "running", "failing", "canceling"],
+                # Buildkite requires array syntax for multi-value filters;
+                # repeated scalar state= params match nothing useful and the
+                # active-build query silently returns zero builds.
+                "state[]": [
+                    "creating",
+                    "scheduled",
+                    "running",
+                    "failing",
+                    "canceling",
+                ],
             }
         )
         finished = self._list_build_pages(

--- a/alerting/main_ci.py
+++ b/alerting/main_ci.py
@@ -18,6 +18,10 @@ from alerting.runtime import HandlerCompletion
 
 INITIAL_LOOKBACK = timedelta(days=1)
 SAFETY_OVERLAP = timedelta(minutes=30)
+# The hourly backstop reconciles every main build finished in this window
+# (plus active builds), so failures the two-minute poller's per-job window
+# missed entirely still open alerts within an hour.
+SWEEP_LOOKBACK = timedelta(hours=48)
 FAILURE_STATES = frozenset({"failed", "failing", "broken", "timed_out"})
 TRACKED_STATES = FAILURE_STATES | {"passed"}
 
@@ -242,6 +246,10 @@ class MainCIStore(Protocol):
 
 
 class MainCIBackstopBuildPort(Protocol):
+    def list_job_builds(
+        self, *, observed_from: datetime, up_to: datetime
+    ) -> list[dict[str, Any]]: ...
+
     def get_build(
         self, build_number: int, *, include_retried_jobs: bool
     ) -> dict[str, Any]: ...
@@ -252,13 +260,25 @@ class MainCIBackstopStore(MainCIStore, Protocol):
 
 
 class MainCIBackstopHandler:
-    """Hourly sweep that re-checks open alerts against their failure build.
+    """Hourly full sweep of recent main builds plus open-alert builds.
 
-    The windowed poller can permanently miss a retry pass when a worker gap
-    lets the scan window move past the pass's finished_at. This sweep fetches
-    each open alert's last-failure build directly and feeds the newest
-    terminal execution of the alert's job key through the normal
-    reconciliation path, so a missed pass resolves within an hour.
+    Two parts per run:
+
+    1. Wide sweep: every active main build and every main build finished in
+       the last ``SWEEP_LOOKBACK`` hours is reconciled with no per-job
+       finished_at window, so a failure the poller missed entirely (a job
+       that failed long before its build finished, hidden by the per-job
+       scan window) still opens an alert within an hour. The
+       ``(build_number, finished_at, job_id)`` order guard in
+       ``commit_main_ci_scan`` keeps newer data authoritative and makes
+       reprocessing the same builds idempotent.
+    2. Targeted re-check: each open alert's last-failure build is fetched
+       directly, so a retry pass on a build older than the wide window
+       still resolves its alert.
+
+    The sweep never advances the poller's scan cursor: it only re-checks
+    data, and moving the cursor could make the poller skip failures that
+    fell into a gap.
     """
 
     def __init__(
@@ -273,11 +293,19 @@ class MainCIBackstopHandler:
         self._clock = clock
 
     def __call__(self, command: ScheduledCommand) -> HandlerCompletion:
+        sweep_builds = self._builds.list_job_builds(
+            observed_from=command.target_time - SWEEP_LOOKBACK,
+            up_to=command.target_time,
+        )
+        observations = [
+            observation
+            for build in sweep_builds
+            for observation in build_job_observations(build)
+        ]
         refs = self._store.open_main_ci_alert_builds()
         job_keys_by_build: dict[int, set[str]] = {}
         for ref in refs:
             job_keys_by_build.setdefault(ref.build_number, set()).add(ref.job_key)
-        observations: list[MainCIJobObservation] = []
         for build_number in sorted(job_keys_by_build):
             build = self._builds.get_build(
                 build_number, include_retried_jobs=True
@@ -293,7 +321,7 @@ class MainCIBackstopHandler:
                     observations.append(
                         max(executions, key=lambda item: item.order)
                     )
-        # The sweep only re-checks known alerts; it must not advance the
+        # The sweep only re-checks known state; it must not advance the
         # poller's scan cursor, or a poller outage covered by the sweep would
         # skip failures that fell into the gap.
         cursor = self._store.main_ci_scan_cursor()

--- a/alerting/tests/test_main_ci.py
+++ b/alerting/tests/test_main_ci.py
@@ -8,6 +8,7 @@ from alerting.full_ci import BuildkiteRestClient
 from alerting.main_ci import (
     INITIAL_LOOKBACK,
     SAFETY_OVERLAP,
+    SWEEP_LOOKBACK,
     BuildkiteMainCISource,
     MainCIBackstopHandler,
     MainCIJobObservation,
@@ -62,7 +63,7 @@ class RecordingRestClient(BuildkiteRestClient):
         self, query: dict[str, str | int | list[str]]
     ) -> list[dict[str, Any]]:
         self.queries.append(dict(query))
-        if query["state"] == "finished":
+        if query.get("state") == "finished":
             return [{"id": "shared"}, {"id": "finished"}]
         return [{"id": "active"}, {"id": "shared"}]
 
@@ -266,7 +267,10 @@ def test_buildkite_client_unions_active_and_recently_finished_builds() -> None:
     rows = client.list_job_builds(observed_from=observed_from, up_to=START)
 
     assert {row["id"] for row in rows} == {"active", "shared", "finished"}
-    assert client.queries[0]["state"] == [
+    # Buildkite requires array syntax for the multi-state filter; repeated
+    # scalar state= params make the active query return zero builds.
+    assert "state" not in client.queries[0]
+    assert client.queries[0]["state[]"] == [
         "creating",
         "scheduled",
         "running",
@@ -279,6 +283,31 @@ def test_buildkite_client_unions_active_and_recently_finished_builds() -> None:
         assert query["branch"] == "main"
         assert query["include_retried_jobs"] == "true"
         assert "exclude_jobs" not in query
+
+
+class RecordingUrlClient(BuildkiteRestClient):
+    def __init__(self) -> None:
+        super().__init__(token="not-used")
+        self.urls: list[str] = []
+
+    def _get_json(self, url: str) -> Any:
+        self.urls.append(url)
+        return []
+
+
+def test_buildkite_client_serializes_state_filter_as_array_params() -> None:
+    client = RecordingUrlClient()
+
+    client.list_job_builds(observed_from=START - timedelta(minutes=30), up_to=START)
+
+    assert len(client.urls) == 2
+    active_url, finished_url = client.urls
+    # urlencode percent-encodes the brackets; Buildkite decodes them back to
+    # state[]=... before parsing the query.
+    assert "state%5B%5D=creating" in active_url
+    assert "state%5B%5D=running" in active_url
+    assert "state=creating" not in active_url
+    assert "state=finished" in finished_url
 
 
 def buildkite_job(
@@ -480,6 +509,14 @@ class FixtureBuilds:
     def __init__(self, builds: dict[int, dict[str, Any]]) -> None:
         self.builds = builds
         self.calls: list[tuple[int, bool]] = []
+        self.sweep_builds: list[dict[str, Any]] = []
+        self.sweep_calls: list[tuple[datetime, datetime]] = []
+
+    def list_job_builds(
+        self, *, observed_from: datetime, up_to: datetime
+    ) -> list[dict[str, Any]]:
+        self.sweep_calls.append((observed_from, up_to))
+        return self.sweep_builds
 
     def get_build(
         self, build_number: int, *, include_retried_jobs: bool
@@ -598,3 +635,97 @@ def test_backstop_ignores_resolved_alerts() -> None:
     assert alert.status == "resolved"
     assert alert.resolution is not None
     assert alert.resolution.job_id == "retry"
+
+
+def test_sweep_opens_alert_for_failure_the_poller_window_missed() -> None:
+    # The build finished recently, but its job failed five hours earlier —
+    # outside any thirty-minute window the poller would have scanned.
+    source = FixtureSource()
+    builds = FixtureBuilds({})
+    runtime, store, _ = combined_runtime_for(source, builds)
+    builds.sweep_builds = [
+        buildkite_build(
+            400,
+            [
+                buildkite_job(
+                    job_id="slow-failure",
+                    state="failed",
+                    finished_at=START - timedelta(hours=5),
+                )
+            ],
+        )
+    ]
+
+    backstop(runtime, START)
+
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("open", 1)
+    ]
+    assert store.alerts()[0].last_failure.job_id == "slow-failure"
+    assert builds.sweep_calls == [(START - SWEEP_LOOKBACK, START)]
+    # Nothing was open when the sweep started, so no targeted re-check ran.
+    assert builds.calls == []
+
+
+def test_sweep_does_not_reopen_when_a_newer_pass_exists() -> None:
+    source = FixtureSource()
+    builds = FixtureBuilds({})
+    runtime, store, _ = combined_runtime_for(source, builds)
+    open_alert(runtime, source)
+    source.observations.append(
+        observation(build_number=300, state="passed", minutes=-170, job_id="retry")
+    )
+    reconcile(runtime, START - timedelta(hours=2, minutes=45))
+    assert [alert.status for alert in store.alerts()] == ["resolved"]
+
+    # The sweep re-feeds the older failure; the order guard must drop it.
+    builds.sweep_builds = [
+        buildkite_build(
+            300,
+            [
+                buildkite_job(
+                    job_id="orig",
+                    state="failed",
+                    finished_at=START - timedelta(hours=3),
+                ),
+                buildkite_job(
+                    job_id="retry",
+                    state="passed",
+                    finished_at=START - timedelta(hours=2, minutes=50),
+                ),
+            ],
+        )
+    ]
+    backstop(runtime, START)
+
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("resolved", 1)
+    ]
+    resolution = store.alerts()[0].resolution
+    assert resolution is not None
+    assert resolution.job_id == "retry"
+
+
+def test_sweep_is_idempotent_across_reruns() -> None:
+    source = FixtureSource()
+    builds = FixtureBuilds({})
+    runtime, store, _ = combined_runtime_for(source, builds)
+    build = buildkite_build(
+        400,
+        [
+            buildkite_job(
+                job_id="slow-failure",
+                state="failed",
+                finished_at=START - timedelta(hours=5),
+            )
+        ],
+    )
+    builds.sweep_builds = [build]
+    builds.builds[400] = build
+
+    backstop(runtime, START)
+    backstop(runtime, START + timedelta(hours=1))
+
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("open", 1)
+    ]

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -96,7 +96,9 @@ start the timers again. `Persistent=true` and `OnBootSec` start reconciliation,
 while the Postgres cursors and processed-run history recover missed Fast, Full,
 or Main CI observations. Each path has a separate timer and service — Main CI
 has three: one for lifecycle reconciliation, one for AI analysis, and one
-hourly backstop sweep that resolves retry passes the poller's window missed —
+hourly backstop sweep that reconciles all builds finished in the last 48
+hours plus active builds (catching failures the poller's window missed) and
+re-checks open alerts against their failure builds —
 so a long Full CI execution cannot occupy either frequent poller.
 
 For instance replacement and stack recreation, see

--- a/deploy/aws/systemd/alerting-main-ci-backstop.service
+++ b/deploy/aws/systemd/alerting-main-ci-backstop.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Re-check open Main CI alerts against their failure builds
+Description=Reconcile recent Main CI builds and re-check open alerts
 After=network-online.target
 Wants=network-online.target
 

--- a/deploy/aws/systemd/alerting-main-ci-backstop.timer
+++ b/deploy/aws/systemd/alerting-main-ci-backstop.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Hourly backstop sweep for Main CI retry resolutions missed by the poller
+Description=Hourly full sweep of recent Main CI builds and open alerts
 
 [Timer]
 OnBootSec=3min


### PR DESCRIPTION
## Confirmed root cause (verified against the live Buildkite API)

`BuildkiteRestClient._list_build_pages` serialized the multi-state filter as repeated scalar params (`state=creating&state=scheduled&...` via `urlencode(doseq=True)`). Buildkite requires array syntax (`state[]=...`); with repeated scalars the API effectively matches nothing — **the active-builds query in `list_job_builds` returned ZERO builds (verified live: 0 builds with the scalar form vs 4 with `state[]`)**.

The poller therefore never saw running builds; it only processed builds through the `finished` query plus the ~30-minute per-job `finished_at` window. Any job that failed more than ~30 minutes before its build finished was silently missed. Production proof: **build 86655 — 5h runtime, ~20 hard failures, zero alerts opened**.

## Changes

**1. State serialization fix** (`alerting/full_ci.py`)
- The active-build query now sends `state[]=creating&state[]=scheduled&...` (key `state[]` with the list through `urlencode(doseq=True)`). The scalar `state=finished` shortcut on the finished query is documented Buildkite behavior and unchanged; no other call site passes a state list.

**2. Hourly backstop becomes a full sweep** (`alerting/main_ci.py`, `MainCIBackstopHandler` / `main-ci-backstop` consumer)
- Each hourly run now ALSO reconciles a wide recent window via the existing `list_job_builds` machinery: active builds (works after fix 1) plus all main builds finished in the last 48h (`SWEEP_LOOKBACK`). All terminal job outcomes are fed through `commit_main_ci_scan` with **no per-job window filtering** — the `(build_number, finished_at, job_id)` order guard keeps newer data authoritative and makes reprocessing idempotent. This closes the 86655 hole: a failure the windowed poller missed entirely opens an alert within an hour.
- The targeted open-alert re-check (single-build GET per open alert's `last_failure_build_number`) is **kept**: it covers retry passes on builds older than the 48h window, which the wide sweep cannot see.
- The sweep still never advances the poller's scan cursor (it passes the current cursor through; the GREATEST update is a no-op).
- Names unchanged (`main-ci-backstop` consumer, `main_ci_backstop` command, systemd units) — the units are already deployed; docstrings/comments/docs updated to describe the full-sweep behavior. Request volume is modest: ~2 days of main builds is a few dozen builds, hourly.
- systemd unit descriptions updated (behavior only; unit names stable).

## Testing

CI checks on this PR are expected to queue indefinitely — the repo's self-hosted runners are still down. All tests run locally:

- `alerting/`: `uv run pytest tests/` — **163 passed**, including new tests:
  - regression: emitted query string uses `state[]=` for the multi-state filter (HTTP-level, URL-capturing client), scalar `state=finished` retained
  - sweep opens an alert for a failure the windowed poller would miss (job finished 5h before its build, build finished within 48h)
  - sweep does not reopen/duplicate when a newer pass exists (order guard)
  - sweep leaves resolved alerts alone; idempotent re-run
- `uv run ruff check .` — clean
- `uv run mypy ...` — only pre-existing errors on main (3 boto3-stub + 2 comparison-overlap in tests/test_worker.py; both classes verified present on unmodified origin/main)
- `deploy/aws/tests/` — **20 passed**

No schema changes; no AWS deployment in this PR.