### PR TITLE
fix(alerting): compute Full CI report stats deterministically

### DIFF
--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -407,6 +407,17 @@ def _build_summary(
             {"name": job.name, "state": job.state, "soft_failed": job.soft_failed}
             for job in jobs
         ],
+        # Deterministic counts for the report's Stats line; the analyzer model
+        # miscounts the jobs array, so it must use these verbatim.
+        "stats": {
+            "passed": sum(1 for job in jobs if job.state == "passed"),
+            "failed": len(_hard_failures(jobs)),
+            "new": len(_hard_failures(jobs) - set(cache.failed_tests)),
+            "recurring": len(_hard_failures(jobs) & set(cache.failed_tests)),
+            "scheduled": sum(1 for job in jobs if job.state == "scheduled"),
+            "has_previous_data": cache.build_number is not None,
+            "total": len(jobs),
+        },
         "skip_report": False,
         "previous_failures": {
             "build_number": cache.build_number,

--- a/alerting/assets/vllm-ci-failure-analyzer.md
+++ b/alerting/assets/vllm-ci-failure-analyzer.md
@@ -57,7 +57,13 @@ Write `.logs/ci_report.txt` as Slack mrkdwn, without posting it. Start with:
 *Stats:* X passed, Y failed (N new, M recurring)
 ```
 
-Count only hard failures in `Y failed`. Add sections for new, recurring, fixed,
+Every number on the Stats line comes from the summary's precomputed `stats`
+object: X = `stats.passed`, Y = `stats.failed` (hard failures only). Never count
+the `jobs` array yourself — it is too long to count reliably. The
+`(N new, M recurring)` breakdown uses `stats.new` and `stats.recurring` and
+appears only when `stats.failed` > 0 and `stats.has_previous_data` is true;
+otherwise show just `Y failed`. If `stats.scheduled` > 0, append
+`, S scheduled` to the Stats line using `stats.scheduled`. Add sections for new, recurring, fixed,
 and soft failures when present. Investigation summaries must be concise. Show
 at most five bullets per section and link to the build for omitted entries.
 Keep the complete report at or below 2,800 characters without breaking Slack

--- a/alerting/tests/test_analyzer.py
+++ b/alerting/tests/test_analyzer.py
@@ -550,6 +550,15 @@ def test_materialized_working_files_match_skill_contract(tmp_path: Path) -> None
     assert summary["previous_failures"]["failed_tests"] == ["Job A"]
     names = {job["name"] for job in summary["jobs"]}
     assert "AMD Job" not in names  # NVIDIA-only filter is preserved
+    assert summary["stats"] == {
+        "passed": 18,
+        "failed": 1,
+        "new": 0,
+        "recurring": 1,
+        "scheduled": 0,
+        "has_previous_data": True,
+        "total": 19,
+    }
     full_names = {job["name"] for job in observed["full"]["jobs"]}
     assert "AMD Job" in full_names
     assert observed["cache"]["failed_tests"] == ["Job A"]


### PR DESCRIPTION
## Problem

The Full CI report's `Stats:` line was rendered by the analyzer model counting the `jobs` array in `nightly_summary.json` by eye. Over ~270 entries the model miscounts nondeterministically — build #86511 reported `200 passed` while the correct count was `273` (failures matched, since they come from short explicit lists).

## Fix

- `_build_summary` now emits a precomputed `stats` object: `passed`, `failed` (hard failures), `new`, `recurring`, `scheduled`, `has_previous_data`, `total` — all derived in Python from the same NVIDIA-filtered job set.
- The analyzer skill renders these numbers verbatim and never counts the jobs array.
- Ports the legacy format rules that were dropped in the rewrite: the `(N new, M recurring)` breakdown only appears when hard failures exist **and** a previous baseline exists; `, S scheduled` is appended when jobs are still scheduled. This matches the old production bot's format exactly.

## Testing

- `alerting/tests/test_analyzer.py` skill-contract test asserts the full stats dict; 163 alerting tests pass.