### PR TITLE
Alerts: sort Main CI failures by job, failures, opened, or last failed

### DIFF
--- a/src/components/main-ci-alerts.test.ts
+++ b/src/components/main-ci-alerts.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { MainCIAlerts, MainCiAlertRow } from "./main-ci-alerts";
+import {
+  MainCIAlerts,
+  MainCiAlertRow,
+  nextSort,
+  sortMainCiAlerts,
+} from "./main-ci-alerts";
 import type { MainCiJobAlert, MainCiJobAnalysis } from "../lib/alerts-main-ci";
 
 function analysis(overrides: Partial<MainCiJobAnalysis> = {}): MainCiJobAnalysis {
@@ -243,4 +248,94 @@ test("hide options filter matching job names out of the list", () => {
   assert.doesNotMatch(hidden, /AMD: MI300X Test/);
   assert.doesNotMatch(hidden, /Lint \(soft-fail\)/);
   assert.doesNotMatch(hidden, /Optional check/);
+});
+
+test("column sort orders by job, failures, opened, and last failed in either direction", () => {
+  const alerts = [
+    alert({
+      alertId: "1",
+      jobName: "b test",
+      failureCount: 3,
+      openedAt: "2026-08-29T08:00:00.000Z",
+      lastFailure: { ...alert().lastFailure, finishedAt: "2026-08-29T10:00:00.000Z" },
+    }),
+    alert({
+      alertId: "2",
+      jobName: "A test",
+      failureCount: 9,
+      openedAt: "2026-08-28T08:00:00.000Z",
+      lastFailure: { ...alert().lastFailure, finishedAt: "2026-08-29T12:00:00.000Z" },
+    }),
+    alert({
+      alertId: "3",
+      jobName: "c test",
+      failureCount: 1,
+      openedAt: "2026-08-30T08:00:00.000Z",
+      lastFailure: { ...alert().lastFailure, finishedAt: "2026-08-29T09:00:00.000Z" },
+    }),
+  ];
+  const ids = (sorted: typeof alerts) => sorted.map((item) => item.alertId);
+
+  // No sort keeps the incoming lifecycle order.
+  assert.deepEqual(ids(sortMainCiAlerts(alerts, null)), ["1", "2", "3"]);
+  // Names sort case-insensitively.
+  assert.deepEqual(
+    ids(sortMainCiAlerts(alerts, { key: "job", direction: "asc" })),
+    ["2", "1", "3"],
+  );
+  assert.deepEqual(
+    ids(sortMainCiAlerts(alerts, { key: "failures", direction: "desc" })),
+    ["2", "1", "3"],
+  );
+  assert.deepEqual(
+    ids(sortMainCiAlerts(alerts, { key: "opened", direction: "asc" })),
+    ["2", "1", "3"],
+  );
+  assert.deepEqual(
+    ids(sortMainCiAlerts(alerts, { key: "lastFailed", direction: "desc" })),
+    ["2", "1", "3"],
+  );
+  assert.deepEqual(
+    ids(sortMainCiAlerts(alerts, { key: "lastFailed", direction: "asc" })),
+    ["3", "1", "2"],
+  );
+});
+
+test("job sort ignores vendor shortcodes and orders shard numbers naturally", () => {
+  const alerts = [
+    alert({ alertId: "amd", jobName: ":amd: (MI300) Entrypoints 10" }),
+    alert({ alertId: "nv2", jobName: ":nvidia: (B200) LM Eval 2" }),
+    alert({ alertId: "nv10", jobName: ":nvidia: (B200) LM Eval 10" }),
+    alert({ alertId: "cpu", jobName: "CPU Test" }),
+  ];
+  assert.deepEqual(
+    sortMainCiAlerts(alerts, { key: "job", direction: "asc" }).map(
+      (item) => item.alertId,
+    ),
+    ["nv2", "nv10", "amd", "cpu"],
+  );
+});
+
+test("clicking a column opens it in its default direction, then flips it", () => {
+  assert.deepEqual(nextSort(null, "job"), { key: "job", direction: "asc" });
+  assert.deepEqual(nextSort(null, "failures"), { key: "failures", direction: "desc" });
+  assert.deepEqual(
+    nextSort({ key: "failures", direction: "desc" }, "failures"),
+    { key: "failures", direction: "asc" },
+  );
+  // Switching columns resets to that column's default rather than carrying the direction over.
+  assert.deepEqual(
+    nextSort({ key: "failures", direction: "asc" }, "opened"),
+    { key: "opened", direction: "desc" },
+  );
+});
+
+test("header cells are sort buttons", () => {
+  const markup = renderToStaticMarkup(
+    createElement(MainCIAlerts, { alerts: [alert()] }),
+  );
+  assert.match(markup, /aria-label="Sort by job"/);
+  assert.match(markup, /aria-label="Sort by failures"/);
+  assert.match(markup, /aria-label="Sort by opened"/);
+  assert.match(markup, /aria-label="Sort by last failed"/);
 });

--- a/src/components/main-ci-alerts.tsx
+++ b/src/components/main-ci-alerts.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from "react";
-import { JobName } from "@/components/job-name";
+import { JobName, splitJobName } from "@/components/job-name";
 import { SegmentedControl } from "@/components/segmented-control";
 import {
   isAmdJobName,
@@ -90,13 +90,211 @@ function isReasonFilter(value: string): value is ReasonFilter {
   return REASON_FILTERS.some((reason) => reason.value === value);
 }
 
+export type SortKey = "job" | "failures" | "opened" | "lastFailed";
+export type SortDirection = "asc" | "desc";
+export interface AlertSort {
+  key: SortKey;
+  direction: SortDirection;
+}
+
+/**
+ * The sortable columns. Each opens in the direction a responder most often
+ * wants first: names alphabetically, everything else with the biggest or most
+ * recent value on top.
+ */
+const SORT_COLUMNS: readonly {
+  key: SortKey;
+  label: string;
+  defaultDirection: SortDirection;
+}[] = [
+  { key: "job", label: "Job", defaultDirection: "asc" },
+  { key: "failures", label: "Failures", defaultDirection: "desc" },
+  { key: "opened", label: "Opened", defaultDirection: "desc" },
+  { key: "lastFailed", label: "Last failed", defaultDirection: "desc" },
+];
+
+function sortColumn(key: SortKey) {
+  return SORT_COLUMNS.find((column) => column.key === key) ?? SORT_COLUMNS[0];
+}
+
+/**
+ * Buildkite job names lead with vendor shortcodes (":nvidia: (B200) …") that
+ * the list never shows, so sorting must use the text a reader actually sees.
+ */
+function displayJobName(jobName: string): string {
+  return splitJobName(jobName)
+    .flatMap((segment) => (segment.type === "text" ? [segment.text] : []))
+    .join("")
+    .trim();
+}
+
+function compareJobNames(a: MainCiJobAlert, b: MainCiJobAlert): number {
+  return displayJobName(a.jobName).localeCompare(
+    displayJobName(b.jobName),
+    undefined,
+    { sensitivity: "base", numeric: true },
+  );
+}
+
+function compareBy(key: SortKey, a: MainCiJobAlert, b: MainCiJobAlert): number {
+  switch (key) {
+    case "job":
+      return compareJobNames(a, b);
+    case "failures":
+      return a.failureCount - b.failureCount;
+    case "opened":
+      return Date.parse(a.openedAt) - Date.parse(b.openedAt);
+    case "lastFailed":
+      return (
+        Date.parse(a.lastFailure.finishedAt) -
+        Date.parse(b.lastFailure.finishedAt)
+      );
+  }
+}
+
+/**
+ * Orders alerts by one column. A null sort keeps the lifecycle order the list
+ * arrives in: open alerts first, most recent activity first. Ties fall back to
+ * the job name so the order is stable between renders.
+ */
+export function sortMainCiAlerts(
+  alerts: readonly MainCiJobAlert[],
+  sort: AlertSort | null,
+): MainCiJobAlert[] {
+  if (sort === null) return [...alerts];
+  const sign = sort.direction === "asc" ? 1 : -1;
+  return [...alerts].sort(
+    (a, b) => sign * compareBy(sort.key, a, b) || compareJobNames(a, b),
+  );
+}
+
+/** Clicking the active column flips it; clicking another opens it in its default direction. */
+export function nextSort(current: AlertSort | null, key: SortKey): AlertSort {
+  if (current?.key === key) {
+    return { key, direction: current.direction === "asc" ? "desc" : "asc" };
+  }
+  return { key, direction: sortColumn(key).defaultDirection };
+}
+
+function SortHeader({
+  columnKey,
+  sort,
+  align = "left",
+  onSort,
+}: {
+  columnKey: SortKey;
+  sort: AlertSort | null;
+  align?: "left" | "right";
+  onSort: (key: SortKey) => void;
+}) {
+  const column = sortColumn(columnKey);
+  const active = sort?.key === columnKey;
+  const direction = active ? sort.direction : null;
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(columnKey)}
+      aria-label={`Sort by ${column.label.toLowerCase()}${
+        direction ? `, currently ${direction === "asc" ? "ascending" : "descending"}` : ""
+      }`}
+      className={`dashboard-control group/sort inline-flex items-center gap-1 rounded text-[11px] font-semibold tracking-wide whitespace-nowrap uppercase ${
+        align === "right" ? "justify-self-end" : "justify-self-start"
+      } ${
+        active
+          ? "text-zinc-900 dark:text-zinc-100"
+          : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
+      }`}
+    >
+      {column.label}
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        className={`h-3 w-3 transition-transform duration-150 motion-reduce:transition-none ${
+          active ? "" : "opacity-0 group-hover/sort:opacity-60"
+        } ${direction === "asc" ? "rotate-180" : ""}`}
+      >
+        <path
+          d="M4 6l4 4 4-4"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </button>
+  );
+}
+
+/** The same sort as the header row, for screens where the header is hidden. */
+function SortSelect({
+  sort,
+  onChange,
+}: {
+  sort: AlertSort | null;
+  onChange: (sort: AlertSort | null) => void;
+}) {
+  const DIRECTION_LABELS: Record<SortKey, Record<SortDirection, string>> = {
+    job: { asc: "Job A→Z", desc: "Job Z→A" },
+    failures: { desc: "Most failures", asc: "Fewest failures" },
+    opened: { desc: "Newest opened", asc: "Oldest opened" },
+    lastFailed: { desc: "Latest failure", asc: "Earliest failure" },
+  };
+  return (
+    <label className="relative inline-flex items-center sm:hidden">
+      <span className="sr-only">Sort alerts</span>
+      <select
+        value={sort ? `${sort.key}:${sort.direction}` : ""}
+        onChange={(event) => {
+          const [key, direction] = event.target.value.split(":");
+          onChange(
+            SORT_COLUMNS.some((column) => column.key === key) &&
+              (direction === "asc" || direction === "desc")
+              ? { key: key as SortKey, direction }
+              : null,
+          );
+        }}
+        className="dashboard-control h-8 cursor-pointer appearance-none rounded-md border border-zinc-200 bg-white pr-7 pl-2.5 text-xs font-medium text-zinc-600 hover:border-zinc-300 hover:text-zinc-900 focus:border-zinc-400 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-400 dark:hover:border-zinc-700 dark:hover:text-zinc-100 dark:focus:border-zinc-600"
+      >
+        <option value="">Default order</option>
+        {SORT_COLUMNS.map((column) => (
+          <optgroup key={column.key} label={column.label}>
+            {(["desc", "asc"] as const).map((direction) => (
+              <option
+                key={direction}
+                value={`${column.key}:${direction}`}
+              >
+                {DIRECTION_LABELS[column.key][direction]}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </select>
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        className="pointer-events-none absolute right-2 h-3.5 w-3.5 text-zinc-400"
+      >
+        <path
+          d="M4 6l4 4 4-4"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </label>
+  );
+}
+
 /**
  * One grid template shared by the header row and every alert row so the
  * columns line up as a table. Narrow screens keep the chevron, name, reason,
  * failure count and action, and drop the two time columns.
  */
 const ROW_GRID =
-  "grid grid-cols-[1rem_minmax(0,1fr)_2.5rem_auto] items-center gap-x-3 sm:grid-cols-[1rem_minmax(0,1fr)_10.5rem_4rem_5.5rem_5.5rem_4.5rem]";
+  "grid grid-cols-[1rem_minmax(0,1fr)_2.5rem_auto] items-center gap-x-3 sm:grid-cols-[1rem_minmax(0,1fr)_10.5rem_4.5rem_6.5rem_6.5rem_4.5rem]";
 
 const LINK_CLASSES = "text-blue-600 hover:underline dark:text-blue-400";
 
@@ -594,6 +792,8 @@ export function MainCIAlerts({
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("open");
   const [reasonFilter, setReasonFilter] = useState<ReasonFilter | null>(null);
   const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<AlertSort | null>(null);
+  const toggleSort = (key: SortKey) => setSort(nextSort(sort, key));
   // One clock per render keeps every relative time in the list consistent.
   const now = new Date();
 
@@ -648,7 +848,7 @@ export function MainCIAlerts({
 
   const visible = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    return inScope.filter((alert) => {
+    const matching = inScope.filter((alert) => {
       if (needle && !alert.jobName.toLowerCase().includes(needle)) return false;
       if (reasonFilter === "unanalyzed") return alert.analysis === null;
       if (reasonFilter !== null) {
@@ -656,7 +856,8 @@ export function MainCIAlerts({
       }
       return true;
     });
-  }, [inScope, reasonFilter, query]);
+    return sortMainCiAlerts(matching, sort);
+  }, [inScope, reasonFilter, query, sort]);
 
   if (alerts.length === 0) {
     return (
@@ -682,6 +883,7 @@ export function MainCIAlerts({
             onChange={setReasonFilter}
           />
         )}
+        <SortSelect sort={sort} onChange={setSort} />
         <label className="relative ml-auto block">
           <svg
             aria-hidden="true"
@@ -719,15 +921,31 @@ export function MainCIAlerts({
       ) : (
         <div className="overflow-hidden rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
           <div
-            aria-hidden="true"
+            role="group"
+            aria-label="Sort alerts"
             className={`${ROW_GRID} hidden border-b border-zinc-200 border-l-[3px] border-l-transparent bg-zinc-50/80 px-3 py-2 text-[11px] font-semibold tracking-wide text-zinc-500 uppercase sm:grid dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-zinc-400`}
           >
             <span />
-            <span>Job</span>
+            <SortHeader columnKey="job" sort={sort} onSort={toggleSort} />
             <span>Reason</span>
-            <span className="text-right">Failures</span>
-            <span className="text-right">Opened</span>
-            <span className="text-right">Last failed</span>
+            <SortHeader
+              columnKey="failures"
+              sort={sort}
+              align="right"
+              onSort={toggleSort}
+            />
+            <SortHeader
+              columnKey="opened"
+              sort={sort}
+              align="right"
+              onSort={toggleSort}
+            />
+            <SortHeader
+              columnKey="lastFailed"
+              sort={sort}
+              align="right"
+              onSort={toggleSort}
+            />
             <span />
           </div>
           <div className="divide-y divide-zinc-100 dark:divide-zinc-800/70">


### PR DESCRIPTION
## Summary

Follow-up to #109. The Failures table's column headers are now sort buttons.

- **Job, Failures, Opened, Last failed** headers sort the list. The first click opens a column in its natural direction (Job A→Z; Failures, Opened and Last failed with the largest or most recent on top). Clicking the active column flips it. Switching columns resets to that column's default rather than carrying the direction over.
- **Indicator.** The active header is darker and shows an arrow for the direction. Inactive headers reveal a faint arrow on hover so they read as clickable.
- **Default order is unchanged.** With no column selected the list keeps the lifecycle order the API returns: open first, most recent activity first.
- **Job sort uses the displayed name.** Raw Buildkite names start with a vendor shortcode (`:amd:`, `:nvidia:`) that the UI strips, so sorting the raw string would have grouped by vendor. Sorting is case-insensitive and numeric-aware, so "Shard 2" sorts before "Shard 10".
- **Phones.** The header row is hidden below `sm`, so the toolbar gains a compact "Default order / Job A→Z / Most failures / …" select there, bound to the same state.
- The two time columns widen from 5.5rem to 6.5rem so "Last failed" plus its arrow fits on one line.

Sorting is a pure exported function (`sortMainCiAlerts`) plus a `nextSort` helper for the click behaviour, both unit-tested.

## Test plan

- [x] `npm test` (60 passing; new tests cover each column in both directions, the shortcode-insensitive and numeric job order, the click cycle, and that the header cells render as sort buttons)
- [x] `npx eslint` on changed files
- [x] Verified in the dev server against production data: sorted by Failures descending then ascending, by Job (B200 → DGX → H200, shards in numeric order), header stays on one line at 1440px, mobile select renders at 375px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
