### PR TITLE
alerting: route each alert path to its own Slack channel

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -5,8 +5,12 @@ DATABRICKS_WAREHOUSE_ID=your-sql-warehouse-id
 
 # Slack (requires bot with chat:write and reactions:write scopes)
 SLACK_BOT_TOKEN=xoxb-your-bot-token
-SLACK_CHANNEL_ID=C0123456789
+# Per-path alert channels (values also live in secrets manager):
 SLACK_CI_NOTIFICATIONS_CHANNEL=C0123456789
+SLACK_CI_FAST_FAILURE_ALERT_CHANNEL=C0123456789
+SLACK_CI_INFRA_ALERT_CHANNEL=C0123456789
+# Legacy shared fallback used when a per-path channel is unset:
+SLACK_CHANNEL_ID=C0123456789
 
 # Supabase Postgres (required for five-minute queue snapshots)
 DATABASE_URL=postgres://user:pass@host:5432/dbname

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Open http://localhost:3000.
 | `OTEL_MAX_REQUEST_BYTES` | Optional OTLP request limit; defaults to 4 MiB |
 | `OTEL_ENDPOINT` | Buildkite notification-service base URL; defaults operationally to `https://ci.vllm.ai/api/otel` |
 | `OTEL_BUILDKITE_OIDC_AUDIENCE`, `OTEL_BUILDKITE_OIDC_ORGANIZATION`, `OTEL_BUILDKITE_OIDC_PIPELINE`, `OTEL_BUILDKITE_OIDC_BRANCH`, `OTEL_BUILDKITE_OIDC_TREATMENT_BRANCH` | Optional restrictions for short-lived Buildkite job tokens; defaults to the production vLLM main pipeline plus API-triggered `khluu/otel` treatment builds |
-| `SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID` | Slack bot for queue-depth alerts (`chat:write`, `reactions:write`) |
+| `SLACK_BOT_TOKEN` | Slack bot for queue-depth alerts (`chat:write`, `reactions:write`) |
+| `SLACK_CI_NOTIFICATIONS_CHANNEL`, `SLACK_CI_FAST_FAILURE_ALERT_CHANNEL`, `SLACK_CI_INFRA_ALERT_CHANNEL` | Per-path Slack channels for Full CI, Fast CI, and infra/queue alerts; `SLACK_CHANNEL_ID` is the legacy shared fallback when a per-path channel is unset |
 | `CRON_SECRET` | Optional shared secret required by Vercel cron handlers |
 
 The dashboard assumes a warehouse schema with tables under `vllm_data_warehouse.buildkite.*` (builds, jobs, agent query rules) and `vllm_data_warehouse.default.vllm_perf_data_ingest` for benchmarks. Adapt the queries in `src/app/api/**/route.ts` if your schema differs.

--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -37,7 +37,7 @@ from typing import Any, Protocol, cast
 from zoneinfo import ZoneInfo
 
 from alerting.commands import ScheduledCommand, SCHEMA_VERSION
-from alerting.fast_ci import slack_channel
+from alerting.fast_ci import full_ci_slack_channel
 from alerting.full_ci import FullCIJobOutcome, FullCIRun
 from alerting.ports import (
     AlertPath,
@@ -684,7 +684,7 @@ class FullCIAnalysisHandler:
                     alert_path=AlertPath.FULL_CI,
                     delivery_mode=self._delivery_mode,
                     destination_mode=DestinationMode.BOT_TOKEN,
-                    destination=slack_channel(),
+                    destination=full_ci_slack_channel(),
                     payload={"text": outputs.report_text},
                 ),
                 now=self._clock.now(),

--- a/alerting/fast_ci.py
+++ b/alerting/fast_ci.py
@@ -31,15 +31,30 @@ INITIAL_LOOKBACK = timedelta(minutes=30)
 SAFETY_OVERLAP = timedelta(minutes=15)
 MAX_DURATION_SECONDS = 30
 SLACK_BATCH_SIZE = 8
-# Both alert paths deliver through the Slack bot token. The channel comes from
-# SLACK_CHANNEL_ID so a channel move is a secret edit, not a code change.
+# Both alert paths deliver through the Slack bot token. Channels follow the
+# per-path convention (values live in secrets manager):
+# SLACK_CI_NOTIFICATIONS_CHANNEL (Full CI), SLACK_CI_FAST_FAILURE_ALERT_CHANNEL
+# (Fast CI), SLACK_CI_INFRA_ALERT_CHANNEL (infra/queue alerts).
+# SLACK_CHANNEL_ID is the legacy shared fallback so a channel move stays a
+# secret edit, not a code change.
 ALERTS_SLACK_CHANNEL = "C0ABTNM9L5U"
 STALE_NOTIFICATION_AGE = timedelta(minutes=30)
 
 
+def _channel(primary_env: str) -> str:
+    return os.environ.get(
+        primary_env, os.environ.get("SLACK_CHANNEL_ID", ALERTS_SLACK_CHANNEL)
+    )
+
+
 def slack_channel() -> str:
-    """The channel alert intents post to; SLACK_CHANNEL_ID wins when set."""
-    return os.environ.get("SLACK_CHANNEL_ID", ALERTS_SLACK_CHANNEL)
+    """The channel Fast CI alert intents post to."""
+    return _channel("SLACK_CI_FAST_FAILURE_ALERT_CHANNEL")
+
+
+def full_ci_slack_channel() -> str:
+    """The channel Full CI report intents post to."""
+    return _channel("SLACK_CI_NOTIFICATIONS_CHANNEL")
 
 
 class FastFailureState(StrEnum):

--- a/alerting/tests/test_fast_ci.py
+++ b/alerting/tests/test_fast_ci.py
@@ -432,7 +432,22 @@ def test_fast_failure_event_has_no_resolution_lifecycle() -> None:
 def test_slack_channel_env_override_wins(monkeypatch: Any) -> None:
     import alerting.fast_ci as fast_ci
 
-    monkeypatch.delenv("SLACK_CHANNEL_ID", raising=False)
+    for var in (
+        "SLACK_CI_FAST_FAILURE_ALERT_CHANNEL",
+        "SLACK_CI_NOTIFICATIONS_CHANNEL",
+        "SLACK_CHANNEL_ID",
+    ):
+        monkeypatch.delenv(var, raising=False)
     assert fast_ci.slack_channel() == fast_ci.ALERTS_SLACK_CHANNEL
+    assert fast_ci.full_ci_slack_channel() == fast_ci.ALERTS_SLACK_CHANNEL
+
+    # Legacy shared env var still applies to both paths.
     monkeypatch.setenv("SLACK_CHANNEL_ID", "C0NEWCHANNEL")
     assert fast_ci.slack_channel() == "C0NEWCHANNEL"
+    assert fast_ci.full_ci_slack_channel() == "C0NEWCHANNEL"
+
+    # Per-path channels win over the legacy fallback and stay independent.
+    monkeypatch.setenv("SLACK_CI_FAST_FAILURE_ALERT_CHANNEL", "C0FASTALERT")
+    monkeypatch.setenv("SLACK_CI_NOTIFICATIONS_CHANNEL", "C0CINOTIF")
+    assert fast_ci.slack_channel() == "C0FASTALERT"
+    assert fast_ci.full_ci_slack_channel() == "C0CINOTIF"

--- a/src/app/api/alerts/queue/route.ts
+++ b/src/app/api/alerts/queue/route.ts
@@ -108,9 +108,15 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  if (!process.env.SLACK_BOT_TOKEN || !process.env.SLACK_CHANNEL_ID) {
+  if (
+    !process.env.SLACK_BOT_TOKEN ||
+    (!process.env.SLACK_CI_INFRA_ALERT_CHANNEL && !process.env.SLACK_CHANNEL_ID)
+  ) {
     return NextResponse.json(
-      { error: "SLACK_BOT_TOKEN and SLACK_CHANNEL_ID not configured" },
+      {
+        error:
+          "SLACK_BOT_TOKEN and SLACK_CI_INFRA_ALERT_CHANNEL (or legacy SLACK_CHANNEL_ID) not configured",
+      },
       { status: 500 },
     );
   }

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -6,9 +6,15 @@ interface SlackPostResult {
 
 function getConfig() {
   const token = process.env.SLACK_BOT_TOKEN;
-  const channel = process.env.SLACK_CHANNEL_ID;
+  // Per-path channel convention (values live in secrets manager):
+  // SLACK_CI_INFRA_ALERT_CHANNEL covers infrastructure/queue alerts;
+  // SLACK_CHANNEL_ID is the legacy shared fallback.
+  const channel =
+    process.env.SLACK_CI_INFRA_ALERT_CHANNEL ?? process.env.SLACK_CHANNEL_ID;
   if (!token || !channel) {
-    throw new Error("SLACK_BOT_TOKEN and SLACK_CHANNEL_ID must be set");
+    throw new Error(
+      "SLACK_BOT_TOKEN and SLACK_CI_INFRA_ALERT_CHANNEL (or legacy SLACK_CHANNEL_ID) must be set",
+    );
   }
   return { token, channel };
 }


### PR DESCRIPTION
## Why

Fast CI failure alerts currently post to the shared channel (in practice `#ci-notifications`) because every alert path resolves its channel through the single `SLACK_CHANNEL_ID` env var. This routes each path to its own secrets-manager channel:

- **Fast CI** → `SLACK_CI_FAST_FAILURE_ALERT_CHANNEL`
- **Full CI** reports → `SLACK_CI_NOTIFICATIONS_CHANNEL`
- **Queue-depth alerts** (dashboard) → `SLACK_CI_INFRA_ALERT_CHANNEL`
- `SLACK_CHANNEL_ID` stays as the fallback everywhere, so behavior is unchanged until the per-path secrets are set — a channel move remains a secret edit, not a code change.

Merge this one **first**; it is independent of the GPU infra-health stack.

## Test plan

- `alerting` pytest: 163 passed (updated channel-resolution tests cover per-path override, legacy fallback, and path independence)
- `npm test`: 56/56, `npm run lint` clean

## Deploy notes

Set the three channel IDs in secrets manager; until then the fallback preserves current routing.