### PR TITLE
gpu page: host health table with CPU/RAM/Disk bars and drill-down

### DIFF
--- a/src/app/api/gpu/latest/route.ts
+++ b/src/app/api/gpu/latest/route.ts
@@ -1,11 +1,15 @@
 import { NextResponse } from "next/server";
 import { queryGpuLatest } from "@/lib/gpu-data";
+import { queryHostLatest } from "@/lib/gpu-host-data";
 
 export async function GET() {
   try {
-    const latest = await queryGpuLatest();
+    const [latest, hosts] = await Promise.all([
+      queryGpuLatest(),
+      queryHostLatest(),
+    ]);
     return NextResponse.json(
-      { latest, checked_at: new Date().toISOString() },
+      { latest, hosts, checked_at: new Date().toISOString() },
       {
         headers: {
           "Cache-Control": "public, max-age=0, must-revalidate",

--- a/src/app/gpu/gpu-dashboard.tsx
+++ b/src/app/gpu/gpu-dashboard.tsx
@@ -4,14 +4,16 @@ import dynamic from "next/dynamic";
 import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import { SearchableSelect } from "@/components/searchable-select";
+import { GpuHostTable } from "@/components/gpu-host-table";
 import type { GpuChartMode } from "@/components/gpu-util-chart";
 import type {
   GpuHistoryResponse,
   GpuLatest,
   GpuLatestResponse,
   GpuOverviewPoint,
+  HostLatest,
 } from "@/lib/gpu-types";
-import { buildHostRows, hostReportStatus } from "@/lib/gpu-host-view";
+import { buildHostRows } from "@/lib/gpu-host-view";
 
 const GpuMemChart = dynamic(
   () => import("@/components/gpu-util-chart").then((module) => module.GpuMemChart),
@@ -57,21 +59,6 @@ function percentile(values: number[], quantile: number): number {
   return sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
 }
 
-function formatMemory(mb: number): string {
-  if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
-  return `${Math.round(mb)} MB`;
-}
-
-function formatTemperature(celsius: number | null): string {
-  return celsius == null ? "—" : `${Math.round(celsius)}°C`;
-}
-
-function formatPower(drawW: number | null, limitW: number | null): string {
-  if (drawW == null) return "—";
-  const draw = `${Math.round(drawW)} W`;
-  return limitW == null ? draw : `${draw} / ${Math.round(limitW)} W`;
-}
-
 function formatCapacityGb(gb: number): string {
   if (gb >= 1024) return `${(gb / 1024).toFixed(1)} TB`;
   return `${Math.round(gb)} GB`;
@@ -105,6 +92,7 @@ function gpuType(name: string | null): string {
 interface GpuDashboardProps {
   initialOverview: GpuOverviewPoint[];
   initialLatest: GpuLatest[];
+  initialHosts: HostLatest[];
   initialLatestCheckedAt: string;
   initialNow: number;
 }
@@ -112,6 +100,7 @@ interface GpuDashboardProps {
 export function GpuDashboard({
   initialOverview,
   initialLatest,
+  initialHosts,
   initialLatestCheckedAt,
   initialNow,
 }: GpuDashboardProps) {
@@ -139,6 +128,7 @@ export function GpuDashboard({
   } = useSWR<GpuLatestResponse>("/api/gpu/latest", fetcher, {
     fallbackData: {
       latest: initialLatest,
+      hosts: initialHosts,
       checked_at: initialLatestCheckedAt,
     },
     // Server-rendered data makes the page useful immediately; this request is
@@ -168,6 +158,7 @@ export function GpuDashboard({
   });
 
   const latest = latestData?.latest ?? initialLatest;
+  const hosts = latestData?.hosts ?? initialHosts;
   const latestCheckedAt = latestData?.checked_at ?? initialLatestCheckedAt;
   const snapshots = needsRawHistory
     ? historyData?.snapshots ?? EMPTY_SNAPSHOTS
@@ -573,160 +564,8 @@ export function GpuDashboard({
         />
       </div>
 
-      {/* Host summary table */}
-      <div className="min-w-0 overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
-        <div className="flex min-h-14 items-center justify-between gap-4 border-b border-zinc-200 px-5 py-3 dark:border-zinc-800 sm:px-6">
-          <h2 className="text-lg font-semibold tracking-[-0.02em]">Host Summary</h2>
-          <span className="text-sm tabular-nums text-zinc-500 dark:text-zinc-400">
-            {hostRows.length} hosts
-          </span>
-        </div>
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[1100px] text-sm">
-            <thead>
-              <tr className="border-b border-zinc-200 text-left text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
-                <th className="px-5 py-3 font-medium sm:px-6">Host</th>
-                <th className="px-5 py-3 font-medium sm:px-6">GPU Type</th>
-                <th className="px-5 py-3 font-medium sm:px-6">Memory</th>
-                <th className="px-5 py-3 font-medium sm:px-6">GPU Utilization</th>
-                <th className="px-5 py-3 font-medium sm:px-6">GPU Temp</th>
-                <th className="px-5 py-3 font-medium sm:px-6">Power</th>
-                <th className="px-5 py-3 font-medium sm:px-6">Per-GPU Memory</th>
-                <th className="px-5 py-3 font-medium sm:px-6">Last Seen</th>
-              </tr>
-            </thead>
-            <tbody>
-              {hostRows.map((h) => {
-                const memPct = h.memTotalMb > 0 ? Math.round((h.memUsedMb / h.memTotalMb) * 100) : 0;
-                const gpuUtil = h.gpuCount > 0 ? Math.round(h.gpuUtil / h.gpuCount) : 0;
-                const ago = now > 0
-                  ? Math.round((now - new Date(h.lastSeen).getTime()) / 60_000)
-                  : 0;
-                const status = now > 0 ? hostReportStatus(ago) : "fresh";
-                const unreporting = status === "unreporting";
-                const stale = status !== "fresh";
-                return (
-                  <tr
-                    key={h.hostname}
-                    className={`border-b border-zinc-100 last:border-0 dark:border-zinc-800/50 ${stale ? "opacity-50" : ""}`}
-                  >
-                    <td className="px-5 py-3.5 font-medium sm:px-6">
-                      {h.hostname}
-                      {unreporting ? (
-                        <span className="ml-2 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/40 dark:text-red-400">
-                          Unreporting
-                        </span>
-                      ) : status === "stale" ? (
-                        <span className="ml-2 rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-400">
-                          Stale
-                        </span>
-                      ) : null}
-                    </td>
-                    <td className="px-5 py-3.5 sm:px-6">{h.gpuType}</td>
-                    <td className="px-5 py-3.5 sm:px-6">
-                      <span className={memPct > 90 ? "font-medium text-red-600 dark:text-red-400" : ""}>
-                        {formatMemory(h.memUsedMb)}
-                      </span>
-                      <span className="text-zinc-400"> / {formatMemory(h.memTotalMb)}</span>
-                      <span className="ml-1 text-xs text-zinc-400">({memPct}%)</span>
-                    </td>
-                    <td className="px-5 py-3.5 sm:px-6">
-                      <div className="flex min-w-28 items-center gap-2">
-                        <span className="w-10 tabular-nums">{gpuUtil}%</span>
-                        <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
-                          <div
-                            className="h-full rounded-full bg-emerald-500 dark:bg-emerald-400"
-                            style={{ width: `${Math.min(Math.max(gpuUtil, 0), 100)}%` }}
-                          />
-                        </div>
-                      </div>
-                    </td>
-                    <td className="whitespace-nowrap px-5 py-3.5 tabular-nums sm:px-6">
-                      <span
-                        className={
-                          h.maxTemperatureC != null && h.maxTemperatureC >= 85
-                            ? "font-medium text-red-600 dark:text-red-400"
-                            : h.maxTemperatureC != null && h.maxTemperatureC >= 75
-                            ? "font-medium text-yellow-600 dark:text-yellow-400"
-                            : ""
-                        }
-                      >
-                        {formatTemperature(h.maxTemperatureC)}
-                      </span>
-                      {h.maxTemperatureC != null && (
-                        <span className="ml-1 text-xs text-zinc-400">max</span>
-                      )}
-                    </td>
-                    <td className="whitespace-nowrap px-5 py-3.5 tabular-nums text-zinc-500 sm:px-6 dark:text-zinc-400">
-                      {formatPower(h.powerDrawW, h.powerLimitW)}
-                    </td>
-                    <td className="px-5 py-3.5 sm:px-6">
-                      <div className="flex items-end gap-1.5" style={{ height: 40 }}>
-                        {h.gpus.map((gpu) => {
-                          const pct = gpu.memTotalMb > 0 ? Math.round((gpu.memUsedMb / gpu.memTotalMb) * 100) : 0;
-                          const barColor = pct > 90
-                            ? "bg-red-500 dark:bg-red-400"
-                            : pct > 60
-                            ? "bg-blue-500 dark:bg-blue-400"
-                            : "bg-blue-400 dark:bg-blue-500";
-                          return (
-                            <div
-                              key={gpu.index}
-                              className="group relative flex flex-col items-center"
-                            >
-                              <div
-                                className="relative w-3 rounded-sm bg-zinc-100 dark:bg-zinc-800"
-                                style={{ height: 40 }}
-                              >
-                                <div
-                                  className={`absolute bottom-0 w-full rounded-sm ${barColor}`}
-                                  style={{ height: `${Math.max(pct, 2)}%` }}
-                                />
-                              </div>
-                              <div className="pointer-events-none absolute -top-14 left-1/2 z-50 hidden -translate-x-1/2 whitespace-nowrap rounded border border-zinc-200 bg-white px-2 py-1 text-xs shadow-lg group-hover:block dark:border-zinc-700 dark:bg-zinc-900">
-                                <span className="font-medium">GPU {gpu.index}</span>
-                                <span className="ml-1 text-zinc-400">
-                                  {formatMemory(gpu.memUsedMb)} / {formatMemory(gpu.memTotalMb)} ({pct}%)
-                                </span>
-                                <span className="block text-zinc-400">
-                                  GPU utilization: {Math.round(gpu.gpuUtil)}%
-                                </span>
-                                <span className="block text-zinc-400">
-                                  Temp: {formatTemperature(gpu.temperatureC)}
-                                  {" · "}
-                                  Power: {formatPower(gpu.powerDrawW, gpu.powerLimitW)}
-                                </span>
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </td>
-                    <td
-                      className={`whitespace-nowrap px-5 py-3.5 sm:px-6 ${
-                        unreporting
-                          ? "text-red-600 dark:text-red-400"
-                          : stale
-                          ? "text-yellow-600 dark:text-yellow-400"
-                          : "text-zinc-500 dark:text-zinc-400"
-                      }`}
-                    >
-                      {stale ? formatAgo(ago) : "just now"}
-                    </td>
-                  </tr>
-                );
-              })}
-              {hostRows.length === 0 && (
-                <tr>
-                  <td colSpan={8} className="px-5 py-12 text-center text-zinc-400">
-                    No GPU data found. Deploy the reporting script to start collecting metrics.
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </div>
+      {/* Host summary table with host-health metrics and drill-down */}
+      <GpuHostTable hostRows={hostRows} hosts={hosts} now={now} />
     </div>
   );
 }

--- a/src/app/gpu/page.tsx
+++ b/src/app/gpu/page.tsx
@@ -1,12 +1,13 @@
 import { GpuDashboard } from "@/app/gpu/gpu-dashboard";
 import { getInitialGpuData } from "@/lib/gpu-data";
-import type { GpuLatest, GpuOverviewPoint } from "@/lib/gpu-types";
+import type { GpuLatest, GpuOverviewPoint, HostLatest } from "@/lib/gpu-types";
 
 export const dynamic = "force-dynamic";
 
 export default async function GpuPage() {
   let initialOverview: GpuOverviewPoint[] = [];
   let initialLatest: GpuLatest[] = [];
+  let initialHosts: HostLatest[] = [];
   let initialLatestCheckedAt = "";
   let initialNow = 0;
 
@@ -14,6 +15,7 @@ export default async function GpuPage() {
     const initial = await getInitialGpuData();
     initialOverview = initial.overview;
     initialLatest = initial.latest;
+    initialHosts = initial.hosts;
     initialLatestCheckedAt = initial.latestCheckedAt;
     initialNow = initial.asOf;
   } catch (error) {
@@ -24,6 +26,7 @@ export default async function GpuPage() {
     <GpuDashboard
       initialOverview={initialOverview}
       initialLatest={initialLatest}
+      initialHosts={initialHosts}
       initialLatestCheckedAt={initialLatestCheckedAt}
       initialNow={initialNow}
     />

--- a/src/components/gpu-host-table.test.ts
+++ b/src/components/gpu-host-table.test.ts
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { GpuHostTable } from "./gpu-host-table";
+import type { HostLatest } from "../lib/gpu-types";
+import type { NormalizedDiskMetric } from "../lib/gpu-report";
+import type { HostRow } from "../lib/gpu-host-view";
+
+const NOW = new Date("2026-09-02T19:05:00.000Z").getTime();
+
+function hostRow(overrides: Partial<HostRow> = {}): HostRow {
+  return {
+    hostname: "h200-ci-1",
+    gpuType: "H200",
+    gpuCount: 2,
+    gpuUtil: 120,
+    memUsedMb: 2000,
+    memTotalMb: 287542,
+    maxTemperatureC: 61,
+    powerDrawW: 300,
+    powerLimitW: 1400,
+    lastSeen: "2026-09-02T19:04:00.000Z",
+    gpus: [
+      {
+        index: 0,
+        gpuUtil: 55,
+        memUsedMb: 1000,
+        memTotalMb: 143771,
+        temperatureC: 61,
+        powerDrawW: 300,
+        powerLimitW: 700,
+      },
+      {
+        index: 1,
+        gpuUtil: 65,
+        memUsedMb: 1000,
+        memTotalMb: 143771,
+        temperatureC: 58,
+        powerDrawW: null,
+        powerLimitW: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function disk(overrides: Partial<NormalizedDiskMetric> = {}): NormalizedDiskMetric {
+  return {
+    mount_point: "/",
+    device: "/dev/nvme0n1p2",
+    fstype: "ext4",
+    role: "system",
+    used_bytes: 40 * 1024 ** 3,
+    total_bytes: 100 * 1024 ** 3,
+    error: null,
+    ...overrides,
+  };
+}
+
+function hostLatest(overrides: Partial<HostLatest> = {}): HostLatest {
+  return {
+    hostname: "h200-ci-1",
+    cpu_util: 42,
+    cpu_count: 64,
+    ram_used_bytes: 96 * 1024 ** 3,
+    ram_total_bytes: 256 * 1024 ** 3,
+    ram_available_bytes: 160 * 1024 ** 3,
+    disks: [disk()],
+    reporter_status: "ok",
+    last_error: null,
+    node_conditions: null,
+    reported_at: "2026-09-02T19:04:30.000Z",
+    ...overrides,
+  };
+}
+
+function render(
+  hostRows: HostRow[],
+  hosts: HostLatest[],
+  defaultExpanded: string | null = null,
+): string {
+  return renderToStaticMarkup(
+    createElement(GpuHostTable, {
+      hostRows,
+      hosts,
+      now: NOW,
+      defaultExpanded,
+    }),
+  );
+}
+
+test("a fresh host renders a health dot, hostname, and metric bars", () => {
+  const markup = render([hostRow()], [hostLatest()]);
+
+  assert.match(markup, /aria-label="Status: fresh"/);
+  assert.match(markup, /h200-ci-1/);
+  assert.doesNotMatch(markup, /Stale|Unreporting/);
+  // CPU 42%, RAM 37.5% -> 38%, disk 40%.
+  assert.match(markup, />42%</);
+  assert.match(markup, />38%</);
+  assert.match(markup, />40%</);
+});
+
+test("stale and unreporting hosts keep their badges and dot colors", () => {
+  const markup = render(
+    [
+      hostRow({
+        hostname: "h200-ci-stale",
+        lastSeen: "2026-09-02T18:58:00.000Z",
+      }),
+      hostRow({
+        hostname: "h200-ci-dead",
+        lastSeen: "2026-09-02T18:40:00.000Z",
+      }),
+    ],
+    [],
+  );
+
+  assert.match(markup, /aria-label="Status: stale"/);
+  assert.match(markup, /aria-label="Status: unreporting"/);
+  assert.match(markup, />Stale</);
+  assert.match(markup, />Unreporting</);
+  assert.match(markup, />7m ago</);
+  assert.match(markup, />25m ago</);
+});
+
+test("a host without host metrics shows empty cells and a graceful drill-down", () => {
+  const markup = render([hostRow()], [], "h200-ci-1");
+
+  // CPU, RAM, and Disk cells all render the em-dash empty state.
+  const dashes = markup.match(/>—</g) ?? [];
+  assert.ok(dashes.length >= 3, `expected >= 3 empty cells, got ${dashes.length}`);
+  assert.match(markup, /No host-level metrics reported yet/);
+  // GPU detail still renders in the drill-down.
+  assert.match(markup, /GPU 0/);
+  assert.match(markup, /No disk metrics reported/);
+});
+
+test("the disk cell shows the worst alertable mount, never an 'other' mount", () => {
+  const markup = render(
+    [hostRow()],
+    [
+      hostLatest({
+        disks: [
+          disk({
+            mount_point: "/dev/shm",
+            device: "tmpfs",
+            fstype: "tmpfs",
+            role: "other",
+            used_bytes: 99 * 1024 ** 3,
+          }),
+          disk({
+            mount_point: "/data",
+            device: "/dev/nvme1n1",
+            role: "data",
+            used_bytes: 60 * 1024 ** 3,
+          }),
+        ],
+      }),
+    ],
+  );
+
+  // 60% (the data mount) drives the cell, not the 99% tmpfs mount.
+  assert.match(markup, />60%</);
+  assert.doesNotMatch(markup, />99%</);
+});
+
+test("tmpfs mounts are labeled as RAM-backed in the drill-down", () => {
+  const markup = render(
+    [hostRow()],
+    [
+      hostLatest({
+        disks: [
+          disk({
+            mount_point: "/dev/shm",
+            device: "tmpfs",
+            fstype: "tmpfs",
+            role: "other",
+            used_bytes: 10 * 1024 ** 3,
+          }),
+        ],
+      }),
+    ],
+    "h200-ci-1",
+  );
+
+  assert.match(markup, /\/dev\/shm/);
+  assert.match(markup, /RAM-backed/);
+});
+
+test("the drill-down surfaces a degraded reporter and its last error", () => {
+  const markup = render(
+    [hostRow()],
+    [
+      hostLatest({
+        reporter_status: "degraded",
+        last_error: "nvidia-smi timed out after 30s",
+      }),
+    ],
+    "h200-ci-1",
+  );
+
+  assert.match(markup, /reporter: degraded/);
+  assert.match(markup, /last error: nvidia-smi timed out after 30s/);
+});
+
+test("a cordoned-but-Ready node is visibly marked as both", () => {
+  const markup = render(
+    [hostRow()],
+    [
+      hostLatest({
+        node_conditions: {
+          ready: true,
+          disk_pressure: true,
+          memory_pressure: false,
+          pid_pressure: false,
+          unschedulable: true,
+        },
+      }),
+    ],
+    "h200-ci-1",
+  );
+
+  assert.match(markup, />Ready</);
+  assert.match(markup, />Cordoned</);
+  assert.match(markup, />DiskPressure</);
+  assert.doesNotMatch(markup, /MemoryPressure/);
+});
+
+test("a NotReady node renders the NotReady chip", () => {
+  const markup = render(
+    [hostRow()],
+    [
+      hostLatest({
+        node_conditions: {
+          ready: false,
+          disk_pressure: false,
+          memory_pressure: true,
+          pid_pressure: false,
+          unschedulable: false,
+        },
+      }),
+    ],
+    "h200-ci-1",
+  );
+
+  assert.match(markup, />NotReady</);
+  assert.match(markup, />MemoryPressure</);
+  assert.doesNotMatch(markup, />Cordoned</);
+});
+
+test("mounts with a per-mount error show the error instead of a bar", () => {
+  const markup = render(
+    [hostRow()],
+    [
+      hostLatest({
+        disks: [
+          disk({
+            mount_point: "/mnt/ephemeral",
+            device: "/dev/nvme2n1",
+            role: "workspace",
+            used_bytes: null,
+            total_bytes: null,
+            error: "i/o error while statfs",
+          }),
+        ],
+      }),
+    ],
+    "h200-ci-1",
+  );
+
+  assert.match(markup, /\/mnt\/ephemeral/);
+  assert.match(markup, /i\/o error while statfs/);
+});
+
+test("the drill-down lists per-GPU utilization, memory, and temperature", () => {
+  const markup = render([hostRow()], [hostLatest()], "h200-ci-1");
+
+  assert.match(markup, /GPU 0/);
+  assert.match(markup, /GPU 1/);
+  assert.match(markup, />55%</);
+  assert.match(markup, />65%</);
+  assert.match(markup, /61°C/);
+});
+
+test("an empty roster keeps the deployment hint", () => {
+  const markup = render([], []);
+
+  assert.match(markup, /No GPU data found/);
+});

--- a/src/components/gpu-host-table.tsx
+++ b/src/components/gpu-host-table.tsx
@@ -1,0 +1,538 @@
+"use client";
+
+import { Fragment, useMemo, useState } from "react";
+import type { HostLatest } from "@/lib/gpu-types";
+import type {
+  NormalizedDiskMetric,
+  NormalizedNodeConditions,
+} from "@/lib/gpu-report";
+import {
+  hostReportStatus,
+  indexHostsByName,
+  isRamBackedMount,
+  worstAlertableDisk,
+  type HostReportStatus,
+  type HostRow,
+} from "@/lib/gpu-host-view";
+
+const COLUMN_COUNT = 9;
+
+function formatMemory(mb: number): string {
+  if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
+  return `${Math.round(mb)} MB`;
+}
+
+function formatTemperature(celsius: number | null): string {
+  return celsius == null ? "—" : `${Math.round(celsius)}°C`;
+}
+
+function formatPower(drawW: number | null, limitW: number | null): string {
+  if (drawW == null) return "—";
+  const draw = `${Math.round(drawW)} W`;
+  return limitW == null ? draw : `${draw} / ${Math.round(limitW)} W`;
+}
+
+function formatBytes(bytes: number): string {
+  const gib = bytes / 1024 ** 3;
+  if (gib >= 1024) return `${(gib / 1024).toFixed(1)} TB`;
+  if (gib >= 1) return `${Math.round(gib)} GB`;
+  return `${Math.round(bytes / 1024 ** 2)} MB`;
+}
+
+function formatAgo(minutes: number): string {
+  if (minutes < 60) return `${minutes}m ago`;
+  if (minutes < 1440) return `${Math.round(minutes / 60)}h ago`;
+  return `${Math.round(minutes / 1440)}d ago`;
+}
+
+function HealthDot({ status }: { status: HostReportStatus }) {
+  const color =
+    status === "unreporting"
+      ? "bg-red-500"
+      : status === "stale"
+        ? "bg-amber-500"
+        : "bg-emerald-500";
+  return (
+    <span
+      className={`inline-block h-2.5 w-2.5 rounded-full ${color}`}
+      title={status}
+      aria-label={`Status: ${status}`}
+    />
+  );
+}
+
+function Meter({
+  value,
+  barClass,
+}: {
+  value: number;
+  barClass?: string;
+}) {
+  const pct = Math.min(Math.max(value, 0), 100);
+  return (
+    <div className="flex min-w-28 items-center gap-2">
+      <span className="w-10 tabular-nums">{Math.round(pct)}%</span>
+      <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+        <div
+          className={`h-full rounded-full ${barClass ?? "bg-emerald-500 dark:bg-emerald-400"}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function EmptyMetric() {
+  return <span className="text-zinc-400">—</span>;
+}
+
+function RamBackedBadge() {
+  return (
+    <span className="ml-1 rounded bg-violet-100 px-1 py-0.5 text-[10px] font-medium whitespace-nowrap text-violet-700 dark:bg-violet-900/40 dark:text-violet-400">
+      RAM-backed
+    </span>
+  );
+}
+
+function mountLabel(disk: NormalizedDiskMetric): string {
+  return disk.mount_point ?? disk.device ?? "unknown";
+}
+
+function DiskCell({ host }: { host: HostLatest | undefined }) {
+  const worst = worstAlertableDisk(host?.disks ?? null);
+  if (!worst) return <EmptyMetric />;
+  const { disk, usedPct } = worst;
+  return (
+    <div className="flex items-center gap-2">
+      <Meter
+        value={usedPct}
+        barClass={
+          usedPct > 90
+            ? "bg-red-500 dark:bg-red-400"
+            : "bg-blue-500 dark:bg-blue-400"
+        }
+      />
+      <span className="font-mono text-xs whitespace-nowrap text-zinc-400">
+        {mountLabel(disk)}
+        {isRamBackedMount(disk) && <RamBackedBadge />}
+      </span>
+    </div>
+  );
+}
+
+function NodeConditionChips({
+  conditions,
+}: {
+  conditions: NormalizedNodeConditions;
+}) {
+  return (
+    <>
+      {conditions.ready === null ? (
+        <span className="rounded-full bg-zinc-100 px-2 py-0.5 font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+          Ready: unknown
+        </span>
+      ) : conditions.ready ? (
+        <span className="rounded-full bg-emerald-100 px-2 py-0.5 font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400">
+          Ready
+        </span>
+      ) : (
+        <span className="rounded-full bg-red-100 px-2 py-0.5 font-medium text-red-700 dark:bg-red-900/40 dark:text-red-400">
+          NotReady
+        </span>
+      )}
+      {conditions.disk_pressure && (
+        <span className="rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+          DiskPressure
+        </span>
+      )}
+      {conditions.memory_pressure && (
+        <span className="rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+          MemoryPressure
+        </span>
+      )}
+      {conditions.pid_pressure && (
+        <span className="rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+          PIDPressure
+        </span>
+      )}
+      {conditions.unschedulable && (
+        <span className="rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+          Cordoned
+        </span>
+      )}
+    </>
+  );
+}
+
+function DiskDetail({ disks }: { disks: NormalizedDiskMetric[] | null }) {
+  if (!disks || disks.length === 0) {
+    return (
+      <p className="mt-1 text-xs text-zinc-400">No disk metrics reported.</p>
+    );
+  }
+  return (
+    <div className="mt-1 space-y-1.5">
+      {disks.map((disk, index) => {
+        const usedPct =
+          disk.used_bytes != null &&
+          disk.total_bytes != null &&
+          disk.total_bytes > 0
+            ? (disk.used_bytes / disk.total_bytes) * 100
+            : null;
+        const detail = [disk.device, disk.fstype, disk.role]
+          .filter(Boolean)
+          .join(" · ");
+        return (
+          <div key={`${mountLabel(disk)}-${index}`}>
+            <div className="flex items-center gap-2">
+              <span className="w-28 truncate font-mono text-xs text-zinc-500 dark:text-zinc-400">
+                {mountLabel(disk)}
+                {isRamBackedMount(disk) && <RamBackedBadge />}
+              </span>
+              {usedPct == null ? (
+                <span className="text-xs text-red-600 dark:text-red-400">
+                  {disk.error ?? "no usage reported"}
+                </span>
+              ) : (
+                <>
+                  <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+                    <div
+                      className={`h-full rounded-full ${
+                        usedPct > 90
+                          ? "bg-red-500 dark:bg-red-400"
+                          : "bg-blue-500 dark:bg-blue-400"
+                      }`}
+                      style={{ width: `${Math.min(usedPct, 100)}%` }}
+                    />
+                  </div>
+                  <span className="w-28 tabular-nums text-xs text-zinc-500 dark:text-zinc-400">
+                    {Math.round(usedPct)}% of {formatBytes(disk.total_bytes!)}
+                  </span>
+                </>
+              )}
+            </div>
+            <div className="mt-0.5 pl-0 text-[11px] text-zinc-400">{detail}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function HostDrillDown({ row, host }: { row: HostRow; host: HostLatest | undefined }) {
+  return (
+    <tr className="border-b border-zinc-100 dark:border-zinc-800/50">
+      <td
+        colSpan={COLUMN_COUNT}
+        className="bg-zinc-50 px-5 py-4 dark:bg-zinc-900/40 sm:px-6"
+      >
+        <div className="mb-3 flex flex-wrap items-center gap-2 text-xs">
+          {host ? (
+            <>
+              <span
+                className={`rounded-full px-2 py-0.5 font-medium ${
+                  host.reporter_status === "ok"
+                    ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400"
+                    : "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400"
+                }`}
+              >
+                reporter: {host.reporter_status}
+              </span>
+              {host.last_error && (
+                <span className="font-mono text-red-600 dark:text-red-400">
+                  last error: {host.last_error}
+                </span>
+              )}
+              {host.node_conditions && (
+                <NodeConditionChips conditions={host.node_conditions} />
+              )}
+              <span className="ml-auto tabular-nums text-zinc-500 dark:text-zinc-400">
+                {host.cpu_count != null && `${host.cpu_count} CPUs`}
+                {host.cpu_count != null &&
+                  host.ram_total_bytes != null &&
+                  " · "}
+                {host.ram_used_bytes != null &&
+                  host.ram_total_bytes != null &&
+                  `RAM ${formatBytes(host.ram_used_bytes)} / ${formatBytes(host.ram_total_bytes)}`}
+              </span>
+            </>
+          ) : (
+            <span className="text-zinc-500 dark:text-zinc-400">
+              No host-level metrics reported yet — the host reporter may not
+              have rolled out to this machine.
+            </span>
+          )}
+        </div>
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+          <div>
+            <div className="text-xs font-medium tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
+              Disks
+            </div>
+            <DiskDetail disks={host?.disks ?? null} />
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[480px] text-sm">
+              <thead>
+                <tr className="border-b border-zinc-200 text-left text-xs text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
+                  <th className="py-1.5 pr-4 font-medium">GPU</th>
+                  <th className="py-1.5 pr-4 font-medium">Utilization</th>
+                  <th className="py-1.5 pr-4 font-medium">Memory</th>
+                  <th className="py-1.5 font-medium">Temp</th>
+                </tr>
+              </thead>
+              <tbody>
+                {row.gpus.map((gpu) => {
+                  const pct =
+                    gpu.memTotalMb > 0
+                      ? Math.round((gpu.memUsedMb / gpu.memTotalMb) * 100)
+                      : 0;
+                  return (
+                    <tr
+                      key={gpu.index}
+                      className="border-b border-zinc-100 last:border-0 dark:border-zinc-800/50"
+                    >
+                      <td className="py-1.5 pr-4 font-medium">GPU {gpu.index}</td>
+                      <td className="py-1.5 pr-4 tabular-nums">
+                        {Math.round(gpu.gpuUtil)}%
+                      </td>
+                      <td className="py-1.5 pr-4 tabular-nums">
+                        {formatMemory(gpu.memUsedMb)} /{" "}
+                        {formatMemory(gpu.memTotalMb)} ({pct}%)
+                      </td>
+                      <td
+                        className={`py-1.5 tabular-nums ${
+                          gpu.temperatureC != null && gpu.temperatureC >= 85
+                            ? "font-medium text-red-600 dark:text-red-400"
+                            : ""
+                        }`}
+                      >
+                        {formatTemperature(gpu.temperatureC)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+interface GpuHostTableProps {
+  hostRows: HostRow[];
+  hosts: HostLatest[];
+  now: number;
+  /** Test hook: render with this hostname's drill-down already expanded. */
+  defaultExpanded?: string | null;
+}
+
+export function GpuHostTable({
+  hostRows,
+  hosts,
+  now,
+  defaultExpanded = null,
+}: GpuHostTableProps) {
+  const [expanded, setExpanded] = useState<string | null>(defaultExpanded);
+  const hostsByName = useMemo(() => indexHostsByName(hosts), [hosts]);
+
+  return (
+    <div className="min-w-0 overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
+      <div className="flex min-h-14 items-center justify-between gap-4 border-b border-zinc-200 px-5 py-3 dark:border-zinc-800 sm:px-6">
+        <h2 className="text-lg font-semibold tracking-[-0.02em]">Host Summary</h2>
+        <span className="text-sm tabular-nums text-zinc-500 dark:text-zinc-400">
+          {hostRows.length} hosts · click a row for details
+        </span>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[1200px] text-sm">
+          <thead>
+            <tr className="border-b border-zinc-200 text-left text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
+              <th className="px-5 py-3 font-medium sm:px-6">Host</th>
+              <th className="px-5 py-3 font-medium sm:px-6">GPU Type</th>
+              <th className="px-5 py-3 font-medium sm:px-6">GPU Utilization</th>
+              <th className="px-5 py-3 font-medium sm:px-6">GPU Temp</th>
+              <th className="px-5 py-3 font-medium sm:px-6">Per-GPU Memory</th>
+              <th className="px-5 py-3 font-medium sm:px-6">CPU</th>
+              <th className="px-5 py-3 font-medium sm:px-6">RAM</th>
+              <th className="px-5 py-3 font-medium sm:px-6">Disk (worst)</th>
+              <th className="px-5 py-3 font-medium sm:px-6">Last Seen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {hostRows.map((h) => {
+              const host = hostsByName.get(h.hostname);
+              const gpuUtil =
+                h.gpuCount > 0 ? Math.round(h.gpuUtil / h.gpuCount) : 0;
+              const ago =
+                now > 0
+                  ? Math.round((now - new Date(h.lastSeen).getTime()) / 60_000)
+                  : 0;
+              const status = now > 0 ? hostReportStatus(ago) : "fresh";
+              const unreporting = status === "unreporting";
+              const stale = status !== "fresh";
+              const isOpen = expanded === h.hostname;
+              const ramPct =
+                host?.ram_used_bytes != null &&
+                host.ram_total_bytes != null &&
+                host.ram_total_bytes > 0
+                  ? (host.ram_used_bytes / host.ram_total_bytes) * 100
+                  : null;
+              return (
+                <Fragment key={h.hostname}>
+                  <tr
+                    onClick={() => setExpanded(isOpen ? null : h.hostname)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        setExpanded(isOpen ? null : h.hostname);
+                      }
+                    }}
+                    tabIndex={0}
+                    aria-expanded={isOpen}
+                    className={`cursor-pointer border-b border-zinc-100 hover:bg-zinc-50 dark:border-zinc-800/50 dark:hover:bg-zinc-900/50 ${stale ? "opacity-50" : ""} ${isOpen ? "bg-zinc-50 dark:bg-zinc-900/50" : ""}`}
+                  >
+                    <td className="px-5 py-3.5 font-medium sm:px-6">
+                      <span className="mr-2 inline-flex">
+                        <HealthDot status={status} />
+                      </span>
+                      {h.hostname}
+                      {unreporting ? (
+                        <span className="ml-2 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/40 dark:text-red-400">
+                          Unreporting
+                        </span>
+                      ) : status === "stale" ? (
+                        <span className="ml-2 rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-400">
+                          Stale
+                        </span>
+                      ) : null}
+                      <span className="ml-2 text-xs text-zinc-400">
+                        {isOpen ? "▾" : "▸"}
+                      </span>
+                    </td>
+                    <td className="px-5 py-3.5 sm:px-6">{h.gpuType}</td>
+                    <td className="px-5 py-3.5 sm:px-6">
+                      <Meter value={gpuUtil} />
+                    </td>
+                    <td className="whitespace-nowrap px-5 py-3.5 tabular-nums sm:px-6">
+                      <span
+                        className={
+                          h.maxTemperatureC != null && h.maxTemperatureC >= 85
+                            ? "font-medium text-red-600 dark:text-red-400"
+                            : h.maxTemperatureC != null && h.maxTemperatureC >= 75
+                              ? "font-medium text-yellow-600 dark:text-yellow-400"
+                              : ""
+                        }
+                      >
+                        {formatTemperature(h.maxTemperatureC)}
+                      </span>
+                      {h.maxTemperatureC != null && (
+                        <span className="ml-1 text-xs text-zinc-400">max</span>
+                      )}
+                    </td>
+                    <td className="px-5 py-3.5 sm:px-6">
+                      <div className="flex items-end gap-1.5" style={{ height: 40 }}>
+                        {h.gpus.map((gpu) => {
+                          const pct = gpu.memTotalMb > 0 ? Math.round((gpu.memUsedMb / gpu.memTotalMb) * 100) : 0;
+                          const barColor = pct > 90
+                            ? "bg-red-500 dark:bg-red-400"
+                            : pct > 60
+                            ? "bg-blue-500 dark:bg-blue-400"
+                            : "bg-blue-400 dark:bg-blue-500";
+                          return (
+                            <div
+                              key={gpu.index}
+                              className="group relative flex flex-col items-center"
+                            >
+                              <div
+                                className="relative w-3 rounded-sm bg-zinc-100 dark:bg-zinc-800"
+                                style={{ height: 40 }}
+                              >
+                                <div
+                                  className={`absolute bottom-0 w-full rounded-sm ${barColor}`}
+                                  style={{ height: `${Math.max(pct, 2)}%` }}
+                                />
+                              </div>
+                              <div className="pointer-events-none absolute -top-14 left-1/2 z-50 hidden -translate-x-1/2 whitespace-nowrap rounded border border-zinc-200 bg-white px-2 py-1 text-xs shadow-lg group-hover:block dark:border-zinc-700 dark:bg-zinc-900">
+                                <span className="font-medium">GPU {gpu.index}</span>
+                                <span className="ml-1 text-zinc-400">
+                                  {formatMemory(gpu.memUsedMb)} / {formatMemory(gpu.memTotalMb)} ({pct}%)
+                                </span>
+                                <span className="block text-zinc-400">
+                                  GPU utilization: {Math.round(gpu.gpuUtil)}%
+                                </span>
+                                <span className="block text-zinc-400">
+                                  Temp: {formatTemperature(gpu.temperatureC)}
+                                  {" · "}
+                                  Power: {formatPower(gpu.powerDrawW, gpu.powerLimitW)}
+                                </span>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </td>
+                    <td className="px-5 py-3.5 sm:px-6">
+                      {host?.cpu_util == null ? (
+                        <EmptyMetric />
+                      ) : (
+                        <Meter
+                          value={host.cpu_util}
+                          barClass={
+                            host.cpu_util > 85
+                              ? "bg-red-500 dark:bg-red-400"
+                              : "bg-sky-500 dark:bg-sky-400"
+                          }
+                        />
+                      )}
+                    </td>
+                    <td className="px-5 py-3.5 sm:px-6">
+                      {ramPct == null ? (
+                        <EmptyMetric />
+                      ) : (
+                        <Meter
+                          value={ramPct}
+                          barClass={
+                            ramPct > 90
+                              ? "bg-red-500 dark:bg-red-400"
+                              : "bg-violet-500 dark:bg-violet-400"
+                          }
+                        />
+                      )}
+                    </td>
+                    <td className="px-5 py-3.5 sm:px-6">
+                      <DiskCell host={host} />
+                    </td>
+                    <td
+                      className={`whitespace-nowrap px-5 py-3.5 sm:px-6 ${
+                        unreporting
+                          ? "text-red-600 dark:text-red-400"
+                          : stale
+                            ? "text-yellow-600 dark:text-yellow-400"
+                            : "text-zinc-500 dark:text-zinc-400"
+                      }`}
+                    >
+                      {stale ? formatAgo(ago) : "just now"}
+                    </td>
+                  </tr>
+                  {isOpen && <HostDrillDown row={h} host={host} />}
+                </Fragment>
+              );
+            })}
+            {hostRows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={COLUMN_COUNT}
+                  className="px-5 py-12 text-center text-zinc-400"
+                >
+                  No GPU data found. Deploy the reporting script to start collecting metrics.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/gpu-data.ts
+++ b/src/lib/gpu-data.ts
@@ -1,5 +1,6 @@
 import { unstable_cache } from "next/cache";
 import { getDb } from "@/lib/db";
+import { queryHostLatest } from "@/lib/gpu-host-data";
 import type {
   GpuHistoryResponse,
   GpuLatest,
@@ -227,11 +228,14 @@ const getCachedInitialHistory = unstable_cache(
 );
 
 const getCachedInitialLatest = unstable_cache(
-  async (): Promise<GpuLatestResponse> => ({
-    latest: await queryGpuLatest(),
-    checked_at: new Date().toISOString(),
-  }),
-  ["gpu-initial-latest-v3"],
+  async (): Promise<GpuLatestResponse> => {
+    const [latest, hosts] = await Promise.all([
+      queryGpuLatest(),
+      queryHostLatest(),
+    ]);
+    return { latest, hosts, checked_at: new Date().toISOString() };
+  },
+  ["gpu-initial-latest-v4"],
   { revalidate: 30, tags: ["gpu-latest"] },
 );
 
@@ -243,6 +247,7 @@ export async function getInitialGpuData() {
   return {
     overview: summarizeGpuHistory(history),
     latest: latestResponse.latest,
+    hosts: latestResponse.hosts,
     latestCheckedAt: latestResponse.checked_at,
     asOf: Date.now(),
   };

--- a/src/lib/gpu-host-data.test.ts
+++ b/src/lib/gpu-host-data.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeHostRow } from "./gpu-host-data";
+
+function row(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    hostname: "h200-ci-1",
+    cpu_util: 42.5,
+    cpu_count: 64,
+    ram_used_bytes: "103079215104",
+    ram_total_bytes: "274877906944",
+    ram_available_bytes: "171798691840",
+    disks: [
+      {
+        mount_point: "/",
+        device: "/dev/nvme0n1p2",
+        fstype: "ext4",
+        role: "system",
+        used_bytes: 193273528320,
+        total_bytes: 515396075520,
+        error: null,
+      },
+    ],
+    reporter_status: "ok",
+    last_error: null,
+    node_conditions: null,
+    reported_at: new Date("2026-09-02T19:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+test("normalizeHostRow coerces bigint columns from strings or BigInt", () => {
+  const fromStrings = normalizeHostRow(row());
+  assert.equal(fromStrings.ram_used_bytes, 103079215104);
+  assert.equal(fromStrings.ram_total_bytes, 274877906944);
+
+  const fromBigInt = normalizeHostRow(
+    row({ ram_used_bytes: BigInt(103079215104) }),
+  );
+  assert.equal(fromBigInt.ram_used_bytes, 103079215104);
+});
+
+test("normalizeHostRow turns Date reported_at into an ISO string", () => {
+  const host = normalizeHostRow(row());
+  assert.equal(host.reported_at, "2026-09-02T19:00:00.000Z");
+});
+
+test("normalizeHostRow keeps degraded reporter status and last_error", () => {
+  const host = normalizeHostRow(
+    row({ reporter_status: "degraded", last_error: "smartctl: Permission denied" }),
+  );
+  assert.equal(host.reporter_status, "degraded");
+  assert.equal(host.last_error, "smartctl: Permission denied");
+});
+
+test("normalizeHostRow passes parsed disks jsonb through untouched", () => {
+  const host = normalizeHostRow(row());
+  assert.equal(host.disks?.length, 1);
+  assert.equal(host.disks?.[0].role, "system");
+  assert.equal(host.disks?.[0].fstype, "ext4");
+});
+
+test("normalizeHostRow maps missing or malformed optionals to null", () => {
+  const host = normalizeHostRow(
+    row({
+      cpu_util: null,
+      cpu_count: null,
+      ram_used_bytes: null,
+      ram_total_bytes: null,
+      ram_available_bytes: null,
+      disks: null,
+      node_conditions: "not-an-object",
+    }),
+  );
+  assert.equal(host.cpu_util, null);
+  assert.equal(host.cpu_count, null);
+  assert.equal(host.ram_used_bytes, null);
+  assert.equal(host.disks, null);
+  assert.equal(host.node_conditions, null);
+});
+
+test("normalizeHostRow keeps valid node_conditions", () => {
+  const conditions = {
+    ready: true,
+    disk_pressure: false,
+    memory_pressure: null,
+    pid_pressure: false,
+    unschedulable: true,
+  };
+  const host = normalizeHostRow(row({ node_conditions: conditions }));
+  assert.deepEqual(host.node_conditions, conditions);
+});

--- a/src/lib/gpu-host-data.ts
+++ b/src/lib/gpu-host-data.ts
@@ -1,0 +1,108 @@
+import { getDb } from "@/lib/db";
+import type { HostLatest } from "@/lib/gpu-types";
+import type {
+  NormalizedDiskMetric,
+  NormalizedNodeConditions,
+} from "@/lib/gpu-report";
+
+// Same lookback as queryGpuLatest: a host stays on the dashboard as long as
+// any report of it exists within the retention window.
+const LATEST_LOOKBACK_HOURS = 720;
+
+type DbRow = Record<string, unknown>;
+
+function isoString(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+}
+
+function nullableNumber(value: unknown): number | null {
+  if (value == null) return null;
+  // postgres.js may surface bigint columns (ram_*_bytes) as strings or
+  // BigInt depending on the driver options; Number() handles both.
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isNodeConditions(value: unknown): value is NormalizedNodeConditions {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as NormalizedNodeConditions).unschedulable === "boolean"
+  );
+}
+
+/**
+ * Coerces one host_snapshots row into the API shape. The table's CHECK
+ * constraints and the ingestion-time validation in gpu-report.ts guarantee
+ * the structural shape; this layer only normalizes driver representations
+ * (bigint strings, parsed jsonb).
+ */
+export function normalizeHostRow(row: DbRow): HostLatest {
+  return {
+    hostname: String(row.hostname),
+    cpu_util: nullableNumber(row.cpu_util),
+    cpu_count: nullableNumber(row.cpu_count),
+    ram_used_bytes: nullableNumber(row.ram_used_bytes),
+    ram_total_bytes: nullableNumber(row.ram_total_bytes),
+    ram_available_bytes: nullableNumber(row.ram_available_bytes),
+    disks: Array.isArray(row.disks)
+      ? (row.disks as NormalizedDiskMetric[])
+      : null,
+    reporter_status: row.reporter_status === "degraded" ? "degraded" : "ok",
+    last_error: row.last_error == null ? null : String(row.last_error),
+    node_conditions: isNodeConditions(row.node_conditions)
+      ? row.node_conditions
+      : null,
+    reported_at: isoString(row.reported_at),
+  };
+}
+
+/**
+ * Latest host_snapshots row per hostname. Same skip-scan shape as
+ * queryGpuLatest: walk the distinct keys via the (hostname, reported_at)
+ * index, then a lateral latest-row lookup per host.
+ */
+export async function queryHostLatest(): Promise<HostLatest[]> {
+  const db = getDb();
+  const rows = await db`
+    WITH RECURSIVE host_keys(hostname) AS (
+      (
+        SELECT hostname
+        FROM host_snapshots
+        WHERE reported_at > NOW() - INTERVAL '1 hour' * ${LATEST_LOOKBACK_HOURS}
+        ORDER BY hostname
+        LIMIT 1
+      )
+      UNION ALL
+      SELECT next_key.hostname
+      FROM host_keys current_key
+      CROSS JOIN LATERAL (
+        SELECT hostname
+        FROM host_snapshots
+        WHERE hostname > current_key.hostname
+          AND reported_at > NOW() - INTERVAL '1 hour' * ${LATEST_LOOKBACK_HOURS}
+        ORDER BY hostname
+        LIMIT 1
+      ) next_key
+    )
+    SELECT l.hostname, l.cpu_util, l.cpu_count,
+           l.ram_used_bytes, l.ram_total_bytes, l.ram_available_bytes,
+           l.disks, l.reporter_status, l.last_error, l.node_conditions,
+           l.reported_at
+    FROM host_keys k
+    CROSS JOIN LATERAL (
+      SELECT hostname, cpu_util, cpu_count,
+             ram_used_bytes, ram_total_bytes, ram_available_bytes,
+             disks, reporter_status, last_error, node_conditions, reported_at
+      FROM host_snapshots s
+      WHERE s.hostname = k.hostname
+      ORDER BY s.reported_at DESC
+      LIMIT 1
+    ) l
+    ORDER BY l.hostname
+  `;
+
+  return (rows as unknown as DbRow[]).map(normalizeHostRow);
+}

--- a/src/lib/gpu-host-view.test.ts
+++ b/src/lib/gpu-host-view.test.ts
@@ -4,9 +4,14 @@ import {
   HOST_STALE_MINUTES,
   HOST_UNREPORTING_MINUTES,
   buildHostRows,
+  diskUsedPct,
   hostReportStatus,
+  indexHostsByName,
+  isRamBackedMount,
+  worstAlertableDisk,
 } from "./gpu-host-view";
-import type { GpuLatest } from "./gpu-types";
+import type { GpuLatest, HostLatest } from "./gpu-types";
+import type { NormalizedDiskMetric } from "./gpu-report";
 
 function gpu(overrides: Partial<GpuLatest> = {}): GpuLatest {
   return {
@@ -85,4 +90,108 @@ test("hosts are sorted, GPUs ordered by index, last seen is the newest report", 
   assert.deepEqual(rows.map((r) => r.hostname), ["dgxb200-01", "h200-ci-2"]);
   assert.deepEqual(rows[1].gpus.map((g) => g.index), [0, 1]);
   assert.equal(rows[1].lastSeen, "2026-09-02T19:00:30.000Z");
+});
+
+function disk(overrides: Partial<NormalizedDiskMetric> = {}): NormalizedDiskMetric {
+  return {
+    mount_point: "/",
+    device: "/dev/nvme0n1p2",
+    fstype: "ext4",
+    role: "system",
+    used_bytes: 50,
+    total_bytes: 100,
+    error: null,
+    ...overrides,
+  };
+}
+
+test("worstAlertableDisk picks the fullest alertable mount", () => {
+  const worst = worstAlertableDisk([
+    disk({ mount_point: "/", role: "system", used_bytes: 40 }),
+    disk({ mount_point: "/data", role: "data", used_bytes: 90 }),
+    disk({ mount_point: "/workspace", role: "workspace", used_bytes: 70 }),
+  ]);
+  assert.equal(worst?.disk.mount_point, "/data");
+  assert.equal(worst?.usedPct, 90);
+});
+
+test("worstAlertableDisk never lets 'other' mounts drive the cell", () => {
+  const worst = worstAlertableDisk([
+    disk({ mount_point: "/dev/shm", fstype: "tmpfs", role: "other", used_bytes: 99 }),
+    disk({ mount_point: "/", role: "system", used_bytes: 40 }),
+  ]);
+  assert.equal(worst?.disk.mount_point, "/");
+});
+
+test("worstAlertableDisk skips error mounts with no usage values", () => {
+  const worst = worstAlertableDisk([
+    disk({
+      mount_point: "/data",
+      role: "data",
+      used_bytes: null,
+      total_bytes: null,
+      error: "i/o error",
+    }),
+    disk({ mount_point: "/", role: "system", used_bytes: 40 }),
+  ]);
+  assert.equal(worst?.disk.mount_point, "/");
+});
+
+test("worstAlertableDisk returns null without usable alertable mounts", () => {
+  assert.equal(worstAlertableDisk(null), null);
+  assert.equal(worstAlertableDisk([]), null);
+  assert.equal(
+    worstAlertableDisk([disk({ role: "other", used_bytes: 99 })]),
+    null,
+  );
+  assert.equal(
+    worstAlertableDisk([
+      disk({ used_bytes: null, total_bytes: null, error: "i/o error" }),
+    ]),
+    null,
+  );
+});
+
+test("diskUsedPct guards against zero totals and missing values", () => {
+  assert.equal(diskUsedPct(disk({ used_bytes: 25, total_bytes: 100 })), 25);
+  assert.equal(diskUsedPct(disk({ used_bytes: 0, total_bytes: 0 })), null);
+  assert.equal(
+    diskUsedPct(disk({ used_bytes: null, total_bytes: null })),
+    null,
+  );
+});
+
+test("isRamBackedMount flags tmpfs and ramfs only", () => {
+  assert.equal(isRamBackedMount(disk({ fstype: "tmpfs" })), true);
+  assert.equal(isRamBackedMount(disk({ fstype: "ramfs" })), true);
+  assert.equal(isRamBackedMount(disk({ fstype: "ext4" })), false);
+  assert.equal(isRamBackedMount(disk({ fstype: "overlay" })), false);
+});
+
+function hostLatest(overrides: Partial<HostLatest> = {}): HostLatest {
+  return {
+    hostname: "h200-ci-1",
+    cpu_util: 42,
+    cpu_count: 64,
+    ram_used_bytes: 96,
+    ram_total_bytes: 256,
+    ram_available_bytes: 160,
+    disks: null,
+    reporter_status: "ok",
+    last_error: null,
+    node_conditions: null,
+    reported_at: "2026-09-02T19:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("indexHostsByName keeps one row per host, the newest one", () => {
+  const map = indexHostsByName([
+    hostLatest({ cpu_util: 10, reported_at: "2026-09-02T18:59:00.000Z" }),
+    hostLatest({ hostname: "h200-ci-2" }),
+    hostLatest({ cpu_util: 55, reported_at: "2026-09-02T19:00:00.000Z" }),
+  ]);
+  assert.equal(map.size, 2);
+  assert.equal(map.get("h200-ci-1")?.cpu_util, 55);
+  assert.equal(map.get("h200-ci-2")?.cpu_util, 42);
 });

--- a/src/lib/gpu-host-view.ts
+++ b/src/lib/gpu-host-view.ts
@@ -1,4 +1,5 @@
-import type { GpuLatest } from "./gpu-types";
+import type { GpuLatest, HostLatest } from "./gpu-types";
+import type { DiskRole, NormalizedDiskMetric } from "./gpu-report";
 
 /** A host is dimmed as Stale once its newest report is this old. */
 export const HOST_STALE_MINUTES = 5;
@@ -101,4 +102,70 @@ export function buildHostRows(
     row.gpus.sort((a, b) => a.index - b.index);
   }
   return [...map.values()].sort((a, b) => a.hostname.localeCompare(b.hostname));
+}
+
+/**
+ * Disk roles that can fill up a job and therefore drive alerting and the
+ * summary Disk cell. "other" mounts (cgroup, tmpfs snapshots, container
+ * plumbing) are shown in the drill-down but never drive the cell.
+ */
+export const ALERTABLE_DISK_ROLES: readonly DiskRole[] = [
+  "workspace",
+  "images",
+  "data",
+  "system",
+];
+
+/** RAM-backed filesystems consume memory, not disk; the UI labels them. */
+export function isRamBackedMount(disk: Pick<NormalizedDiskMetric, "fstype">): boolean {
+  return disk.fstype === "tmpfs" || disk.fstype === "ramfs";
+}
+
+/** Percentage used, or null when the mount reported no usage (error mounts). */
+export function diskUsedPct(
+  disk: Pick<NormalizedDiskMetric, "used_bytes" | "total_bytes">,
+): number | null {
+  if (disk.used_bytes == null || disk.total_bytes == null) return null;
+  if (disk.total_bytes <= 0) return null;
+  return (disk.used_bytes / disk.total_bytes) * 100;
+}
+
+export interface WorstDisk {
+  disk: NormalizedDiskMetric;
+  usedPct: number;
+}
+
+/**
+ * The alertable mount with the highest usage, or null when no alertable
+ * mount reported usage. Mounts with a per-mount error (no usage values) and
+ * "other" mounts are skipped.
+ */
+export function worstAlertableDisk(
+  disks: NormalizedDiskMetric[] | null,
+): WorstDisk | null {
+  if (!disks) return null;
+  let worst: WorstDisk | null = null;
+  for (const disk of disks) {
+    if (!ALERTABLE_DISK_ROLES.includes(disk.role)) continue;
+    const usedPct = diskUsedPct(disk);
+    if (usedPct == null) continue;
+    if (!worst || usedPct > worst.usedPct) worst = { disk, usedPct };
+  }
+  return worst;
+}
+
+/**
+ * One HostLatest per hostname, keeping the newest row when duplicates slip
+ * in. queryHostLatest already returns one row per host; this keeps the
+ * client-side join safe regardless.
+ */
+export function indexHostsByName(hosts: HostLatest[]): Map<string, HostLatest> {
+  const map = new Map<string, HostLatest>();
+  for (const host of hosts) {
+    const existing = map.get(host.hostname);
+    if (!existing || host.reported_at > existing.reported_at) {
+      map.set(host.hostname, host);
+    }
+  }
+  return map;
 }

--- a/src/lib/gpu-types.ts
+++ b/src/lib/gpu-types.ts
@@ -1,3 +1,9 @@
+import type {
+  NormalizedDiskMetric,
+  NormalizedNodeConditions,
+  ReporterStatus,
+} from "./gpu-report";
+
 export interface GpuSnapshot {
   time_bucket: string;
   hostname: string;
@@ -20,6 +26,21 @@ export interface GpuLatest {
   reported_at: string;
 }
 
+/** Latest host-level report for one hostname, as stored in host_snapshots. */
+export interface HostLatest {
+  hostname: string;
+  cpu_util: number | null;
+  cpu_count: number | null;
+  ram_used_bytes: number | null;
+  ram_total_bytes: number | null;
+  ram_available_bytes: number | null;
+  disks: NormalizedDiskMetric[] | null;
+  reporter_status: ReporterStatus;
+  last_error: string | null;
+  node_conditions: NormalizedNodeConditions | null;
+  reported_at: string;
+}
+
 export interface GpuHistoryResponse {
   hours: number;
   snapshots: GpuSnapshot[];
@@ -38,6 +59,7 @@ export interface GpuOverviewPoint {
 
 export interface GpuLatestResponse {
   latest: GpuLatest[];
+  hosts: HostLatest[];
   checked_at: string;
   error?: string;
 }


### PR DESCRIPTION
Stacked on #113 (base retargets to `main` automatically when it merges).

## What

The approved "table + drill-down" prototype design, rewritten properly on the real stack:

- Host Summary table gains **CPU / RAM / Disk progress bars** per host, next to the existing health dot, Stale/Unreporting badges, GPU Utilization bar, GPU Temp, and the per-GPU memory mini-bars (kept verbatim)
- The Disk cell shows the worst **job-critical** mount (roles workspace/images/data/system); `other` mounts never drive it; tmpfs mounts are labeled RAM-backed
- Row click expands a **drill-down**: reporter status + last error (broken reporter vs broken machine), k8s node-condition chips with a distinct **Cordoned** marker, per-mount disk bars with role/device/fstype/size (including errored mounts), and per-GPU util/mem/temp
- Hosts without host metrics yet (reporter not rolled out) render em-dashes, not broken cells
- `/api/gpu/latest` gains a `hosts` array via a skip-scan latest-row-per-host query over `host_snapshots`, keeping the page's single 30s SWR poll

## Test plan

- `npm test`: 98/98 (24 new: query normalization, worst-alertable-disk selection, graceful-missing-host path, 11 renderToStaticMarkup component tests)
- `npm run lint`, `tsc --noEmit`, `npm run build` all clean