### PR TITLE
alerting: infra health alerts (unreporting/disk/GPU temp) + /alerts Infra tab + per-alert docs

### DIFF
--- a/.github/workflows/python-backend-tests.yml
+++ b/.github/workflows/python-backend-tests.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Type check
         working-directory: alerting
-        run: python -m mypy __init__.py analyzer.py commands.py control.py cutover.py fast_ci.py full_ci.py kimi.py main_ci.py main_ci_analysis.py memory.py migration.py ports.py postgres.py retention.py runtime.py slack.py worker.py tests
+        run: python -m mypy __init__.py analyzer.py commands.py control.py cutover.py fast_ci.py full_ci.py infra.py kimi.py main_ci.py main_ci_analysis.py memory.py migration.py ports.py postgres.py retention.py runtime.py slack.py worker.py tests
 
       - name: Type check migrations
         working-directory: migrations

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ A Next.js dashboard for observing vLLM's Buildkite CI: build status, job runtime
   live in the Python [`migrations/`](./migrations) module. Runtime request
   handlers never create or alter tables.
 - Cron schedules live in `vercel.json`.
+- **Alert reference**: end-to-end docs per alert type —
+  [Fast CI](./alerting/docs/fast-ci.md), [Full CI](./alerting/docs/full-ci.md),
+  [Main CI](./alerting/docs/main-ci.md), and [Infra](./alerting/docs/infra.md)
+  (produced by the alerting worker), plus
+  [Queue wait](./docs/alerts/queue-wait.md) (owned by this app).
 
 The Queue page uses Buildkite's cluster-queue counts directly. Because the
 public queue metrics schema stops at p95, p99 is calculated from the current

--- a/alerting/CONTEXT.md
+++ b/alerting/CONTEXT.md
@@ -65,3 +65,21 @@ _Avoid_: Last event time, checkpoint
 **Notification Intent**:
 A durable request to deliver one rendered alert message to a destination.
 _Avoid_: Slack message, notification attempt
+
+**Expected Host Set**:
+The union of Kubernetes node names from each GPU cluster, GPU-queue Buildkite
+agent hostnames lowercased, and hostnames seen recently in gpu_snapshots. It
+authoritatively defines which hosts must report telemetry.
+_Avoid_: Inventory, fleet registry
+
+**Infra Alert Episode**:
+One breach episode for an infra subject (an unreporting host, a shared disk
+group, or one GPU). It opens only after the breach sustains across the
+configured consecutive scans and resolves on the first positive observation,
+so every episode produces exactly two Notification Intents.
+_Avoid_: Machine-down alarm, flapping page
+
+**Retired Host**:
+A host absent from every expected source and silent for seven days. It stops
+alerting and keeps a queryable retirement timestamp for the dashboard.
+_Avoid_: Deleted host, decommission record

--- a/alerting/README.md
+++ b/alerting/README.md
@@ -27,6 +27,18 @@ tests. Domain language is recorded in [`CONTEXT.md`](./CONTEXT.md), and the
 repository-level relationship with the dashboard is recorded in
 [`CONTEXT-MAP.md`](../CONTEXT-MAP.md).
 
+## Alert reference
+
+End-to-end docs per alert type produced here:
+
+- [Fast CI failure alerts](./docs/fast-ci.md)
+- [Full CI comparison alerts](./docs/full-ci.md)
+- [Main CI job failure alerts](./docs/main-ci.md)
+- [Infra health alerts](./docs/infra.md)
+
+Queue-wait alerting is owned by the dashboard context:
+[`docs/alerts/queue-wait.md`](../docs/alerts/queue-wait.md).
+
 ## Layout
 
 - `commands.py` — the command model; a command is a reconciliation

--- a/alerting/README.md
+++ b/alerting/README.md
@@ -13,8 +13,9 @@ The package uses vertical domain slices rather than layer-only folders:
 
 - `commands.py` defines the scheduled-command value object shared by all
   slices.
-- `fast_ci.py`, `full_ci.py`, and `main_ci.py` keep each signal's domain records,
-  reconciliation behavior, source port, and source adapter together.
+- `fast_ci.py`, `full_ci.py`, `main_ci.py`, and `infra.py` keep each signal's
+  domain records, reconciliation behavior, source port, and source adapter
+  together.
 - `runtime.py` exposes the small application interface:
   `process_command` and `dispatch_due_notifications`.
 - `ports.py` defines infrastructure seams used by the runtime.
@@ -60,6 +61,15 @@ repository-level relationship with the dashboard is recorded in
   poller's scan cursor; the outcome order guard keeps reprocessing
   idempotent. It writes raw lifecycle and Buildkite evidence only;
   Sherlock's diagnosis remains in Slack.
+- `infra.py` — the five-minute infra health scan. It reconciles the
+  expected-host set (Kubernetes node names from each cluster, GPU-queue
+  Buildkite agent hostnames, and hostnames seen recently in gpu_snapshots)
+  against the latest reported telemetry. An unreporting episode opens only
+  after the silence sustains across the configured consecutive scans and
+  resolves on the first fresh report; a host absent from every expected
+  source and silent for seven days is auto-retired. Every episode sends
+  exactly two Slack messages (open and resolve) through the outbox, and the
+  wording always says a host stopped reporting, never that it is down.
 - `analyzer.py` — the Full CI analyzer compatibility adapter. It materializes
   the working files the bundled analyzer instructions expect (summary, full
   build data, previous-failure cache, agent memory hydrated from the latest
@@ -150,7 +160,8 @@ enabling the new path, and preserves Postgres and S3 baselines on rollback.
   `MainCIAnalysisHandler` registers as `main_ci_analyze`. Workers expose them
   as the `fast-ci`, `full-ci`, `full-ci-analyze`, `main-ci`,
   `main-ci-backstop`, and
-  `main-ci-analyze` consumers so the
+  `main-ci-analyze` consumers, and `InfraScanHandler` registers as
+  `infra_scan` on the `infra` consumer, so the
   long-running LLM analysis never blocks ingest. The Main CI analysis consumer
   writes only the `alerting_main_ci_job_analysis` sidecar table; the
   deterministic alert lifecycle stays owned by `main_ci_reconcile`.
@@ -170,6 +181,6 @@ enabling the new path, and preserves Postgres and S3 baselines on rollback.
 cd alerting
 uv sync --extra dev
 uv run pytest
-uv run mypy __init__.py analyzer.py commands.py control.py cutover.py fast_ci.py full_ci.py kimi.py main_ci.py main_ci_analysis.py memory.py migration.py ports.py postgres.py retention.py runtime.py slack.py worker.py tests
+uv run mypy __init__.py analyzer.py commands.py control.py cutover.py fast_ci.py full_ci.py infra.py kimi.py main_ci.py main_ci_analysis.py memory.py migration.py ports.py postgres.py retention.py runtime.py slack.py worker.py tests
 uv run ruff check .
 ```

--- a/alerting/README.md
+++ b/alerting/README.md
@@ -67,7 +67,11 @@ repository-level relationship with the dashboard is recorded in
   against the latest reported telemetry. An unreporting episode opens only
   after the silence sustains across the configured consecutive scans and
   resolves on the first fresh report; a host absent from every expected
-  source and silent for seven days is auto-retired. Every episode sends
+  source and silent for seven days is auto-retired. Disk-usage episodes are
+  keyed by the shared (fstype, device) group rather than hostname, so an
+  NFS volume mounted by many hosts pages once, and GPU temperature episodes
+  are keyed per host and GPU. RAM, load, and network are display-only and
+  never alert. Every episode sends
   exactly two Slack messages (open and resolve) through the outbox, and the
   wording always says a host stopped reporting, never that it is down.
 - `analyzer.py` — the Full CI analyzer compatibility adapter. It materializes

--- a/alerting/control.py
+++ b/alerting/control.py
@@ -44,11 +44,13 @@ _UNITS = {
         ("alerting-main-ci-analysis.timer", "alerting-main-ci-analysis.service"),
         ("alerting-main-ci-backstop.timer", "alerting-main-ci-backstop.service"),
     ),
+    AlertPath.INFRA: (("alerting-infra.timer", "alerting-infra.service"),),
 }
 _MODE_FILES = {
     AlertPath.FAST_CI: "fast-ci.mode",
     AlertPath.FULL_CI: "full-ci.mode",
     AlertPath.MAIN_CI: "main-ci.mode",
+    AlertPath.INFRA: "infra.mode",
 }
 
 

--- a/alerting/docs/fast-ci.md
+++ b/alerting/docs/fast-ci.md
@@ -1,0 +1,62 @@
+# Fast CI failure alerts
+
+## What it detects
+
+A required job in the `CI` Buildkite pipeline on the `main` branch that
+finishes in a hard failure state (`failed`, `failing`, `broken`,
+`timed_out`) within 30 seconds. These fast failures almost always mean the
+merge queue is broken for everyone (bad base image, missing secret, setup
+step failing), so they page immediately. Soft-failed, non-script, and
+unnamed jobs are excluded. Fast failure events have no resolution
+lifecycle: each is a one-way observation.
+
+## Where the code lives
+
+- `alerting/fast_ci.py` — the slice: `FastFailureEvent` record, the
+  preserved Databricks SQL predicate, `DatabricksFastCISource`, the Slack
+  renderer, and `FastCIScanHandler`.
+- `alerting/runtime.py` — claims and completes the `fast_ci_scan` scheduled
+  command; `alerting/postgres.py` is the production store,
+  `alerting/memory.py` the in-memory test double.
+- Deployment: `deploy/aws/systemd/alerting-fast-ci.timer` runs
+  `run-worker fast-ci` every 15 minutes (`America/Los_Angeles`) on the EC2
+  alerting worker.
+
+## Configuration
+
+- `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, `DATABRICKS_WAREHOUSE_ID` — the
+  source warehouse query (secrets).
+- `SLACK_BOT_TOKEN` — delivery; `SLACK_CHANNEL_ID` overrides the default
+  channel (`C0ABTNM9L5U`).
+- Control plane: the S3 `control/fast_ci.mode` object, applied by
+  `alerting/control.py` to `alerting-fast-ci.timer`. `shadow` (the default)
+  persists rendered messages without delivering; `live` delivers;
+  `disabled` stops the timer.
+- Scan bounds: 30-second duration ceiling (`MAX_DURATION_SECONDS`), a
+  15-minute safety overlap behind the durable cursor, and a 30-minute
+  initial lookback on first run — constants in `fast_ci.py`.
+
+## What it posts to Slack
+
+One message per batch of up to 8 new failures
+("*Fast CI job failure alert* — N jobs failed in 30s or less"), listing job
+link, duration, build, branch, commit, PR, and author. Batches are
+content-addressed (`fast-ci:<sha256 of job IDs>`), so retries never
+duplicate. A pending batch older than 30 minutes is superseded and folded
+into a single "*Fast CI recovery summary*" so a Slack outage does not flood
+the channel later.
+
+## Dashboard history
+
+`/alerts?tab=fast-ci` ("Fast failures (<30s)") shows the last 7 days of
+events grouped by build and commit, including how far each event's Slack
+notification got. Backed by `src/app/api/alerts/fast-ci/route.ts`.
+
+## Tables
+
+Reads: Databricks `vllm_data_warehouse.buildkite.build_job` /
+`build` / `pipeline` (via the SQL Statements API);
+`alerting_fast_ci_imported_deduplication_keys`.
+Writes: `alerting_fast_failure_events`, `alerting_fast_failure_notifications`,
+`alerting_fast_ci_scan_cursors`, `alerting_notification_outbox`,
+`alerting_automation_executions`.

--- a/alerting/docs/full-ci.md
+++ b/alerting/docs/full-ci.md
@@ -1,0 +1,62 @@
+# Full CI comparison alerts
+
+## What it detects
+
+The scheduled Full CI runs — Buildkite builds on `main` whose message is
+exactly `full ci run - nightly` or `full ci run - daily` — and how each run
+compares to its chronological predecessor. The ingest slice
+(`alerting/full_ci.py`) records every run, its job outcomes, and the
+comparison link. The analysis sidecar (`alerting/analyzer.py`) then runs a
+Kimi-driven agent over each pending comparison to classify every failing
+job (new / recurring / fixed; cause: infrastructure, flaky test, test,
+code, unknown), attribute culprit and fixing PRs, and post the rendered
+analysis report.
+
+## Where the code lives
+
+- `alerting/full_ci.py` — `FullCIRun` / `FullCIJobOutcome` records,
+  `BuildkiteRestClient`, `BuildkiteFullCISource`,
+  `FullCIReconciliationHandler` (`full_ci_reconcile`).
+- `alerting/analyzer.py` — `FullCIAnalysisHandler` (`full_ci_analyze`) and
+  the classification/commit logic; `alerting/kimi.py` is the runner.
+- Deployment: `deploy/aws/systemd/alerting-full-ci.timer` fires at 05:00
+  and 19:00 `America/Los_Angeles`; `alerting-full-ci.service` runs
+  `run-worker full-ci` and then `run-worker full-ci-analyze` in one tick.
+
+## Configuration
+
+- `BUILDKITE_TOKEN` (source reads), `GITHUB_TOKEN` (PR attribution),
+  `KIMI_API_KEY` plus optional `KIMI_BASE_URL`, `KIMI_MODEL`,
+  `KIMI_TIMEOUT_SECONDS`, `KIMI_REASONING_EFFORT`.
+- `ALERTING_CHECKPOINT_BUCKET` — the S3 bucket for immutable analyzer
+  checkpoints and the per-path control objects.
+- Slack: `SLACK_BOT_TOKEN`; `SLACK_CHANNEL_ID` overrides the default
+  channel (`C0ABTNM9L5U`).
+- Control plane: S3 `control/full_ci.mode` (`shadow` default / `live` /
+  `disabled`) applies to both the reconciler and the analyzer.
+
+## What it posts to Slack
+
+One message per analyzed comparison: the analyzer's report text, delivered
+through the outbox with delivery ID `full-ci:<build_id>` (idempotent per
+build). The reconciler itself posts nothing. Each analysis commits its
+report, classifications, checkpoint reference, and the notification intent
+in one Postgres transaction; a failure leaves the comparison pending for
+the next tick.
+
+## Dashboard history
+
+Full CI comparisons and analyses are delivered to Slack only; the
+dashboard's `/alerts` page does not render them (its tabs are Main CI
+failures, Fast CI observations, and infra episodes).
+
+## Tables
+
+Reads: Buildkite REST API (builds, jobs).
+Writes: `alerting_full_ci_runs`, `alerting_full_ci_job_outcomes`,
+`alerting_full_ci_comparisons`, `alerting_full_ci_analyses`,
+`alerting_full_ci_failure_conditions`, `alerting_analyzer_checkpoints`,
+`alerting_notification_outbox`, `alerting_automation_executions`.
+Legacy cutover state: `alerting_full_ci_import_baselines`.
+Analyzer memory lives as immutable S3 objects referenced from
+`alerting_analyzer_checkpoints`; unreferenced objects are crash debris.

--- a/alerting/docs/infra.md
+++ b/alerting/docs/infra.md
@@ -1,0 +1,78 @@
+# Infra health alerts
+
+## What it detects
+
+Three fleet-health signals, reconciled by one five-minute scan
+(`infra_scan`):
+
+- **Unreporting** — an expected host whose latest successful report
+  (any `gpu_snapshots` / `host_snapshots` row) is older than the threshold
+  for `consecutive_scans` consecutive scans. The wording always says the
+  host "stopped reporting"; the alert never claims a machine is down. A
+  host absent from every expected source and silent for 7 days is
+  auto-retired (`retired_at` set): it stops alerting, its open episode
+  resolves, and the dashboard can still show it.
+- **Disk usage** — any reported mount with role `workspace`, `images`,
+  `data`, or `system` at ≥ the threshold percent. Episodes are keyed by the
+  shared `(fstype, device)` group, not hostname, so an NFS volume mounted
+  by N hosts pages once and resolves only when every mount in the group
+  drops below the threshold. Mounts with role `other` or a per-mount error
+  never alert.
+- **GPU temperature** — any GPU at ≥ the threshold in °C, keyed per
+  hostname and GPU index.
+
+RAM, load, and network are display-only and never alert. Every episode
+opens only after the breach sustains across `consecutive_scans` and
+resolves on the first healthy observation — exactly two Slack messages per
+episode.
+
+## Where the code lives
+
+- `alerting/infra.py` — the slice: records, the pure `plan_infra_scan`
+  planner, renderers, `InfraScanHandler`, and the production sources
+  (`KubectlNodesSource`, `BuildkiteGpuQueueAgentsSource`,
+  `UnionExpectedHostSource`).
+- Ports/adapters: `InfraSnapshotPort` + `InfraStore` implemented by
+  `alerting/postgres.py` (`PostgresAlertStore`), with in-memory doubles in
+  `alerting/memory.py`.
+- Deployment: `deploy/aws/systemd/alerting-infra.timer` runs
+  `run-worker infra` every 5 minutes (UTC) on the EC2 worker.
+
+## Configuration
+
+- `alert_thresholds` Postgres table (fleet-wide, operator-tunable;
+  `enabled = false` suppresses that alert type). Seeded defaults:
+  `unreporting` 10 minutes / 2 scans, `disk_usage` 90% / 2 scans,
+  `gpu_temperature` 85°C / 2 scans.
+- The expected-host set is the union of: Kubernetes node names from both
+  clusters (`GPU_REPORTER_KUBECONFIG_H100`, `GPU_REPORTER_KUBECONFIG_DGX`),
+  Buildkite agents in the `gpu` queue (`BUILDKITE_TOKEN`, hostname
+  lowercased), and hostnames seen in `gpu_snapshots` within the last 7
+  days. All hostnames are lowercased.
+- Slack: `SLACK_BOT_TOKEN`; channel `SLACK_CI_INFRA_ALERT_CHANNEL` (falls
+  back to the shared alerts channel `C0ABTNM9L5U` until the secret exists).
+- Control plane: S3 `control/infra.mode` (`shadow` default / `live` /
+  `disabled`) applied to `alerting-infra.timer`.
+
+## What it posts to Slack
+
+One message when an episode opens and one when it resolves (including the
+auto-retire resolution). Opens name the subject and evidence (last report
+time, breaching mounts with per-host percentages, or GPU temperature);
+resolves confirm the recovery. Delivery IDs are deterministic per episode
+and transition (`infra:<type>:<digest>:<opened epoch>:open|resolve`), so
+retries never duplicate.
+
+## Dashboard history
+
+`/alerts?tab=infra` ("Infra") lists open and resolved episodes plus retired
+hosts; the view is read-only — there is nothing to resolve by hand. Backed
+by `src/app/api/alerts/infra/route.ts`.
+
+## Tables
+
+Reads: `gpu_snapshots`, `host_snapshots`, `alert_thresholds`.
+Writes: `alerting_infra_host_states` (per-subject consecutive-breach counts
+and retirement), `alerting_infra_alerts` (episodes; partial unique index
+keeps at most one open episode per `(alert_type, subject_key)`),
+`alerting_notification_outbox`, `alerting_automation_executions`.

--- a/alerting/docs/main-ci.md
+++ b/alerting/docs/main-ci.md
@@ -1,0 +1,64 @@
+# Main CI job failure alerts
+
+## What it detects
+
+Hard terminal failures of command jobs on the `main` branch of the `CI`
+pipeline, keyed by the configured Buildkite step key plus the rendered job
+name (so matrix cells stay independent). One alert is one failure episode:
+repeated failures refresh the open episode, and only a positively observed
+pass of the same logical job in the same or a newer build resolves it.
+Soft-failed, canceled, missing, or late-finishing older jobs never resolve
+an episode. Episodes can also be closed by hand from the dashboard
+(`resolution_kind = 'manual'`).
+
+## Where the code lives
+
+- `alerting/main_ci.py` — `MainCIJobObservation` / `MainCIJobAlert`
+  records, `BuildkiteMainCISource`, `MainCIReconciliationHandler`
+  (`main_ci_reconcile`, two-minute poller) and `MainCIBackstopHandler`
+  (`main_ci_backstop`, hourly sweep of the last 48 hours plus re-checks of
+  every open alert's last-failure build, so retry passes the windowed
+  poller missed still resolve within an hour).
+- `alerting/main_ci_analysis.py` — the `main_ci_analyze` sidecar: for each
+  open alert it runs a Kimi analysis over the failing job's log and stores
+  the classification in `alerting_main_ci_job_analysis`. It never
+  enqueues notifications and never writes alert state.
+- Deployment: `alerting-main-ci.timer` every 2 minutes,
+  `alerting-main-ci-backstop.timer` hourly at :17, and
+  `alerting-main-ci-analysis.timer` every 10 minutes (all UTC) on the EC2
+  worker.
+
+## Configuration
+
+- `BUILDKITE_TOKEN` — source reads; the analysis sidecar also needs
+  `GITHUB_TOKEN` and `KIMI_API_KEY`. The sidecar has dedicated knobs
+  `KIMI_MAIN_CI_TIMEOUT_SECONDS` (default 1200) and
+  `KIMI_MAIN_CI_REASONING_EFFORT` (default `max`), independent of the
+  shared `KIMI_*` settings.
+- Control plane: S3 `control/main_ci.mode` (`shadow` default / `live` /
+  `disabled`) governs all three timers together. Main CI currently posts
+  nothing to Slack, so the mode only enables or disables the timers.
+
+## What it posts to Slack
+
+Nothing. Lifecycle records deliberately carry raw Buildkite evidence only;
+diagnosis stays a curated Slack concern. The dashboard is the consumer.
+
+## Dashboard history
+
+`/alerts?tab=main-ci` ("Failures") lists open and recently resolved
+episodes with first/last failure evidence and the sidecar's analysis when
+present, and offers manual resolution (POST
+`src/app/api/alerts/main-ci/resolve`). Backed by
+`src/app/api/alerts/main-ci/route.ts`.
+
+## Tables
+
+Reads: Buildkite REST API (active and finished main builds, retried jobs,
+job logs for analysis); GitHub for PR context in analysis.
+Writes: `alerting_main_ci_job_states` (current per-job state, guarded so an
+older build finishing late cannot overwrite a newer outcome),
+`alerting_main_ci_job_alerts` (episodes; partial unique index keeps at most
+one open episode per job key), `alerting_main_ci_scan_cursors`,
+`alerting_main_ci_job_analysis` (sidecar),
+`alerting_automation_executions`.

--- a/alerting/full_ci.py
+++ b/alerting/full_ci.py
@@ -113,6 +113,7 @@ class BuildkiteRestClient:
     """Read-only Buildkite REST client for Full CI build and job pages."""
 
     _BUILDS_URL = "https://api.buildkite.com/v2/organizations/vllm/pipelines/ci/builds"
+    _AGENTS_URL = "https://api.buildkite.com/v2/organizations/vllm/agents"
 
     def __init__(self, *, token: str) -> None:
         self._token = token
@@ -248,6 +249,23 @@ class BuildkiteRestClient:
         if not isinstance(payload, dict):
             raise RuntimeError("Buildkite build response was not an object")
         return cast(dict[str, Any], payload)
+
+    def list_agents(self, *, queue: str) -> list[dict[str, Any]]:
+        """Agents in one cluster queue, paginating the agents endpoint."""
+        agents: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            query = urllib.parse.urlencode(
+                {"queue": queue, "per_page": 100, "page": page}
+            )
+            payload = self._get_json(f"{self._AGENTS_URL}?{query}")
+            if not isinstance(payload, list):
+                raise RuntimeError("Buildkite agents response was not a list")
+            rows = cast(list[dict[str, Any]], payload)
+            agents.extend(rows)
+            if len(rows) < 100:
+                return agents
+            page += 1
 
 
 class BuildkiteFullCISource:

--- a/alerting/infra.py
+++ b/alerting/infra.py
@@ -5,7 +5,11 @@ reported telemetry. An episode opens only after a breach sustains across the
 configured consecutive scan count and resolves on the first positive
 observation, so every episode produces exactly two Slack messages: open and
 resolve. Unreporting wording always says a host "stopped reporting"; the
-alert never claims a machine is down.
+alert never claims a machine is down. Disk usage is keyed by the shared
+(fstype, device) group — not hostname — so a fleet-wide NFS volume pages
+once no matter how many hosts mount it; mounts with role 'other' or a
+per-mount error never alert. GPU temperature is keyed per host and GPU.
+RAM, load, and network are display-only and never alert.
 """
 
 from __future__ import annotations
@@ -34,6 +38,9 @@ from alerting.runtime import HandlerCompletion
 # A host absent from every expected source and silent for this long is
 # auto-retired: it stops alerting and stays queryable for the dashboard.
 RETIREMENT_AGE = timedelta(days=7)
+# Only these mount roles alert on disk usage; 'other' and errored mounts
+# never do. RAM, load, and network are display-only and never alert.
+DISK_ALERT_ROLES = frozenset({"workspace", "images", "data", "system"})
 
 
 class InfraAlertType(StrEnum):
@@ -58,6 +65,35 @@ class HostReport:
     """The latest successful telemetry receipt for one host."""
 
     hostname: str
+    reported_at: datetime
+
+
+@dataclass(frozen=True)
+class DiskMountObservation:
+    """One mount from a host's latest host_snapshots disk detail."""
+
+    hostname: str
+    mount_point: str
+    device: str
+    fstype: str
+    role: str
+    used_bytes: int
+    total_bytes: int
+    error: str | None
+    reported_at: datetime
+
+    @property
+    def used_percent(self) -> float:
+        return self.used_bytes / self.total_bytes * 100
+
+
+@dataclass(frozen=True)
+class GpuTemperatureObservation:
+    """One GPU's latest temperature reading from gpu_snapshots."""
+
+    hostname: str
+    gpu_index: int
+    temperature_c: float
     reported_at: datetime
 
 
@@ -123,6 +159,14 @@ class InfraSnapshotPort(Protocol):
 
     def recent_gpu_hosts(self, *, since: datetime) -> frozenset[str]:
         """Distinct hostnames with a gpu_snapshots row since `since`."""
+        ...
+
+    def disk_mounts(self) -> list[DiskMountObservation]:
+        """Every mount from each host's latest host_snapshots disk detail."""
+        ...
+
+    def gpu_temperatures(self) -> list[GpuTemperatureObservation]:
+        """The latest temperature reading per (hostname, gpu_index)."""
         ...
 
 
@@ -253,12 +297,179 @@ def _plan_unreporting(
     )
 
 
+def _disk_subject(fstype: str, device: str) -> str:
+    return f"disk:{fstype.lower()}:{device.lower()}"
+
+
+def _plan_disk_usage(
+    *,
+    now: datetime,
+    threshold: InfraThreshold,
+    disk_mounts: list[DiskMountObservation],
+    states: Mapping[tuple[str, str], InfraSubjectState],
+    open_episodes: Mapping[tuple[str, str], InfraAlertEpisode],
+) -> InfraScanPlan:
+    """Plan shared-volume episodes, deduplicated by (fstype, device).
+
+    A group breaches while any reported mount is at or above the threshold
+    and resolves only when every mount in the group drops below it, so an
+    NFS share mounted by N hosts pages once. Groups with no current
+    observations (every mounting host is silent) hold their state.
+    """
+    out_states: list[InfraSubjectState] = []
+    opened: list[InfraAlertEpisode] = []
+    resolved: list[InfraAlertEpisode] = []
+    groups: dict[str, list[DiskMountObservation]] = {}
+    for mount in disk_mounts:
+        if (
+            mount.role not in DISK_ALERT_ROLES
+            or mount.error is not None
+            or mount.total_bytes <= 0
+        ):
+            continue
+        subject = _disk_subject(mount.fstype, mount.device)
+        groups.setdefault(subject, []).append(mount)
+    for subject in sorted(groups):
+        members = groups[subject]
+        breaching = [
+            mount
+            for mount in members
+            if mount.used_percent >= threshold.threshold_value
+        ]
+        key = (InfraAlertType.DISK_USAGE.value, subject)
+        state = states.get(
+            key, InfraSubjectState(InfraAlertType.DISK_USAGE.value, subject)
+        )
+        episode = open_episodes.get(key)
+        details = {
+            "device": members[0].device,
+            "fstype": members[0].fstype,
+            "max_used_percent": round(
+                max(mount.used_percent for mount in members), 1
+            ),
+            "threshold_percent": threshold.threshold_value,
+            "mounts": [
+                {
+                    "hostname": mount.hostname,
+                    "mount_point": mount.mount_point,
+                    "used_percent": round(mount.used_percent, 1),
+                }
+                for mount in sorted(
+                    breaching, key=lambda mount: mount.used_percent, reverse=True
+                )
+            ],
+        }
+        if breaching:
+            breaches = state.consecutive_breaches + 1
+            out_states.append(
+                replace(state, consecutive_breaches=breaches, details=details)
+            )
+            if breaches >= threshold.consecutive_scans and episode is None:
+                opened.append(
+                    InfraAlertEpisode(
+                        alert_type=InfraAlertType.DISK_USAGE.value,
+                        subject_key=subject,
+                        opened_at=now,
+                        details={
+                            **details,
+                            "consecutive_scans": threshold.consecutive_scans,
+                        },
+                    )
+                )
+            continue
+        out_states.append(replace(state, consecutive_breaches=0, details=details))
+        if episode is not None:
+            resolved.append(
+                replace(
+                    episode,
+                    resolved_at=now,
+                    details={
+                        **episode.details,
+                        "resolution": "below_threshold",
+                        "max_used_percent": details["max_used_percent"],
+                    },
+                )
+            )
+    return InfraScanPlan(
+        states=tuple(out_states), opened=tuple(opened), resolved=tuple(resolved)
+    )
+
+
+def _plan_gpu_temperature(
+    *,
+    now: datetime,
+    threshold: InfraThreshold,
+    gpu_temperatures: list[GpuTemperatureObservation],
+    states: Mapping[tuple[str, str], InfraSubjectState],
+    open_episodes: Mapping[tuple[str, str], InfraAlertEpisode],
+) -> InfraScanPlan:
+    out_states: list[InfraSubjectState] = []
+    opened: list[InfraAlertEpisode] = []
+    resolved: list[InfraAlertEpisode] = []
+    observed = sorted(
+        {(reading.hostname, reading.gpu_index) for reading in gpu_temperatures}
+    )
+    latest = {
+        (reading.hostname, reading.gpu_index): reading for reading in gpu_temperatures
+    }
+    for hostname, gpu_index in observed:
+        reading = latest[(hostname, gpu_index)]
+        subject = f"gpu:{hostname}:{gpu_index}"
+        key = (InfraAlertType.GPU_TEMPERATURE.value, subject)
+        state = states.get(
+            key, InfraSubjectState(InfraAlertType.GPU_TEMPERATURE.value, subject)
+        )
+        episode = open_episodes.get(key)
+        details = {
+            "hostname": hostname,
+            "gpu_index": gpu_index,
+            "temperature_c": reading.temperature_c,
+            "threshold_celsius": threshold.threshold_value,
+        }
+        if reading.temperature_c >= threshold.threshold_value:
+            breaches = state.consecutive_breaches + 1
+            out_states.append(
+                replace(state, consecutive_breaches=breaches, details=details)
+            )
+            if breaches >= threshold.consecutive_scans and episode is None:
+                opened.append(
+                    InfraAlertEpisode(
+                        alert_type=InfraAlertType.GPU_TEMPERATURE.value,
+                        subject_key=subject,
+                        opened_at=now,
+                        details={
+                            **details,
+                            "consecutive_scans": threshold.consecutive_scans,
+                        },
+                    )
+                )
+            continue
+        out_states.append(replace(state, consecutive_breaches=0, details=details))
+        if episode is not None:
+            resolved.append(
+                replace(
+                    episode,
+                    resolved_at=now,
+                    details={
+                        **episode.details,
+                        "resolution": "below_threshold",
+                        "temperature_c": reading.temperature_c,
+                    },
+                )
+            )
+    return InfraScanPlan(
+        states=tuple(out_states), opened=tuple(opened), resolved=tuple(resolved)
+    )
+
+
 def plan_infra_scan(
     *,
     now: datetime,
     thresholds: Mapping[str, InfraThreshold],
     expected_hosts: frozenset[str],
     latest_reports: Mapping[str, datetime],
+    disk_mounts: list[DiskMountObservation],
+    gpu_temperatures: list[GpuTemperatureObservation],
     states: Mapping[tuple[str, str], InfraSubjectState],
     open_episodes: Mapping[tuple[str, str], InfraAlertEpisode],
 ) -> InfraScanPlan:
@@ -275,6 +486,28 @@ def plan_infra_scan(
                 threshold=unreporting,
                 expected_hosts=expected_hosts,
                 latest_reports=latest_reports,
+                states=states,
+                open_episodes=open_episodes,
+            )
+        )
+    disk_usage = thresholds.get(InfraAlertType.DISK_USAGE.value)
+    if disk_usage is not None and disk_usage.enabled:
+        plans.append(
+            _plan_disk_usage(
+                now=now,
+                threshold=disk_usage,
+                disk_mounts=disk_mounts,
+                states=states,
+                open_episodes=open_episodes,
+            )
+        )
+    gpu_temperature = thresholds.get(InfraAlertType.GPU_TEMPERATURE.value)
+    if gpu_temperature is not None and gpu_temperature.enabled:
+        plans.append(
+            _plan_gpu_temperature(
+                now=now,
+                threshold=gpu_temperature,
+                gpu_temperatures=gpu_temperatures,
                 states=states,
                 open_episodes=open_episodes,
             )
@@ -298,6 +531,14 @@ def _utc(value: datetime) -> str:
     return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
 
+def _render_disk_subject(details: Mapping[str, Any], subject_key: str) -> str:
+    device = details.get("device")
+    fstype = details.get("fstype")
+    if device and fstype:
+        return f"{_code(device)} ({_escape(fstype)})"
+    return _code(subject_key)
+
+
 def _render_open(episode: InfraAlertEpisode) -> str:
     if episode.alert_type == InfraAlertType.UNREPORTING:
         hostname = _code(episode.details.get("hostname") or episode.subject_key)
@@ -318,6 +559,37 @@ def _render_open(episode: InfraAlertEpisode) -> str:
                 ),
             ]
         )
+    if episode.alert_type == InfraAlertType.DISK_USAGE:
+        disk = _render_disk_subject(episode.details, episode.subject_key)
+        percent = _escape(episode.details.get("max_used_percent"))
+        threshold = _escape(episode.details.get("threshold_percent"))
+        scans = _escape(episode.details.get("consecutive_scans"))
+        lines = [
+            f":rotating_light: *Infra alert* — disk {disk} at {percent}% used "
+            f"(threshold {threshold}%, {scans} consecutive scans)",
+        ]
+        mounts = episode.details.get("mounts")
+        if isinstance(mounts, list) and mounts:
+            rendered = ", ".join(
+                f"{_code(mount.get('hostname'))}:{_escape(mount.get('mount_point'))} "
+                f"({_escape(mount.get('used_percent'))}%)"
+                for mount in mounts
+                if isinstance(mount, dict)
+            )
+            if rendered:
+                lines.append(f"Breaching mounts: {rendered}")
+        return "\n".join(lines)
+    if episode.alert_type == InfraAlertType.GPU_TEMPERATURE:
+        hostname = _code(episode.details.get("hostname"))
+        gpu_index = _escape(episode.details.get("gpu_index"))
+        temperature = _escape(episode.details.get("temperature_c"))
+        threshold = _escape(episode.details.get("threshold_celsius"))
+        scans = _escape(episode.details.get("consecutive_scans"))
+        return (
+            f":rotating_light: *Infra alert* — GPU {gpu_index} on {hostname} "
+            f"at {temperature}°C (threshold {threshold}°C, "
+            f"{scans} consecutive scans)"
+        )
     raise ValueError(f"no open renderer for alert type: {episode.alert_type}")
 
 
@@ -331,6 +603,23 @@ def _render_resolve(episode: InfraAlertEpisode) -> str:
                 "source; it no longer alerts."
             )
         return f":white_check_mark: *Infra resolved* — host {hostname} is reporting again"
+    if episode.alert_type == InfraAlertType.DISK_USAGE:
+        disk = _render_disk_subject(episode.details, episode.subject_key)
+        threshold = _escape(episode.details.get("threshold_percent"))
+        percent = _escape(episode.details.get("max_used_percent"))
+        return (
+            f":white_check_mark: *Infra resolved* — disk {disk} back below "
+            f"{threshold}% used (now {percent}%)"
+        )
+    if episode.alert_type == InfraAlertType.GPU_TEMPERATURE:
+        hostname = _code(episode.details.get("hostname"))
+        gpu_index = _escape(episode.details.get("gpu_index"))
+        threshold = _escape(episode.details.get("threshold_celsius"))
+        temperature = _escape(episode.details.get("temperature_c"))
+        return (
+            f":white_check_mark: *Infra resolved* — GPU {gpu_index} on "
+            f"{hostname} back below {threshold}°C (now {temperature}°C)"
+        )
     raise ValueError(f"no resolve renderer for alert type: {episode.alert_type}")
 
 
@@ -415,6 +704,8 @@ class InfraScanHandler:
                 report.hostname: report.reported_at
                 for report in self._snapshots.latest_reports()
             },
+            disk_mounts=self._snapshots.disk_mounts(),
+            gpu_temperatures=self._snapshots.gpu_temperatures(),
             states={
                 (state.alert_type, state.subject_key): state
                 for state in snapshot.states

--- a/alerting/infra.py
+++ b/alerting/infra.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import hashlib
 import html
 import json
+import os
 import subprocess
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field, replace
@@ -25,7 +26,7 @@ from enum import StrEnum
 from typing import Any, Protocol
 
 from alerting.commands import ScheduledCommand
-from alerting.fast_ci import slack_channel
+from alerting.fast_ci import ALERTS_SLACK_CHANNEL
 from alerting.ports import (
     AlertPath,
     Clock,
@@ -34,6 +35,18 @@ from alerting.ports import (
     NotificationIntent,
 )
 from alerting.runtime import HandlerCompletion
+
+
+def slack_channel() -> str:
+    """The channel infra alert intents post to.
+
+    SLACK_CI_INFRA_ALERT_CHANNEL (set from secrets manager) wins when set;
+    falls back to the shared alerts channel so delivery keeps working before
+    the secret is deployed. Channel naming follows the per-path convention:
+    SLACK_CI_NOTIFICATIONS_CHANNEL (Full CI), SLACK_CI_FAST_FAILURE_ALERT_CHANNEL
+    (Fast CI), SLACK_CI_INFRA_ALERT_CHANNEL (infra/queue alerts).
+    """
+    return os.environ.get("SLACK_CI_INFRA_ALERT_CHANNEL", ALERTS_SLACK_CHANNEL)
 
 # A host absent from every expected source and silent for this long is
 # auto-retired: it stops alerting and stays queryable for the dashboard.

--- a/alerting/infra.py
+++ b/alerting/infra.py
@@ -1,0 +1,520 @@
+"""Infra health alerting: unreporting hosts, disk usage, and GPU temperature.
+
+One five-minute scan reconciles the expected-host set against the latest
+reported telemetry. An episode opens only after a breach sustains across the
+configured consecutive scan count and resolves on the first positive
+observation, so every episode produces exactly two Slack messages: open and
+resolve. Unreporting wording always says a host "stopped reporting"; the
+alert never claims a machine is down.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import subprocess
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta, timezone
+from enum import StrEnum
+from typing import Any, Protocol
+
+from alerting.commands import ScheduledCommand
+from alerting.fast_ci import slack_channel
+from alerting.ports import (
+    AlertPath,
+    Clock,
+    DeliveryMode,
+    DestinationMode,
+    NotificationIntent,
+)
+from alerting.runtime import HandlerCompletion
+
+# A host absent from every expected source and silent for this long is
+# auto-retired: it stops alerting and stays queryable for the dashboard.
+RETIREMENT_AGE = timedelta(days=7)
+
+
+class InfraAlertType(StrEnum):
+    UNREPORTING = "unreporting"
+    DISK_USAGE = "disk_usage"
+    GPU_TEMPERATURE = "gpu_temperature"
+
+
+@dataclass(frozen=True)
+class InfraThreshold:
+    """One fleet-wide threshold row from alert_thresholds."""
+
+    alert_type: str
+    threshold_value: float
+    threshold_unit: str
+    consecutive_scans: int
+    enabled: bool
+
+
+@dataclass(frozen=True)
+class HostReport:
+    """The latest successful telemetry receipt for one host."""
+
+    hostname: str
+    reported_at: datetime
+
+
+@dataclass(frozen=True)
+class InfraSubjectState:
+    """Durable per-subject scan state carried between scans."""
+
+    alert_type: str
+    subject_key: str
+    consecutive_breaches: int = 0
+    last_reported_at: datetime | None = None
+    retired_at: datetime | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class InfraAlertEpisode:
+    """One open-or-resolved breach episode for an infra alert subject."""
+
+    alert_type: str
+    subject_key: str
+    opened_at: datetime
+    resolved_at: datetime | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+    alert_id: int | None = None
+
+    @property
+    def status(self) -> str:
+        return "resolved" if self.resolved_at is not None else "open"
+
+
+@dataclass(frozen=True)
+class InfraScanPlan:
+    """The state upserts and episode transitions one scan decided."""
+
+    states: tuple[InfraSubjectState, ...] = ()
+    opened: tuple[InfraAlertEpisode, ...] = ()
+    resolved: tuple[InfraAlertEpisode, ...] = ()
+
+
+@dataclass(frozen=True)
+class InfraStateSnapshot:
+    """Durable scan state and open episodes read before planning."""
+
+    states: tuple[InfraSubjectState, ...]
+    open_episodes: tuple[InfraAlertEpisode, ...]
+
+
+class ExpectedHostSource(Protocol):
+    def expected_hosts(self) -> frozenset[str]:
+        """Lowercased hostnames expected to report telemetry."""
+        ...
+
+
+class InfraSnapshotPort(Protocol):
+    """Read seam over the telemetry and threshold tables."""
+
+    def infra_thresholds(self) -> list[InfraThreshold]: ...
+
+    def latest_reports(self) -> list[HostReport]:
+        """The newest gpu/host snapshot receipt per hostname, unbounded."""
+        ...
+
+    def recent_gpu_hosts(self, *, since: datetime) -> frozenset[str]:
+        """Distinct hostnames with a gpu_snapshots row since `since`."""
+        ...
+
+
+class InfraStore(Protocol):
+    def infra_state(self) -> InfraStateSnapshot: ...
+
+    def commit_infra_scan(
+        self,
+        *,
+        command: ScheduledCommand,
+        plan: InfraScanPlan,
+        now: datetime,
+        notification_factory: InfraNotificationFactory,
+    ) -> None:
+        """Atomically persist state upserts and episode transitions, enqueue
+        notifications for the transitions that were actually applied, and
+        complete the command execution. A failure commits none of them.
+        """
+        ...
+
+
+def _plan_unreporting(
+    *,
+    now: datetime,
+    threshold: InfraThreshold,
+    expected_hosts: frozenset[str],
+    latest_reports: Mapping[str, datetime],
+    states: Mapping[tuple[str, str], InfraSubjectState],
+    open_episodes: Mapping[tuple[str, str], InfraAlertEpisode],
+) -> InfraScanPlan:
+    out_states: list[InfraSubjectState] = []
+    opened: list[InfraAlertEpisode] = []
+    resolved: list[InfraAlertEpisode] = []
+    silence = timedelta(minutes=threshold.threshold_value)
+    subjects = sorted(
+        expected_hosts
+        | {
+            subject_key
+            for alert_type, subject_key in [*states, *open_episodes]
+            if alert_type == InfraAlertType.UNREPORTING
+        }
+    )
+    for hostname in subjects:
+        key = (InfraAlertType.UNREPORTING.value, hostname)
+        state = states.get(
+            key, InfraSubjectState(InfraAlertType.UNREPORTING.value, hostname)
+        )
+        episode = open_episodes.get(key)
+        last_seen = latest_reports.get(hostname, state.last_reported_at)
+        if state.retired_at is not None:
+            # A retired host that rejoins the expected set (a replacement
+            # node reusing the name) alerts again from a clean count.
+            if hostname not in expected_hosts:
+                continue
+            state = replace(state, retired_at=None, consecutive_breaches=0)
+        fresh = last_seen is not None and now - last_seen <= silence
+        if hostname not in expected_hosts:
+            # A never-reported host has an unknown silence start, so only a
+            # positively observed last report can age it into retirement.
+            silent_too_long = (
+                last_seen is not None and now - last_seen >= RETIREMENT_AGE
+            )
+            if silent_too_long:
+                out_states.append(
+                    replace(
+                        state, last_reported_at=last_seen, retired_at=now
+                    )
+                )
+                if episode is not None:
+                    resolved.append(
+                        replace(
+                            episode,
+                            resolved_at=now,
+                            details={**episode.details, "resolution": "retired"},
+                        )
+                    )
+                continue
+            # Recently seen but no longer expected: hold the count, but a
+            # fresh report still resolves an episode the scan already opened.
+            if episode is not None and fresh:
+                out_states.append(
+                    replace(state, consecutive_breaches=0, last_reported_at=last_seen)
+                )
+                resolved.append(
+                    replace(
+                        episode,
+                        resolved_at=now,
+                        details={**episode.details, "resolution": "reporting"},
+                    )
+                )
+            continue
+        if fresh:
+            if state.consecutive_breaches or episode is not None:
+                out_states.append(
+                    replace(state, consecutive_breaches=0, last_reported_at=last_seen)
+                )
+            if episode is not None:
+                resolved.append(
+                    replace(
+                        episode,
+                        resolved_at=now,
+                        details={**episode.details, "resolution": "reporting"},
+                    )
+                )
+            continue
+        breaches = state.consecutive_breaches + 1
+        out_states.append(
+            replace(state, consecutive_breaches=breaches, last_reported_at=last_seen)
+        )
+        if breaches >= threshold.consecutive_scans and episode is None:
+            opened.append(
+                InfraAlertEpisode(
+                    alert_type=InfraAlertType.UNREPORTING.value,
+                    subject_key=hostname,
+                    opened_at=now,
+                    details={
+                        "hostname": hostname,
+                        "last_reported_at": (
+                            last_seen.isoformat() if last_seen is not None else None
+                        ),
+                        "threshold_minutes": threshold.threshold_value,
+                        "consecutive_scans": threshold.consecutive_scans,
+                    },
+                )
+            )
+    return InfraScanPlan(
+        states=tuple(out_states), opened=tuple(opened), resolved=tuple(resolved)
+    )
+
+
+def plan_infra_scan(
+    *,
+    now: datetime,
+    thresholds: Mapping[str, InfraThreshold],
+    expected_hosts: frozenset[str],
+    latest_reports: Mapping[str, datetime],
+    states: Mapping[tuple[str, str], InfraSubjectState],
+    open_episodes: Mapping[tuple[str, str], InfraAlertEpisode],
+) -> InfraScanPlan:
+    """Decide state upserts and episode transitions for one scan.
+
+    Disabled threshold rows suppress their alert type entirely.
+    """
+    plans: list[InfraScanPlan] = []
+    unreporting = thresholds.get(InfraAlertType.UNREPORTING.value)
+    if unreporting is not None and unreporting.enabled:
+        plans.append(
+            _plan_unreporting(
+                now=now,
+                threshold=unreporting,
+                expected_hosts=expected_hosts,
+                latest_reports=latest_reports,
+                states=states,
+                open_episodes=open_episodes,
+            )
+        )
+    return InfraScanPlan(
+        states=tuple(state for plan in plans for state in plan.states),
+        opened=tuple(episode for plan in plans for episode in plan.opened),
+        resolved=tuple(episode for plan in plans for episode in plan.resolved),
+    )
+
+
+def _escape(value: Any) -> str:
+    return html.escape(str(value or ""), quote=False)
+
+
+def _code(value: Any) -> str:
+    return f"`{_escape(value).replace('`', "'")}`"
+
+
+def _utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _render_open(episode: InfraAlertEpisode) -> str:
+    if episode.alert_type == InfraAlertType.UNREPORTING:
+        hostname = _code(episode.details.get("hostname") or episode.subject_key)
+        minutes = _escape(episode.details.get("threshold_minutes"))
+        scans = _escape(episode.details.get("consecutive_scans"))
+        last = episode.details.get("last_reported_at")
+        seen = (
+            f"Last report: {_escape(_utc(datetime.fromisoformat(str(last))))}"
+            if last
+            else "No report has ever been received."
+        )
+        return "\n".join(
+            [
+                f":rotating_light: *Infra alert* — host {hostname} stopped reporting",
+                (
+                    f"No successful report for over {minutes} minutes "
+                    f"({scans} consecutive scans). {seen}"
+                ),
+            ]
+        )
+    raise ValueError(f"no open renderer for alert type: {episode.alert_type}")
+
+
+def _render_resolve(episode: InfraAlertEpisode) -> str:
+    if episode.alert_type == InfraAlertType.UNREPORTING:
+        hostname = _code(episode.details.get("hostname") or episode.subject_key)
+        if episode.details.get("resolution") == "retired":
+            return (
+                f":package: *Infra retired* — host {hostname} stopped reporting "
+                "and was auto-retired after 7 days absent from every expected "
+                "source; it no longer alerts."
+            )
+        return f":white_check_mark: *Infra resolved* — host {hostname} is reporting again"
+    raise ValueError(f"no resolve renderer for alert type: {episode.alert_type}")
+
+
+InfraNotificationFactory = Callable[[InfraScanPlan], list[NotificationIntent]]
+
+
+def _intent(
+    episode: InfraAlertEpisode,
+    *,
+    opening: bool,
+    delivery_mode: DeliveryMode,
+) -> NotificationIntent:
+    digest = hashlib.sha256(
+        f"{episode.alert_type}\0{episode.subject_key}".encode()
+    ).hexdigest()[:16]
+    epoch = int(episode.opened_at.timestamp())
+    verb = "open" if opening else "resolve"
+    delivery_id = f"infra:{episode.alert_type}:{digest}:{epoch}:{verb}"
+    return NotificationIntent(
+        delivery_id=delivery_id,
+        alert_ref=f"infra:{episode.alert_type}:{episode.subject_key}",
+        alert_path=AlertPath.INFRA,
+        delivery_mode=delivery_mode,
+        destination_mode=DestinationMode.BOT_TOKEN,
+        destination=slack_channel(),
+        payload={
+            "text": _render_open(episode) if opening else _render_resolve(episode)
+        },
+    )
+
+
+def infra_notifications(
+    plan: InfraScanPlan, *, delivery_mode: DeliveryMode
+) -> list[NotificationIntent]:
+    """Render exactly one intent per applied transition: open and resolve."""
+    return [
+        *(
+            _intent(episode, opening=True, delivery_mode=delivery_mode)
+            for episode in plan.opened
+        ),
+        *(
+            _intent(episode, opening=False, delivery_mode=delivery_mode)
+            for episode in plan.resolved
+        ),
+    ]
+
+
+class InfraScanHandler:
+    """Run one infra health scan and atomically persist its durable effects."""
+
+    def __init__(
+        self,
+        *,
+        hosts: ExpectedHostSource,
+        snapshots: InfraSnapshotPort,
+        store: InfraStore,
+        clock: Clock,
+        delivery_mode: DeliveryMode = DeliveryMode.LIVE,
+    ) -> None:
+        self._hosts = hosts
+        self._snapshots = snapshots
+        self._store = store
+        self._clock = clock
+        self._delivery_mode = delivery_mode
+
+    def __call__(self, command: ScheduledCommand) -> HandlerCompletion:
+        now = command.target_time
+        expected = frozenset(
+            hostname.lower()
+            for hostname in self._hosts.expected_hosts()
+            if hostname.strip()
+        ) | self._snapshots.recent_gpu_hosts(since=now - RETIREMENT_AGE)
+        snapshot = self._store.infra_state()
+        plan = plan_infra_scan(
+            now=now,
+            thresholds={
+                threshold.alert_type: threshold
+                for threshold in self._snapshots.infra_thresholds()
+            },
+            expected_hosts=expected,
+            latest_reports={
+                report.hostname: report.reported_at
+                for report in self._snapshots.latest_reports()
+            },
+            states={
+                (state.alert_type, state.subject_key): state
+                for state in snapshot.states
+            },
+            open_episodes={
+                (episode.alert_type, episode.subject_key): episode
+                for episode in snapshot.open_episodes
+            },
+        )
+        self._store.commit_infra_scan(
+            command=command,
+            plan=plan,
+            now=self._clock.now(),
+            notification_factory=lambda applied: infra_notifications(
+                applied, delivery_mode=self._delivery_mode
+            ),
+        )
+        return HandlerCompletion.TRANSACTIONAL
+
+
+class UnionExpectedHostSource:
+    """The expected-host set is the union of every configured source."""
+
+    def __init__(self, sources: Iterable[ExpectedHostSource]) -> None:
+        self._sources = list(sources)
+
+    def expected_hosts(self) -> frozenset[str]:
+        hosts: set[str] = set()
+        for source in self._sources:
+            hosts.update(source.expected_hosts())
+        return frozenset(hostname.lower() for hostname in hosts if hostname.strip())
+
+
+class KubectlNodesSource:
+    """Node names from one Kubernetes cluster, read through kubectl."""
+
+    def __init__(
+        self,
+        *,
+        kubeconfig: str,
+        kubectl: str = "kubectl",
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self._kubeconfig = kubeconfig
+        self._kubectl = kubectl
+        self._timeout_seconds = timeout_seconds
+
+    def expected_hosts(self) -> frozenset[str]:
+        result = subprocess.run(
+            [
+                self._kubectl,
+                "--kubeconfig",
+                self._kubeconfig,
+                "get",
+                "nodes",
+                "-o",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=self._timeout_seconds,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"kubectl get nodes failed: {result.stderr.strip()[:500]}"
+            )
+        payload = json.loads(result.stdout)
+        items = payload.get("items") if isinstance(payload, dict) else None
+        if not isinstance(items, list):
+            raise RuntimeError("kubectl get nodes returned an invalid response")
+        return frozenset(
+            name
+            for item in items
+            if isinstance(item, dict)
+            and isinstance(item.get("metadata"), dict)
+            for name in [str(item["metadata"].get("name") or "").strip().lower()]
+            if name
+        )
+
+
+class BuildkiteAgentPort(Protocol):
+    def list_agents(self, *, queue: str) -> list[dict[str, Any]]: ...
+
+
+class BuildkiteGpuQueueAgentsSource:
+    """GPU-queue Buildkite agents, keyed by their lowercased hostname.
+
+    These cover the bare-metal hosts that run reporters without being
+    Kubernetes nodes.
+    """
+
+    def __init__(self, *, buildkite: BuildkiteAgentPort, queue: str = "gpu") -> None:
+        self._buildkite = buildkite
+        self._queue = queue
+
+    def expected_hosts(self) -> frozenset[str]:
+        return frozenset(
+            hostname
+            for agent in self._buildkite.list_agents(queue=self._queue)
+            for hostname in [str(agent.get("hostname") or "").strip().lower()]
+            if hostname
+        )

--- a/alerting/memory.py
+++ b/alerting/memory.py
@@ -35,6 +35,13 @@ from alerting.full_ci import (
     FullCIRun,
     ordered_unique_runs,
 )
+from alerting.infra import (
+    InfraAlertEpisode,
+    InfraNotificationFactory,
+    InfraScanPlan,
+    InfraStateSnapshot,
+    InfraSubjectState,
+)
 from alerting.main_ci import (
     MainCIJobAlert,
     MainCIJobObservation,
@@ -536,6 +543,106 @@ class InMemoryMainCIStore:
 
     def state(self, job_key: str) -> MainCIJobObservation | None:
         return self._states.get(job_key)
+
+
+class InMemoryInfraStore:
+    """Atomic in-memory model of infra subject state and alert episodes."""
+
+    def __init__(
+        self,
+        *,
+        executions: InMemoryAutomationExecutionStore,
+        outbox: InMemoryOutboxStore,
+    ) -> None:
+        self._executions = executions
+        self._outbox = outbox
+        self._states: dict[tuple[str, str], InfraSubjectState] = {}
+        self._episodes: list[InfraAlertEpisode] = []
+        self._active: dict[tuple[str, str], int] = {}
+        self._fail_commit = False
+
+    def infra_state(self) -> InfraStateSnapshot:
+        return InfraStateSnapshot(
+            states=tuple(self._states.values()),
+            open_episodes=tuple(
+                self._episodes[index] for index in self._active.values()
+            ),
+        )
+
+    def commit_infra_scan(
+        self,
+        *,
+        command: ScheduledCommand,
+        plan: InfraScanPlan,
+        now: datetime,
+        notification_factory: InfraNotificationFactory,
+    ) -> None:
+        execution_snapshot = self._executions._snapshot()
+        outbox_snapshot = self._outbox._snapshot()
+        states_snapshot = dict(self._states)
+        episodes_snapshot = list(self._episodes)
+        active_snapshot = dict(self._active)
+        try:
+            for state in plan.states:
+                self._states[(state.alert_type, state.subject_key)] = state
+            applied = InfraScanPlan(
+                states=plan.states,
+                opened=tuple(
+                    episode
+                    for episode in plan.opened
+                    if self._open_episode(episode)
+                ),
+                resolved=tuple(
+                    episode
+                    for episode in plan.resolved
+                    if self._resolve_episode(episode)
+                ),
+            )
+            for message in notification_factory(applied):
+                self._outbox.enqueue(message, now=now)
+            if self._fail_commit:
+                self._fail_commit = False
+                raise RuntimeError("Infra transaction failed")
+            self._executions.complete(command.idempotency_key, now=now)
+        except Exception:
+            self._executions._restore(execution_snapshot)
+            self._outbox._restore(outbox_snapshot)
+            self._states = states_snapshot
+            self._episodes = episodes_snapshot
+            self._active = active_snapshot
+            raise
+
+    def _open_episode(self, episode: InfraAlertEpisode) -> bool:
+        key = (episode.alert_type, episode.subject_key)
+        if key in self._active:
+            return False
+        self._episodes.append(replace(episode, alert_id=len(self._episodes) + 1))
+        self._active[key] = len(self._episodes) - 1
+        return True
+
+    def _resolve_episode(self, episode: InfraAlertEpisode) -> bool:
+        index = self._active.pop((episode.alert_type, episode.subject_key), None)
+        if index is None:
+            return False
+        current = self._episodes[index]
+        self._episodes[index] = replace(
+            current, resolved_at=episode.resolved_at, details=episode.details
+        )
+        return True
+
+    def episodes(self) -> list[InfraAlertEpisode]:
+        return list(self._episodes)
+
+    def open_episodes(self) -> list[InfraAlertEpisode]:
+        return [self._episodes[index] for index in self._active.values()]
+
+    def subject_state(
+        self, alert_type: str, subject_key: str
+    ) -> InfraSubjectState | None:
+        return self._states.get((alert_type, subject_key))
+
+    def fail_next_commit(self) -> None:
+        self._fail_commit = True
 
 
 class InMemoryMainCIAnalysisStore:

--- a/alerting/ports.py
+++ b/alerting/ports.py
@@ -53,6 +53,7 @@ class AlertPath(StrEnum):
     FAST_CI = "fast_ci"
     FULL_CI = "full_ci"
     MAIN_CI = "main_ci"
+    INFRA = "infra"
 
 
 class DeliveryMode(StrEnum):

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -33,6 +33,15 @@ from alerting.full_ci import (
     FullCIRun,
     ordered_unique_runs,
 )
+from alerting.infra import (
+    HostReport,
+    InfraAlertEpisode,
+    InfraNotificationFactory,
+    InfraScanPlan,
+    InfraStateSnapshot,
+    InfraSubjectState,
+    InfraThreshold,
+)
 from alerting.main_ci import (
     MainCIJobObservation,
     MainCIOpenAlertRef,
@@ -1048,6 +1057,203 @@ class PostgresAlertStore:
             for row in rows
         ]
 
+    def infra_thresholds(self) -> list[InfraThreshold]:
+        with self._connection_factory() as connection:
+            rows = connection.execute(
+                """
+                SELECT alert_type, threshold_value, threshold_unit,
+                       consecutive_scans, enabled
+                FROM alert_thresholds
+                """
+            ).fetchall()
+        return [
+            InfraThreshold(
+                alert_type=str(row[0]),
+                threshold_value=float(row[1]),
+                threshold_unit=str(row[2]),
+                consecutive_scans=int(row[3]),
+                enabled=bool(row[4]),
+            )
+            for row in rows
+        ]
+
+    def latest_reports(self) -> list[HostReport]:
+        """Newest gpu or host snapshot receipt per hostname, unbounded."""
+        with self._connection_factory() as connection:
+            rows = connection.execute(
+                """
+                WITH gpu AS (
+                    SELECT DISTINCT ON (hostname) hostname, reported_at
+                    FROM gpu_snapshots
+                    ORDER BY hostname, reported_at DESC
+                ),
+                host AS (
+                    SELECT DISTINCT ON (hostname) hostname, reported_at
+                    FROM host_snapshots
+                    ORDER BY hostname, reported_at DESC
+                )
+                SELECT COALESCE(gpu.hostname, host.hostname),
+                       GREATEST(gpu.reported_at, host.reported_at)
+                FROM gpu
+                FULL OUTER JOIN host ON host.hostname = gpu.hostname
+                """
+            ).fetchall()
+        return [HostReport(hostname=row[0], reported_at=row[1]) for row in rows]
+
+    def recent_gpu_hosts(self, *, since: datetime) -> frozenset[str]:
+        with self._connection_factory() as connection:
+            rows = connection.execute(
+                """
+                SELECT DISTINCT hostname
+                FROM gpu_snapshots
+                WHERE reported_at >= %s
+                """,
+                (since,),
+            ).fetchall()
+        return frozenset(str(row[0]) for row in rows)
+
+    def infra_state(self) -> InfraStateSnapshot:
+        with self._connection_factory() as connection:
+            state_rows = connection.execute(
+                """
+                SELECT alert_type, subject_key, consecutive_breaches,
+                       last_reported_at, retired_at, details
+                FROM alerting_infra_host_states
+                """
+            ).fetchall()
+            episode_rows = connection.execute(
+                """
+                SELECT alert_id, alert_type, subject_key, opened_at, details
+                FROM alerting_infra_alerts
+                WHERE status = 'open'
+                """
+            ).fetchall()
+        return InfraStateSnapshot(
+            states=tuple(
+                InfraSubjectState(
+                    alert_type=row[0],
+                    subject_key=row[1],
+                    consecutive_breaches=int(row[2]),
+                    last_reported_at=row[3],
+                    retired_at=row[4],
+                    details=dict(row[5]),
+                )
+                for row in state_rows
+            ),
+            open_episodes=tuple(
+                InfraAlertEpisode(
+                    alert_id=int(row[0]),
+                    alert_type=row[1],
+                    subject_key=row[2],
+                    opened_at=row[3],
+                    details=dict(row[4]),
+                )
+                for row in episode_rows
+            ),
+        )
+
+    def commit_infra_scan(
+        self,
+        *,
+        command: ScheduledCommand,
+        plan: InfraScanPlan,
+        now: datetime,
+        notification_factory: InfraNotificationFactory,
+    ) -> None:
+        with self._connection_factory() as connection:
+            with connection.transaction():
+                connection.execute(
+                    """
+                    SELECT pg_advisory_xact_lock(
+                        hashtext('alerting_infra_scan')
+                    )
+                    """
+                )
+                for state in plan.states:
+                    connection.execute(
+                        """
+                        INSERT INTO alerting_infra_host_states (
+                            alert_type, subject_key, consecutive_breaches,
+                            last_reported_at, retired_at, details, updated_at
+                        ) VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s)
+                        ON CONFLICT (alert_type, subject_key) DO UPDATE
+                        SET consecutive_breaches = EXCLUDED.consecutive_breaches,
+                            last_reported_at = EXCLUDED.last_reported_at,
+                            retired_at = EXCLUDED.retired_at,
+                            details = EXCLUDED.details,
+                            updated_at = EXCLUDED.updated_at
+                        """,
+                        (
+                            state.alert_type,
+                            state.subject_key,
+                            state.consecutive_breaches,
+                            state.last_reported_at,
+                            state.retired_at,
+                            json.dumps(state.details),
+                            now,
+                        ),
+                    )
+                opened: list[InfraAlertEpisode] = []
+                for episode in plan.opened:
+                    inserted = connection.execute(
+                        """
+                        INSERT INTO alerting_infra_alerts (
+                            alert_type, subject_key, status, opened_at,
+                            details, created_at, updated_at
+                        ) VALUES (%s, %s, 'open', %s, %s::jsonb, %s, %s)
+                        ON CONFLICT (alert_type, subject_key)
+                        WHERE status = 'open' DO NOTHING
+                        """,
+                        (
+                            episode.alert_type,
+                            episode.subject_key,
+                            episode.opened_at,
+                            json.dumps(episode.details),
+                            now,
+                            now,
+                        ),
+                    )
+                    if inserted.rowcount == 1:
+                        opened.append(episode)
+                resolved: list[InfraAlertEpisode] = []
+                for episode in plan.resolved:
+                    updated = connection.execute(
+                        """
+                        UPDATE alerting_infra_alerts
+                        SET status = 'resolved', resolved_at = %s,
+                            details = %s::jsonb, updated_at = %s
+                        WHERE alert_type = %s AND subject_key = %s
+                          AND status = 'open'
+                        """,
+                        (
+                            episode.resolved_at,
+                            json.dumps(episode.details),
+                            now,
+                            episode.alert_type,
+                            episode.subject_key,
+                        ),
+                    )
+                    if updated.rowcount == 1:
+                        resolved.append(episode)
+                applied = InfraScanPlan(
+                    states=plan.states,
+                    opened=tuple(opened),
+                    resolved=tuple(resolved),
+                )
+                for message in notification_factory(applied):
+                    self._enqueue(connection, message, next_attempt_at=now)
+                completed = connection.execute(
+                    """
+                    UPDATE alerting_automation_executions
+                    SET status = 'completed', completed_at = %s,
+                        lease_expires_at = NULL, last_error = NULL
+                    WHERE idempotency_key = %s AND status = 'running'
+                    """,
+                    (now, command.idempotency_key),
+                )
+                if completed.rowcount != 1:
+                    raise RuntimeError("Infra execution was not running at commit")
+
     def pending_main_ci_analyses(self, *, limit: int) -> list[MainCIAnalysisTarget]:
         with self._connection_factory() as connection:
             rows = connection.execute(
@@ -1628,6 +1834,52 @@ def build_main_ci_backstop_runtime(
         clock=clock,
         handlers={"main_ci_backstop": handler},
         alert_path=AlertPath.MAIN_CI,
+    )
+
+
+def build_infra_runtime(
+    *,
+    database_url: str,
+    buildkite_token: str,
+    kubeconfigs: list[str],
+    slack: SlackPort,
+    clock: Clock,
+    delivery_mode: DeliveryMode = DeliveryMode.LIVE,
+    buildkite_queue: str = "gpu",
+) -> AlertingRuntime:
+    """Wire the infra health scan: kubectl nodes + GPU-queue agents + Postgres."""
+    from alerting.full_ci import BuildkiteRestClient
+    from alerting.infra import (
+        BuildkiteGpuQueueAgentsSource,
+        InfraScanHandler,
+        KubectlNodesSource,
+        UnionExpectedHostSource,
+    )
+
+    store = PostgresAlertStore.from_database_url(database_url)
+    hosts = UnionExpectedHostSource(
+        [
+            *(KubectlNodesSource(kubeconfig=path) for path in kubeconfigs),
+            BuildkiteGpuQueueAgentsSource(
+                buildkite=BuildkiteRestClient(token=buildkite_token),
+                queue=buildkite_queue,
+            ),
+        ]
+    )
+    handler = InfraScanHandler(
+        hosts=hosts,
+        snapshots=store,
+        store=store,
+        clock=clock,
+        delivery_mode=delivery_mode,
+    )
+    return AlertingRuntime(
+        executions=store,
+        outbox=store,
+        slack=slack,
+        clock=clock,
+        handlers={"infra_scan": handler},
+        alert_path=AlertPath.INFRA,
     )
 
 

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -34,6 +34,8 @@ from alerting.full_ci import (
     ordered_unique_runs,
 )
 from alerting.infra import (
+    DiskMountObservation,
+    GpuTemperatureObservation,
     HostReport,
     InfraAlertEpisode,
     InfraNotificationFactory,
@@ -1111,6 +1113,66 @@ class PostgresAlertStore:
                 (since,),
             ).fetchall()
         return frozenset(str(row[0]) for row in rows)
+
+    def disk_mounts(self) -> list[DiskMountObservation]:
+        """Every mount from each host's latest host_snapshots disk detail."""
+        with self._connection_factory() as connection:
+            rows = connection.execute(
+                """
+                WITH latest AS (
+                    SELECT DISTINCT ON (hostname) hostname, disks, reported_at
+                    FROM host_snapshots
+                    ORDER BY hostname, reported_at DESC
+                )
+                SELECT latest.hostname,
+                       mount->>'mount_point',
+                       mount->>'device',
+                       mount->>'fstype',
+                       mount->>'role',
+                       (mount->>'used_bytes')::bigint,
+                       (mount->>'total_bytes')::bigint,
+                       mount->>'error',
+                       latest.reported_at
+                FROM latest,
+                LATERAL jsonb_array_elements(latest.disks) AS mount
+                WHERE latest.disks IS NOT NULL
+                """
+            ).fetchall()
+        return [
+            DiskMountObservation(
+                hostname=str(row[0]),
+                mount_point=str(row[1] or ""),
+                device=str(row[2] or ""),
+                fstype=str(row[3] or ""),
+                role=str(row[4] or ""),
+                used_bytes=int(row[5] or 0),
+                total_bytes=int(row[6] or 0),
+                error=str(row[7]) if row[7] is not None else None,
+                reported_at=row[8],
+            )
+            for row in rows
+        ]
+
+    def gpu_temperatures(self) -> list[GpuTemperatureObservation]:
+        with self._connection_factory() as connection:
+            rows = connection.execute(
+                """
+                SELECT DISTINCT ON (hostname, gpu_index)
+                       hostname, gpu_index, temperature_c, reported_at
+                FROM gpu_snapshots
+                WHERE temperature_c IS NOT NULL
+                ORDER BY hostname, gpu_index, reported_at DESC
+                """
+            ).fetchall()
+        return [
+            GpuTemperatureObservation(
+                hostname=str(row[0]),
+                gpu_index=int(row[1]),
+                temperature_c=float(row[2]),
+                reported_at=row[3],
+            )
+            for row in rows
+        ]
 
     def infra_state(self) -> InfraStateSnapshot:
         with self._connection_factory() as connection:

--- a/alerting/tests/test_control.py
+++ b/alerting/tests/test_control.py
@@ -46,6 +46,7 @@ def test_reconcile_controls_defaults_missing_path_to_shadow_and_disables_one_pat
             AlertPath.FAST_CI: None,
             AlertPath.FULL_CI: ControlMode.DISABLED,
             AlertPath.MAIN_CI: ControlMode.DISABLED,
+            AlertPath.INFRA: ControlMode.DISABLED,
         }
     )
     units = RecordingUnits()
@@ -62,18 +63,23 @@ def test_reconcile_controls_defaults_missing_path_to_shadow_and_disables_one_pat
     assert (tmp_path / "main-ci.mode").read_text() == (
         "ALERTING_DELIVERY_MODE=shadow\n"
     )
+    assert (tmp_path / "infra.mode").read_text() == (
+        "ALERTING_DELIVERY_MODE=shadow\n"
+    )
     assert units.enabled == ["alerting-fast-ci.timer"]
     assert units.disabled == [
         "alerting-full-ci.timer",
         "alerting-main-ci.timer",
         "alerting-main-ci-analysis.timer",
         "alerting-main-ci-backstop.timer",
+        "alerting-infra.timer",
     ]
     assert units.stopped == [
         "alerting-full-ci.service",
         "alerting-main-ci.service",
         "alerting-main-ci-analysis.service",
         "alerting-main-ci-backstop.service",
+        "alerting-infra.service",
     ]
 
 
@@ -83,6 +89,7 @@ def test_live_control_enables_only_selected_path(tmp_path: Path) -> None:
             AlertPath.FAST_CI: ControlMode.DISABLED,
             AlertPath.FULL_CI: ControlMode.LIVE,
             AlertPath.MAIN_CI: ControlMode.DISABLED,
+            AlertPath.INFRA: ControlMode.DISABLED,
         }
     )
     units = RecordingUnits()
@@ -99,6 +106,7 @@ def test_main_ci_live_control_enables_its_independent_timers(tmp_path: Path) -> 
             AlertPath.FAST_CI: ControlMode.DISABLED,
             AlertPath.FULL_CI: ControlMode.DISABLED,
             AlertPath.MAIN_CI: ControlMode.LIVE,
+            AlertPath.INFRA: ControlMode.DISABLED,
         }
     )
     units = RecordingUnits()
@@ -113,3 +121,38 @@ def test_main_ci_live_control_enables_its_independent_timers(tmp_path: Path) -> 
         "alerting-main-ci-analysis.timer",
         "alerting-main-ci-backstop.timer",
     ]
+
+
+def test_infra_live_control_enables_its_timer_and_mode(tmp_path: Path) -> None:
+    controls = MemoryAlertControl(
+        {
+            AlertPath.FAST_CI: ControlMode.DISABLED,
+            AlertPath.FULL_CI: ControlMode.DISABLED,
+            AlertPath.MAIN_CI: ControlMode.DISABLED,
+            AlertPath.INFRA: ControlMode.LIVE,
+        }
+    )
+    units = RecordingUnits()
+
+    reconcile_controls(controls=controls, units=units, mode_dir=tmp_path)
+
+    assert (tmp_path / "infra.mode").read_text() == "ALERTING_DELIVERY_MODE=live\n"
+    assert units.enabled == ["alerting-infra.timer"]
+
+
+def test_missing_infra_control_defaults_to_shadow(tmp_path: Path) -> None:
+    controls = MemoryAlertControl(
+        {
+            AlertPath.FAST_CI: ControlMode.DISABLED,
+            AlertPath.FULL_CI: ControlMode.DISABLED,
+            AlertPath.MAIN_CI: ControlMode.DISABLED,
+            AlertPath.INFRA: None,
+        }
+    )
+    units = RecordingUnits()
+
+    reconcile_controls(controls=controls, units=units, mode_dir=tmp_path)
+
+    assert controls.writes == [(AlertPath.INFRA, ControlMode.SHADOW)]
+    assert (tmp_path / "infra.mode").read_text() == "ALERTING_DELIVERY_MODE=shadow\n"
+    assert units.enabled == ["alerting-infra.timer"]

--- a/alerting/tests/test_infra.py
+++ b/alerting/tests/test_infra.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 
 from alerting.commands import ScheduledCommand
+from alerting.fast_ci import ALERTS_SLACK_CHANNEL
 from alerting.full_ci import BuildkiteRestClient
 from alerting.infra import (
     RETIREMENT_AGE,
@@ -22,6 +23,7 @@ from alerting.infra import (
     InfraThreshold,
     KubectlNodesSource,
     UnionExpectedHostSource,
+    slack_channel,
 )
 from alerting.memory import (
     FixedClock,
@@ -620,3 +622,13 @@ def test_expected_host_set_is_the_union_of_sources() -> None:
     )
 
     assert source.expected_hosts() == frozenset({"gpu-h100-01", "h200-ci-1"})
+
+
+def test_infra_alerts_post_to_the_infra_channel_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SLACK_CI_INFRA_ALERT_CHANNEL", raising=False)
+    assert slack_channel() == ALERTS_SLACK_CHANNEL
+
+    monkeypatch.setenv("SLACK_CI_INFRA_ALERT_CHANNEL", "C-INFRA-1")
+    assert slack_channel() == "C-INFRA-1"

--- a/alerting/tests/test_infra.py
+++ b/alerting/tests/test_infra.py
@@ -1,4 +1,4 @@
-"""Infra unreporting-host scans through the scheduled-command seam."""
+"""Infra health scans through the scheduled-command seam."""
 
 from __future__ import annotations
 
@@ -14,10 +14,12 @@ from alerting.full_ci import BuildkiteRestClient
 from alerting.infra import (
     RETIREMENT_AGE,
     BuildkiteGpuQueueAgentsSource,
+    DiskMountObservation,
+    GpuTemperatureObservation,
     HostReport,
+    InfraAlertType,
     InfraScanHandler,
     InfraThreshold,
-    InfraAlertType,
     KubectlNodesSource,
     UnionExpectedHostSource,
 )
@@ -57,6 +59,8 @@ class FixtureSnapshots:
         ]
         self.gpu_reports: dict[str, datetime] = {}
         self.host_reports: dict[str, datetime] = {}
+        self.disks: list[DiskMountObservation] = []
+        self.temps: list[GpuTemperatureObservation] = []
 
     def infra_thresholds(self) -> list[InfraThreshold]:
         return list(self.threshold_rows)
@@ -76,6 +80,54 @@ class FixtureSnapshots:
             for hostname, reported_at in self.gpu_reports.items()
             if reported_at >= since
         )
+
+    def disk_mounts(self) -> list[DiskMountObservation]:
+        return list(self.disks)
+
+    def gpu_temperatures(self) -> list[GpuTemperatureObservation]:
+        return list(self.temps)
+
+
+def threshold(
+    alert_type: InfraAlertType,
+    value: float,
+    unit: str,
+    *,
+    scans: int = 2,
+    enabled: bool = True,
+) -> InfraThreshold:
+    return InfraThreshold(
+        alert_type=alert_type.value,
+        threshold_value=value,
+        threshold_unit=unit,
+        consecutive_scans=scans,
+        enabled=enabled,
+    )
+
+
+def mount(
+    hostname: str,
+    device: str,
+    *,
+    fstype: str = "nfs4",
+    role: str = "data",
+    used_percent: float = 95.0,
+    mount_point: str = "/data",
+    error: str | None = None,
+    reported_at: datetime = START,
+) -> DiskMountObservation:
+    total_bytes = 1000
+    return DiskMountObservation(
+        hostname=hostname,
+        mount_point=mount_point,
+        device=device,
+        fstype=fstype,
+        role=role,
+        used_bytes=int(total_bytes * used_percent / 100),
+        total_bytes=total_bytes,
+        error=error,
+        reported_at=reported_at,
+    )
 
 
 def runtime_for(
@@ -307,6 +359,156 @@ def test_failed_commit_rolls_back_state_episode_and_outbox_before_retry() -> Non
     scan(runtime, START + timedelta(minutes=5))
     assert [episode.status for episode in store.episodes()] == ["open"]
     assert outbox.count() == 1
+
+
+def test_shared_nfs_volume_pages_once_regardless_of_mounting_host_count() -> None:
+    snapshots = FixtureSnapshots()
+    snapshots.threshold_rows.append(
+        threshold(InfraAlertType.DISK_USAGE, 90, "percent")
+    )
+    snapshots.disks = [
+        mount("h200-ci-1", "nfs01:/exports/ci"),
+        mount("h200-ci-2", "nfs01:/exports/ci"),
+    ]
+    runtime, store, outbox, slack, clock = runtime_for(FixtureHosts(), snapshots)
+
+    scan(runtime, clock.now())
+    assert store.episodes() == []
+
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    runtime.dispatch_due_notifications()
+
+    episodes = store.episodes()
+    assert [(episode.alert_type, episode.status) for episode in episodes] == [
+        ("disk_usage", "open")
+    ]
+    assert episodes[0].subject_key == "disk:nfs4:nfs01:/exports/ci"
+    assert outbox.count() == 1
+    text = slack.deliveries[0].payload["text"]
+    assert "nfs01:/exports/ci" in text
+    assert "h200-ci-1" in text and "h200-ci-2" in text
+
+    # One mounting host dropping below the threshold does not resolve the
+    # shared episode while another host still breaches.
+    snapshots.disks = [
+        mount("h200-ci-1", "nfs01:/exports/ci", used_percent=50.0),
+        mount("h200-ci-2", "nfs01:/exports/ci"),
+    ]
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    runtime.dispatch_due_notifications()
+    assert [episode.status for episode in store.episodes()] == ["open"]
+    assert outbox.count() == 1
+
+    # The episode resolves only when every mount in the group is below.
+    snapshots.disks = [
+        mount("h200-ci-1", "nfs01:/exports/ci", used_percent=50.0),
+        mount("h200-ci-2", "nfs01:/exports/ci", used_percent=40.0),
+    ]
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    runtime.dispatch_due_notifications()
+    assert [episode.status for episode in store.episodes()] == ["resolved"]
+    assert outbox.count() == 2
+    assert "back below" in slack.deliveries[1].payload["text"]
+
+
+def test_other_role_and_errored_mounts_never_alert() -> None:
+    snapshots = FixtureSnapshots()
+    snapshots.threshold_rows.append(
+        threshold(InfraAlertType.DISK_USAGE, 90, "percent")
+    )
+    snapshots.disks = [
+        mount("h200-ci-1", "/dev/sdb1", fstype="ext4", role="other",
+              used_percent=99.0, mount_point="/scratch"),
+        mount("h200-ci-1", "nfs01:/exports/ci", used_percent=99.0,
+              error="i/o error"),
+    ]
+    runtime, store, outbox, _, clock = runtime_for(FixtureHosts(), snapshots)
+
+    scan(runtime, clock.now())
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+
+    assert store.episodes() == []
+    assert outbox.count() == 0
+
+
+def test_disabled_disk_threshold_suppresses_alerts() -> None:
+    snapshots = FixtureSnapshots()
+    snapshots.threshold_rows.append(
+        threshold(InfraAlertType.DISK_USAGE, 90, "percent", enabled=False)
+    )
+    snapshots.disks = [mount("h200-ci-1", "nfs01:/exports/ci")]
+    runtime, store, outbox, _, clock = runtime_for(FixtureHosts(), snapshots)
+
+    scan(runtime, clock.now())
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+
+    assert store.episodes() == []
+    assert outbox.count() == 0
+
+    # Re-enabling the row resumes detection with a clean consecutive count.
+    snapshots.threshold_rows[1] = threshold(InfraAlertType.DISK_USAGE, 90, "percent")
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    assert store.episodes() == []
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    assert [episode.status for episode in store.episodes()] == ["open"]
+
+
+def test_gpu_temperature_requires_sustained_breach_across_scans() -> None:
+    snapshots = FixtureSnapshots()
+    snapshots.threshold_rows.append(
+        threshold(InfraAlertType.GPU_TEMPERATURE, 85, "celsius")
+    )
+    snapshots.temps = [
+        GpuTemperatureObservation(
+            hostname="gpu-h100-01",
+            gpu_index=3,
+            temperature_c=92.0,
+            reported_at=START,
+        )
+    ]
+    runtime, store, outbox, slack, clock = runtime_for(FixtureHosts(), snapshots)
+
+    scan(runtime, clock.now())
+    assert store.episodes() == []
+    assert outbox.count() == 0
+
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    runtime.dispatch_due_notifications()
+
+    [episode] = store.episodes()
+    assert episode.alert_type == "gpu_temperature"
+    assert episode.subject_key == "gpu:gpu-h100-01:3"
+    assert episode.status == "open"
+    text = slack.deliveries[0].payload["text"]
+    assert "GPU 3" in text
+    assert "gpu-h100-01" in text
+    assert "92.0°C" in text
+
+    snapshots.temps = [
+        GpuTemperatureObservation(
+            hostname="gpu-h100-01",
+            gpu_index=3,
+            temperature_c=70.0,
+            reported_at=clock.now(),
+        )
+    ]
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    runtime.dispatch_due_notifications()
+
+    assert [episode.status for episode in store.episodes()] == ["resolved"]
+    assert outbox.count() == 2
+    assert "back below" in slack.deliveries[1].payload["text"]
 
 
 class _FakeCompletedProcess:

--- a/alerting/tests/test_infra.py
+++ b/alerting/tests/test_infra.py
@@ -1,0 +1,420 @@
+"""Infra unreporting-host scans through the scheduled-command seam."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from alerting.commands import ScheduledCommand
+from alerting.full_ci import BuildkiteRestClient
+from alerting.infra import (
+    RETIREMENT_AGE,
+    BuildkiteGpuQueueAgentsSource,
+    HostReport,
+    InfraScanHandler,
+    InfraThreshold,
+    InfraAlertType,
+    KubectlNodesSource,
+    UnionExpectedHostSource,
+)
+from alerting.memory import (
+    FixedClock,
+    InMemoryAutomationExecutionStore,
+    InMemoryInfraStore,
+    InMemoryOutboxStore,
+    RecordingSlackPort,
+)
+from alerting.ports import DeliveryMode
+from alerting.runtime import AlertingRuntime, ProcessStatus
+
+START = datetime(2026, 9, 2, 10, 0, tzinfo=timezone.utc)
+
+
+class FixtureHosts:
+    def __init__(self, hosts: set[str] | None = None) -> None:
+        self.hosts = hosts if hosts is not None else set()
+
+    def expected_hosts(self) -> frozenset[str]:
+        return frozenset(self.hosts)
+
+
+class FixtureSnapshots:
+    """In-memory gpu/host snapshot tables plus fleet thresholds."""
+
+    def __init__(self) -> None:
+        self.threshold_rows = [
+            InfraThreshold(
+                alert_type=InfraAlertType.UNREPORTING.value,
+                threshold_value=10,
+                threshold_unit="minutes",
+                consecutive_scans=2,
+                enabled=True,
+            )
+        ]
+        self.gpu_reports: dict[str, datetime] = {}
+        self.host_reports: dict[str, datetime] = {}
+
+    def infra_thresholds(self) -> list[InfraThreshold]:
+        return list(self.threshold_rows)
+
+    def latest_reports(self) -> list[HostReport]:
+        merged = dict(self.host_reports)
+        for hostname, reported_at in self.gpu_reports.items():
+            merged[hostname] = max(reported_at, merged.get(hostname, reported_at))
+        return [
+            HostReport(hostname=hostname, reported_at=reported_at)
+            for hostname, reported_at in merged.items()
+        ]
+
+    def recent_gpu_hosts(self, *, since: datetime) -> frozenset[str]:
+        return frozenset(
+            hostname
+            for hostname, reported_at in self.gpu_reports.items()
+            if reported_at >= since
+        )
+
+
+def runtime_for(
+    hosts: FixtureHosts,
+    snapshots: FixtureSnapshots,
+    *,
+    delivery_mode: DeliveryMode = DeliveryMode.LIVE,
+) -> tuple[
+    AlertingRuntime, InMemoryInfraStore, InMemoryOutboxStore, RecordingSlackPort, FixedClock
+]:
+    clock = FixedClock(START)
+    executions = InMemoryAutomationExecutionStore()
+    outbox = InMemoryOutboxStore()
+    slack = RecordingSlackPort()
+    store = InMemoryInfraStore(executions=executions, outbox=outbox)
+    runtime = AlertingRuntime(
+        executions=executions,
+        outbox=outbox,
+        slack=slack,
+        clock=clock,
+        handlers={
+            "infra_scan": InfraScanHandler(
+                hosts=hosts,
+                snapshots=snapshots,
+                store=store,
+                clock=clock,
+                delivery_mode=delivery_mode,
+            )
+        },
+        alert_path=None,
+    )
+    return runtime, store, outbox, slack, clock
+
+
+def scan(runtime: AlertingRuntime, target: datetime) -> None:
+    result = runtime.process_command(
+        ScheduledCommand(command_type="infra_scan", target_time=target)
+    )
+    assert result.status is ProcessStatus.COMPLETED
+
+
+def test_episode_opens_on_second_consecutive_silent_scan_not_the_first() -> None:
+    hosts = FixtureHosts({"gpu-h100-01"})
+    snapshots = FixtureSnapshots()
+    runtime, store, outbox, slack, _ = runtime_for(hosts, snapshots)
+
+    scan(runtime, START)
+    assert store.episodes() == []
+    assert outbox.count() == 0
+    state = store.subject_state("unreporting", "gpu-h100-01")
+    assert state is not None
+    assert state.consecutive_breaches == 1
+
+    scan(runtime, START + timedelta(minutes=5))
+    assert [episode.status for episode in store.episodes()] == ["open"]
+    assert outbox.count() == 1
+
+    runtime.dispatch_due_notifications()
+    assert len(slack.deliveries) == 1
+    text = slack.deliveries[0].payload["text"]
+    assert "stopped reporting" in text
+    assert "gpu-h100-01" in text
+    assert "down" not in text.lower()
+
+
+def test_first_fresh_report_resolves_episode_with_exactly_two_messages() -> None:
+    hosts = FixtureHosts({"gpu-h100-01"})
+    snapshots = FixtureSnapshots()
+    runtime, store, outbox, slack, clock = runtime_for(hosts, snapshots)
+
+    scan(runtime, clock.now())
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    runtime.dispatch_due_notifications()
+    assert len(slack.deliveries) == 1
+
+    clock.advance(minutes=5)
+    snapshots.gpu_reports["gpu-h100-01"] = clock.now()
+    scan(runtime, clock.now())
+    runtime.dispatch_due_notifications()
+
+    assert [episode.status for episode in store.episodes()] == ["resolved"]
+    assert outbox.count() == 2
+    assert len(slack.deliveries) == 2
+    assert "stopped reporting" in slack.deliveries[0].payload["text"]
+    assert "reporting again" in slack.deliveries[1].payload["text"]
+
+
+def test_reopened_episode_after_resolution_sends_a_new_pair() -> None:
+    hosts = FixtureHosts({"gpu-h100-01"})
+    snapshots = FixtureSnapshots()
+    runtime, store, outbox, slack, clock = runtime_for(hosts, snapshots)
+
+    scan(runtime, clock.now())
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    clock.advance(minutes=5)
+    snapshots.gpu_reports["gpu-h100-01"] = clock.now()
+    scan(runtime, clock.now())
+    runtime.dispatch_due_notifications()
+
+    # The host goes silent again: two consecutive silent scans reopen it.
+    clock.advance(minutes=15)
+    scan(runtime, clock.now())
+    assert outbox.count() == 2
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    runtime.dispatch_due_notifications()
+
+    assert [episode.status for episode in store.episodes()] == ["resolved", "open"]
+    assert len(slack.deliveries) == 3
+    assert "stopped reporting" in slack.deliveries[2].payload["text"]
+
+
+def test_absent_and_silent_host_is_auto_retired_after_seven_days() -> None:
+    hosts = FixtureHosts({"h200-bare-1"})
+    snapshots = FixtureSnapshots()
+    # The host's last report is already a day old, so it goes silent fast.
+    snapshots.gpu_reports["h200-bare-1"] = START - timedelta(days=1)
+    runtime, store, outbox, slack, clock = runtime_for(hosts, snapshots)
+
+    scan(runtime, clock.now())
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    runtime.dispatch_due_notifications()
+    assert len(slack.deliveries) == 1
+    assert [episode.status for episode in store.episodes()] == ["open"]
+
+    # The host leaves the Kubernetes node list, but gpu_snapshots still saw
+    # it within the last seven days, so it stays expected and unretired.
+    hosts.hosts.clear()
+    clock.advance(minutes=5)
+    scan(runtime, clock.now())
+    state = store.subject_state("unreporting", "h200-bare-1")
+    assert state is not None
+    assert state.retired_at is None
+    assert [episode.status for episode in store.episodes()] == ["open"]
+
+    # Once the last report is seven days old the host is absent from every
+    # expected source: it is retired and the open episode is resolved.
+    retire_scan = START - timedelta(days=1) + RETIREMENT_AGE + timedelta(minutes=5)
+    scan(runtime, retire_scan)
+    state = store.subject_state("unreporting", "h200-bare-1")
+    assert state is not None
+    assert state.retired_at == retire_scan
+    runtime.dispatch_due_notifications()
+
+    assert [episode.status for episode in store.episodes()] == ["resolved"]
+    assert outbox.count() == 2
+    assert len(slack.deliveries) == 2
+    assert "auto-retired" in slack.deliveries[1].payload["text"]
+
+    # Retired hosts stop alerting even while they stay absent and silent.
+    scan(runtime, retire_scan + timedelta(minutes=5))
+    scan(runtime, retire_scan + timedelta(minutes=10))
+    assert outbox.count() == 2
+
+    # A replacement node reusing the hostname rejoins the expected set and
+    # alerts again from a clean consecutive-scan count.
+    hosts.hosts.add("h200-bare-1")
+    scan(runtime, retire_scan + timedelta(minutes=15))
+    state = store.subject_state("unreporting", "h200-bare-1")
+    assert state is not None
+    assert state.retired_at is None
+    assert state.consecutive_breaches == 1
+    assert len(store.episodes()) == 1
+    scan(runtime, retire_scan + timedelta(minutes=20))
+    assert [episode.status for episode in store.episodes()] == ["resolved", "open"]
+
+
+def test_disabled_unreporting_threshold_suppresses_episode_and_messages() -> None:
+    hosts = FixtureHosts({"gpu-h100-01"})
+    snapshots = FixtureSnapshots()
+    snapshots.threshold_rows[0] = InfraThreshold(
+        alert_type=InfraAlertType.UNREPORTING.value,
+        threshold_value=10,
+        threshold_unit="minutes",
+        consecutive_scans=2,
+        enabled=False,
+    )
+    runtime, store, outbox, _, _ = runtime_for(hosts, snapshots)
+
+    scan(runtime, START)
+    scan(runtime, START + timedelta(minutes=5))
+
+    assert store.episodes() == []
+    assert outbox.count() == 0
+
+
+def test_shadow_scan_persists_rendered_output_without_slack_delivery() -> None:
+    hosts = FixtureHosts({"gpu-h100-01"})
+    snapshots = FixtureSnapshots()
+    runtime, store, outbox, slack, _ = runtime_for(
+        hosts, snapshots, delivery_mode=DeliveryMode.SHADOW
+    )
+
+    scan(runtime, START)
+    scan(runtime, START + timedelta(minutes=5))
+    result = runtime.dispatch_due_notifications()
+
+    assert [episode.status for episode in store.episodes()] == ["open"]
+    assert outbox.count() == 1
+    record = outbox.records()[0]
+    assert record.delivery_mode is DeliveryMode.SHADOW
+    assert "stopped reporting" in record.payload["text"]
+    assert result.delivered == 0
+    assert slack.deliveries == []
+
+
+def test_failed_commit_rolls_back_state_episode_and_outbox_before_retry() -> None:
+    hosts = FixtureHosts({"gpu-h100-01"})
+    snapshots = FixtureSnapshots()
+    runtime, store, outbox, _, _ = runtime_for(hosts, snapshots)
+
+    scan(runtime, START)
+    store.fail_next_commit()
+    failed = runtime.process_command(
+        ScheduledCommand(
+            command_type="infra_scan", target_time=START + timedelta(minutes=5)
+        )
+    )
+    assert failed.status is ProcessStatus.FAILED
+    assert store.episodes() == []
+    assert outbox.count() == 0
+    state = store.subject_state("unreporting", "gpu-h100-01")
+    assert state is not None
+    assert state.consecutive_breaches == 1
+
+    scan(runtime, START + timedelta(minutes=5))
+    assert [episode.status for episode in store.episodes()] == ["open"]
+    assert outbox.count() == 1
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_kubectl_source_lowercases_node_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> _FakeCompletedProcess:
+        commands.append(cmd)
+        return _FakeCompletedProcess(
+            0,
+            stdout=json.dumps(
+                {
+                    "items": [
+                        {"metadata": {"name": "GPU-H100-01"}},
+                        {"metadata": {"name": "dgx-h100-02"}},
+                        {"metadata": {}},
+                    ]
+                }
+            ),
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    source = KubectlNodesSource(kubeconfig="/run/alerting/h100.conf")
+    assert source.expected_hosts() == frozenset({"gpu-h100-01", "dgx-h100-02"})
+    assert commands == [
+        [
+            "kubectl",
+            "--kubeconfig",
+            "/run/alerting/h100.conf",
+            "get",
+            "nodes",
+            "-o",
+            "json",
+        ]
+    ]
+
+
+def test_kubectl_source_fails_closed_on_kubectl_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: _FakeCompletedProcess(1, stderr="forbidden"),
+    )
+
+    source = KubectlNodesSource(kubeconfig="/run/alerting/h100.conf")
+    with pytest.raises(RuntimeError, match="kubectl get nodes failed"):
+        source.expected_hosts()
+
+
+class _FixtureAgentClient:
+    def __init__(self, agents: list[dict[str, Any]]) -> None:
+        self.agents = agents
+        self.queues: list[str] = []
+
+    def list_agents(self, *, queue: str) -> list[dict[str, Any]]:
+        self.queues.append(queue)
+        return self.agents
+
+
+def test_buildkite_agents_source_lowercases_gpu_queue_hostnames() -> None:
+    client = _FixtureAgentClient(
+        [
+            {"hostname": "H200-CI-1"},
+            {"hostname": "h200-ci-2"},
+            {"hostname": "  "},
+            {"name": "no-hostname"},
+        ]
+    )
+
+    source = BuildkiteGpuQueueAgentsSource(buildkite=client)
+    assert source.expected_hosts() == frozenset({"h200-ci-1", "h200-ci-2"})
+    assert client.queues == ["gpu"]
+
+
+class _RecordingAgentsClient(BuildkiteRestClient):
+    def __init__(self) -> None:
+        super().__init__(token="not-used")
+        self.urls: list[str] = []
+
+    def _get_json(self, url: str) -> Any:
+        self.urls.append(url)
+        return []
+
+
+def test_buildkite_rest_client_queries_the_agents_endpoint_with_queue() -> None:
+    client = _RecordingAgentsClient()
+
+    assert client.list_agents(queue="gpu") == []
+    assert client.urls == [
+        "https://api.buildkite.com/v2/organizations/vllm/agents"
+        "?queue=gpu&per_page=100&page=1"
+    ]
+
+
+def test_expected_host_set_is_the_union_of_sources() -> None:
+    source = UnionExpectedHostSource(
+        [FixtureHosts({"GPU-H100-01"}), FixtureHosts({"h200-ci-1"})]
+    )
+
+    assert source.expected_hosts() == frozenset({"gpu-h100-01", "h200-ci-1"})

--- a/alerting/tests/test_postgres_infra.py
+++ b/alerting/tests/test_postgres_infra.py
@@ -1,0 +1,297 @@
+"""Postgres infra scan transaction behavior through the runtime seam."""
+
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime, timedelta, timezone
+from types import TracebackType
+from typing import Any, Literal
+
+from alerting.commands import ScheduledCommand
+from alerting.infra import InfraScanHandler
+from alerting.memory import FixedClock, RecordingSlackPort
+from alerting.postgres import PostgresAlertStore
+from alerting.runtime import AlertingRuntime, ProcessStatus
+
+START = datetime(2026, 9, 2, 10, 0, tzinfo=timezone.utc)
+
+
+class Result:
+    def __init__(
+        self,
+        row: tuple[Any, ...] | None = None,
+        rowcount: int = 0,
+        rows: list[tuple[Any, ...]] | None = None,
+    ) -> None:
+        self._row = row
+        self.rowcount = rowcount
+        self._rows = rows or []
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self._row
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return self._rows
+
+
+class Transaction:
+    def __init__(self, connection: FakePostgresConnection) -> None:
+        self.connection = connection
+        self.snapshot: dict[str, Any] = {}
+
+    def __enter__(self) -> None:
+        self.snapshot = copy.deepcopy(self.connection.state)
+        self.connection.transaction_depth += 1
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> Literal[False]:
+        self.connection.transaction_depth -= 1
+        if exc_type is not None:
+            self.connection.state = self.snapshot
+        return False
+
+
+class FakePostgresConnection:
+    """Small transaction-capable DB fake for the infra adapter contract."""
+
+    def __init__(self) -> None:
+        self.state: dict[str, Any] = {
+            "executions": {},
+            "thresholds": [("unreporting", 10.0, "minutes", 2, True)],
+            "reports": [],
+            "recent_hosts": [],
+            "infra_states": {},
+            "infra_alerts": [],
+            "outbox": {},
+        }
+        self.transaction_depth = 0
+        self.fail_on_complete = False
+
+    def __enter__(self) -> FakePostgresConnection:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> Literal[False]:
+        return False
+
+    def transaction(self) -> Transaction:
+        return Transaction(self)
+
+    def execute(self, sql: str, params: tuple[Any, ...] = ()) -> Result:
+        statement = " ".join(sql.split())
+        executions: dict[str, dict[str, Any]] = self.state["executions"]
+        if statement.startswith("INSERT INTO alerting_automation_executions"):
+            key = params[0]
+            if key in executions:
+                return Result()
+            executions[key] = {"status": "running", "lease": params[4], "attempts": 1}
+            return Result((key,))
+        if statement.startswith("SELECT status, lease_expires_at"):
+            record = executions[params[0]]
+            return Result((record["status"], record["lease"]))
+        if "SET status = 'running', attempts = attempts + 1" in statement:
+            record = executions[params[1]]
+            record.update(
+                status="running", lease=params[0], attempts=record["attempts"] + 1
+            )
+            return Result(rowcount=1)
+        if statement.startswith("SELECT alert_type, threshold_value"):
+            return Result(rows=list(self.state["thresholds"]))
+        if statement.startswith("WITH gpu AS ("):
+            return Result(rows=list(self.state["reports"]))
+        if statement.startswith("SELECT DISTINCT hostname FROM gpu_snapshots"):
+            return Result(rows=list(self.state["recent_hosts"]))
+        if statement.startswith(
+            "SELECT alert_type, subject_key, consecutive_breaches"
+        ):
+            return Result(rows=list(self.state["infra_states"].values()))
+        if statement.startswith("SELECT alert_id, alert_type, subject_key, opened_at"):
+            return Result(
+                rows=[
+                    (
+                        alert["alert_id"],
+                        alert["alert_type"],
+                        alert["subject_key"],
+                        alert["opened_at"],
+                        alert["details"],
+                    )
+                    for alert in self.state["infra_alerts"]
+                    if alert["status"] == "open"
+                ]
+            )
+        if statement.startswith("SELECT pg_advisory_xact_lock"):
+            assert self.transaction_depth == 1
+            return Result()
+        if statement.startswith("INSERT INTO alerting_infra_host_states"):
+            assert self.transaction_depth == 1
+            self.state["infra_states"][(params[0], params[1])] = (
+                *params[:5],
+                json.loads(params[5]),
+                params[6],
+            )
+            return Result(rowcount=1)
+        if statement.startswith("INSERT INTO alerting_infra_alerts"):
+            assert self.transaction_depth == 1
+            alerts: list[dict[str, Any]] = self.state["infra_alerts"]
+            for alert in alerts:
+                if (
+                    alert["alert_type"] == params[0]
+                    and alert["subject_key"] == params[1]
+                    and alert["status"] == "open"
+                ):
+                    return Result(rowcount=0)
+            alerts.append(
+                {
+                    "alert_id": len(alerts) + 1,
+                    "alert_type": params[0],
+                    "subject_key": params[1],
+                    "status": "open",
+                    "opened_at": params[2],
+                    "details": json.loads(params[3]),
+                    "resolved_at": None,
+                }
+            )
+            return Result(rowcount=1)
+        if statement.startswith("UPDATE alerting_infra_alerts SET status = 'resolved'"):
+            assert self.transaction_depth == 1
+            for alert in self.state["infra_alerts"]:
+                if (
+                    alert["alert_type"] == params[3]
+                    and alert["subject_key"] == params[4]
+                    and alert["status"] == "open"
+                ):
+                    alert["status"] = "resolved"
+                    alert["resolved_at"] = params[0]
+                    alert["details"] = json.loads(params[1])
+                    return Result(rowcount=1)
+            return Result(rowcount=0)
+        if statement.startswith("INSERT INTO alerting_notification_outbox"):
+            assert self.transaction_depth == 1
+            self.state["outbox"][params[0]] = params
+            return Result(rowcount=1)
+        if "SET status = 'completed'" in statement:
+            assert self.transaction_depth == 1
+            if self.fail_on_complete:
+                self.fail_on_complete = False
+                raise RuntimeError("database connection lost")
+            executions[params[1]].update(status="completed", lease=None)
+            return Result(rowcount=1)
+        if "SET status = 'failed'" in statement:
+            executions[params[1]].update(status="failed", lease=None)
+            return Result(rowcount=1)
+        raise AssertionError(f"unexpected SQL: {statement}")
+
+
+class FixtureHosts:
+    def __init__(self, hosts: set[str]) -> None:
+        self.hosts = hosts
+
+    def expected_hosts(self) -> frozenset[str]:
+        return frozenset(self.hosts)
+
+
+def runtime_for(
+    connection: FakePostgresConnection, hosts: FixtureHosts
+) -> tuple[AlertingRuntime, FixedClock]:
+    store = PostgresAlertStore(lambda: connection)
+    clock = FixedClock(START)
+    runtime = AlertingRuntime(
+        executions=store,
+        outbox=store,
+        slack=RecordingSlackPort(),
+        clock=clock,
+        handlers={
+            "infra_scan": InfraScanHandler(
+                hosts=hosts, snapshots=store, store=store, clock=clock
+            )
+        },
+    )
+    return runtime, clock
+
+
+def scan(runtime: AlertingRuntime, target: datetime) -> None:
+    result = runtime.process_command(
+        ScheduledCommand(command_type="infra_scan", target_time=target)
+    )
+    assert result.status is ProcessStatus.COMPLETED
+
+
+def test_postgres_scan_opens_episode_and_outbox_row_in_one_transaction() -> None:
+    connection = FakePostgresConnection()
+    runtime, _ = runtime_for(connection, FixtureHosts({"gpu-h100-01"}))
+
+    scan(runtime, START)
+    assert connection.state["infra_alerts"] == []
+    assert connection.state["outbox"] == {}
+    state = connection.state["infra_states"][("unreporting", "gpu-h100-01")]
+    assert state[2] == 1  # consecutive_breaches
+
+    scan(runtime, START + timedelta(minutes=5))
+
+    [alert] = connection.state["infra_alerts"]
+    assert alert["alert_type"] == "unreporting"
+    assert alert["subject_key"] == "gpu-h100-01"
+    assert alert["status"] == "open"
+    [outbox_row] = connection.state["outbox"].values()
+    assert outbox_row[2] == "infra"
+    assert "stopped reporting" in json.loads(outbox_row[6])["text"]
+    command = ScheduledCommand(command_type="infra_scan", target_time=START)
+    assert (
+        connection.state["executions"][command.idempotency_key]["status"]
+        == "completed"
+    )
+
+
+def test_postgres_failure_rolls_back_state_episode_and_outbox_before_retry() -> None:
+    connection = FakePostgresConnection()
+    runtime, _ = runtime_for(connection, FixtureHosts({"gpu-h100-01"}))
+    scan(runtime, START)
+
+    connection.fail_on_complete = True
+    failed = runtime.process_command(
+        ScheduledCommand(
+            command_type="infra_scan", target_time=START + timedelta(minutes=5)
+        )
+    )
+
+    assert failed.status is ProcessStatus.FAILED
+    assert connection.state["infra_alerts"] == []
+    assert connection.state["outbox"] == {}
+    state = connection.state["infra_states"][("unreporting", "gpu-h100-01")]
+    assert state[2] == 1  # rollback restored the first scan's count
+
+    scan(runtime, START + timedelta(minutes=5))
+    assert len(connection.state["infra_alerts"]) == 1
+    assert len(connection.state["outbox"]) == 1
+
+
+def test_postgres_scan_resolves_episode_on_first_fresh_report() -> None:
+    connection = FakePostgresConnection()
+    runtime, _ = runtime_for(connection, FixtureHosts({"gpu-h100-01"}))
+    scan(runtime, START)
+    scan(runtime, START + timedelta(minutes=5))
+
+    fresh = START + timedelta(minutes=10)
+    connection.state["reports"] = [("gpu-h100-01", fresh)]
+    connection.state["recent_hosts"] = [("gpu-h100-01",)]
+    scan(runtime, fresh)
+
+    [alert] = connection.state["infra_alerts"]
+    assert alert["status"] == "resolved"
+    assert alert["resolved_at"] == fresh
+    assert len(connection.state["outbox"]) == 2
+    resolve_row = next(
+        row
+        for delivery_id, row in connection.state["outbox"].items()
+        if delivery_id.endswith(":resolve")
+    )
+    assert "reporting again" in json.loads(resolve_row[6])["text"]

--- a/alerting/tests/test_postgres_infra.py
+++ b/alerting/tests/test_postgres_infra.py
@@ -65,6 +65,8 @@ class FakePostgresConnection:
             "thresholds": [("unreporting", 10.0, "minutes", 2, True)],
             "reports": [],
             "recent_hosts": [],
+            "mounts": [],
+            "temps": [],
             "infra_states": {},
             "infra_alerts": [],
             "outbox": {},
@@ -110,6 +112,10 @@ class FakePostgresConnection:
             return Result(rows=list(self.state["reports"]))
         if statement.startswith("SELECT DISTINCT hostname FROM gpu_snapshots"):
             return Result(rows=list(self.state["recent_hosts"]))
+        if statement.startswith("WITH latest AS ("):
+            return Result(rows=list(self.state["mounts"]))
+        if statement.startswith("SELECT DISTINCT ON (hostname, gpu_index)"):
+            return Result(rows=list(self.state["temps"]))
         if statement.startswith(
             "SELECT alert_type, subject_key, consecutive_breaches"
         ):
@@ -295,3 +301,30 @@ def test_postgres_scan_resolves_episode_on_first_fresh_report() -> None:
         if delivery_id.endswith(":resolve")
     )
     assert "reporting again" in json.loads(resolve_row[6])["text"]
+
+
+def test_postgres_disk_group_deduplicates_across_hosts_sharing_a_volume() -> None:
+    connection = FakePostgresConnection()
+    connection.state["thresholds"].append(("disk_usage", 90.0, "percent", 2, True))
+    connection.state["mounts"] = [
+        ("h200-ci-1", "/data", "nfs01:/exports/ci", "nfs4", "data", 950, 1000, None, START),
+        ("h200-ci-2", "/data", "nfs01:/exports/ci", "nfs4", "data", 960, 1000, None, START),
+        ("h200-ci-1", "/scratch", "/dev/sdb1", "ext4", "other", 990, 1000, None, START),
+    ]
+    runtime, _ = runtime_for(connection, FixtureHosts(set()))
+
+    scan(runtime, START)
+    assert connection.state["infra_alerts"] == []
+
+    scan(runtime, START + timedelta(minutes=5))
+
+    [alert] = connection.state["infra_alerts"]
+    assert alert["alert_type"] == "disk_usage"
+    assert alert["subject_key"] == "disk:nfs4:nfs01:/exports/ci"
+    assert alert["status"] == "open"
+    assert len(connection.state["outbox"]) == 1
+    [outbox_row] = connection.state["outbox"].values()
+    assert outbox_row[2] == "infra"
+    text = json.loads(outbox_row[6])["text"]
+    assert "h200-ci-1" in text and "h200-ci-2" in text
+    assert "/scratch" not in text

--- a/alerting/tests/test_worker.py
+++ b/alerting/tests/test_worker.py
@@ -107,6 +107,53 @@ def test_main_ci_backstop_timer_uses_its_sweep_command(
     ]
 
 
+def test_infra_timer_uses_its_scan_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = RecordingRuntime()
+    monkeypatch.setattr(worker, "_runtime", lambda *args: runtime)
+
+    assert worker.main(["infra"]) == 0
+    assert [command.command_type for command in runtime.commands] == ["infra_scan"]
+
+
+def test_infra_runtime_requires_both_kubeconfigs_and_buildkite_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_build(**kwargs: object) -> RecordingRuntime:
+        captured.update(kwargs)
+        return RecordingRuntime()
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://example.invalid/alerting")
+    monkeypatch.setenv("BUILDKITE_TOKEN", "bk-token")
+    monkeypatch.setenv("GPU_REPORTER_KUBECONFIG_H100", "/run/alerting/h100.conf")
+    monkeypatch.setenv("GPU_REPORTER_KUBECONFIG_DGX", "/run/alerting/dgx.conf")
+    monkeypatch.setattr(worker, "build_infra_runtime", fake_build)
+
+    worker._runtime("infra", worker.SystemClock(), DeliveryMode.SHADOW)
+
+    assert captured["kubeconfigs"] == [
+        "/run/alerting/h100.conf",
+        "/run/alerting/dgx.conf",
+    ]
+    assert captured["buildkite_token"] == "bk-token"
+    assert captured["delivery_mode"] is DeliveryMode.SHADOW
+
+
+def test_infra_runtime_fails_closed_without_kubeconfigs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://example.invalid/alerting")
+    monkeypatch.setenv("BUILDKITE_TOKEN", "bk-token")
+    monkeypatch.delenv("GPU_REPORTER_KUBECONFIG_H100", raising=False)
+    monkeypatch.delenv("GPU_REPORTER_KUBECONFIG_DGX", raising=False)
+
+    with pytest.raises(RuntimeError, match="GPU_REPORTER_KUBECONFIG_H100"):
+        worker._runtime("infra", worker.SystemClock(), DeliveryMode.SHADOW)
+
+
 def _set_analysis_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DATABASE_URL", "postgresql://example.invalid/alerting")
     monkeypatch.setenv("BUILDKITE_TOKEN", "bk-token")

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -13,6 +13,7 @@ from alerting.postgres import (
     build_fast_ci_runtime,
     build_full_ci_analysis_runtime,
     build_full_ci_runtime,
+    build_infra_runtime,
     build_main_ci_analysis_runtime,
     build_main_ci_backstop_runtime,
     build_main_ci_runtime,
@@ -106,6 +107,18 @@ def _runtime(
             slack=_slack(),
             clock=clock,
         )
+    if consumer == "infra":
+        return build_infra_runtime(
+            database_url=database_url,
+            buildkite_token=_required_environment("BUILDKITE_TOKEN"),
+            kubeconfigs=[
+                _required_environment("GPU_REPORTER_KUBECONFIG_H100"),
+                _required_environment("GPU_REPORTER_KUBECONFIG_DGX"),
+            ],
+            slack=_slack(),
+            clock=clock,
+            delivery_mode=delivery_mode,
+        )
     if consumer == "main-ci-analyze":
         return build_main_ci_analysis_runtime(
             database_url=database_url,
@@ -144,6 +157,7 @@ def scheduled_command(consumer: str, target_time: datetime) -> ScheduledCommand:
         "main-ci": "main_ci_reconcile",
         "main-ci-backstop": "main_ci_backstop",
         "main-ci-analyze": "main_ci_analyze",
+        "infra": "infra_scan",
     }
     try:
         command_type = command_types[consumer]
@@ -162,6 +176,7 @@ def main(arguments: Sequence[str] | None = None) -> int:
         "main-ci",
         "main-ci-backstop",
         "main-ci-analyze",
+        "infra",
     }:
         return 2
 

--- a/deploy/aws/bin/run-worker
+++ b/deploy/aws/bin/run-worker
@@ -7,6 +7,7 @@ case "$consumer" in
   fast-ci) alert_path=fast-ci ;;
   full-ci|full-ci-analyze) alert_path=full-ci ;;
   main-ci|main-ci-analyze|main-ci-backstop) alert_path=main-ci ;;
+  infra) alert_path=infra ;;
   *) echo "unknown consumer: $consumer" >&2; exit 2 ;;
 esac
 mode_path="/run/alerting/${alert_path}.mode"

--- a/deploy/aws/systemd/alerting-infra.service
+++ b/deploy/aws/systemd/alerting-infra.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Scan infra host health (unreporting, disk, GPU temperature)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=alerting
+Group=alerting
+ExecStart=/opt/alerting/bin/run-worker infra
+StandardOutput=null
+StandardError=null
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+TimeoutStartSec=10min

--- a/deploy/aws/systemd/alerting-infra.timer
+++ b/deploy/aws/systemd/alerting-infra.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Schedule infra host health scans every five minutes
+
+[Timer]
+OnBootSec=2min
+OnCalendar=*-*-* *:00/5:00 UTC
+Persistent=true
+AccuracySec=30s
+RandomizedDelaySec=0
+Unit=alerting-infra.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/aws/tests/test_alerting_worker_infrastructure.py
+++ b/deploy/aws/tests/test_alerting_worker_infrastructure.py
@@ -81,6 +81,27 @@ def test_main_ci_backstop_timer_runs_hourly_off_the_hour_mark() -> None:
         assert sensitive_name not in service + timer
 
 
+def test_infra_timer_scans_every_five_minutes_without_sensitive_data() -> None:
+    timer = read("systemd/alerting-infra.timer")
+    service = read("systemd/alerting-infra.service")
+
+    assert "OnCalendar=*-*-* *:00/5:00 UTC" in timer
+    assert "OnBootSec=" in timer
+    assert "Persistent=true" in timer
+    assert "Unit=alerting-infra.service" in timer
+    assert "run-worker infra" in service
+    assert "StandardOutput=null" in service
+    assert "StandardError=null" in service
+    for sensitive_name in ("DATABASE_URL", "TOKEN", "PASSWORD"):
+        assert sensitive_name not in service + timer
+
+
+def test_run_worker_maps_infra_consumer_to_its_own_control_path() -> None:
+    runner = read("bin/run-worker")
+
+    assert "infra) alert_path=infra ;;" in runner
+
+
 def test_main_ci_analysis_timer_runs_every_ten_minutes() -> None:
     timer = read("systemd/alerting-main-ci-analysis.timer")
 
@@ -232,6 +253,7 @@ def test_retention_timer_prunes_daily_without_sensitive_data() -> None:
         ("main-ci", "main_ci_reconcile"),
         ("main-ci-backstop", "main_ci_backstop"),
         ("main-ci-analyze", "main_ci_analyze"),
+        ("infra", "infra_scan"),
     ],
 )
 def test_timer_wake_up_creates_a_minute_stable_reconciliation_command(

--- a/docs/alerts/queue-wait.md
+++ b/docs/alerts/queue-wait.md
@@ -1,0 +1,59 @@
+# Queue wait alerts
+
+## What it detects
+
+A Buildkite queue whose observed P90 wait time exceeds 30 minutes while
+jobs are waiting or scheduled. Wait percentiles come from the
+`queue_snapshots` table (P90 is computed from currently `SCHEDULED` command
+jobs as `now - runnableAt`; see the Queue page note in the top-level
+README), and the waiting-job count goes through `effectiveWaiting`
+(`src/lib/queue-plugins.ts`) because Buildkite's Agent Metrics
+`jobs_waiting` is inaccurate for some queues.
+
+Unlike the CI and infra alert types, queue-wait alerting is owned by the
+CI Dashboard context (see `CONTEXT-MAP.md` and `src/CONTEXT.md`), not by
+the `alerting/` worker: it runs inside the Next.js app on Vercel, has no
+outbox, and keeps its state in `alert_summary`.
+
+## Where the code lives
+
+- `src/app/api/alerts/queue/route.ts` — the whole lifecycle: threshold
+  check, per-queue active/resolved state, and the combined Slack message.
+- `src/lib/slack.ts` — `postMessage` / `updateMessage` / `addReaction`.
+- `src/lib/queue-plugins.ts` — `effectiveWaiting`.
+- Schedule: Vercel cron in `vercel.json` hits `/api/alerts/queue` every 15
+  minutes (`*/15 * * * *`).
+
+## Configuration
+
+- `SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID` — the bot and channel the combined
+  message posts to. The route returns 500 if either is missing.
+- `CRON_SECRET` — when set, the route requires `Authorization: Bearer`.
+- The threshold is a code constant, `WAIT_THRESHOLD_MINUTES = 30`, in the
+  route. There is no thresholds table row and no shadow/disabled control
+  plane for this alert type.
+
+## What it posts to Slack
+
+One combined message per Pacific day (keyed by `alert_summary.id =` the
+Pacific date). On each tick with a state change the route either posts the
+day's message or edits it in place, then adds a thread reply so the channel
+gets a notification (":rotating_light: N queues still alerting" or
+"All queues resolved"). Active queues list P90 wait and waiting-job count,
+worst first; resolved queues are struck through with their resolution time.
+When every queue is resolved, a ✅ reaction is added to the day message.
+State persists in `alert_summary.queues` as JSONB, so a Vercel redeploy or
+retry never loses which queues are alerting.
+
+## Dashboard history
+
+There is no queue-alert history view on `/alerts`; the alert's record is
+the Slack message plus the `alert_summary` row. The underlying wait-time
+data is visible on the `/queue` page.
+
+## Tables
+
+Reads: `queue_snapshots` (latest P90/P50/P95 per queue within 15 minutes,
+plus latest scheduled/waiting/agents counts).
+Writes: `alert_summary` (one row per Pacific day: message ts + per-queue
+alert state).

--- a/migrations/sql/0019_infra_alerts.sql
+++ b/migrations/sql/0019_infra_alerts.sql
@@ -1,0 +1,85 @@
+-- Infra health alerting: per-subject scan state is separate from alert
+-- episodes, following the Main CI state/episode split. A subject is a host
+-- (unreporting), a shared (fstype, device) disk group (disk_usage), or one
+-- GPU on one host (gpu_temperature), so a fleet-wide NFS volume pages once
+-- no matter how many hosts mount it.
+ALTER TABLE alerting_notification_outbox
+    DROP CONSTRAINT IF EXISTS alerting_notification_outbox_path_check;
+ALTER TABLE alerting_notification_outbox
+    ADD CONSTRAINT alerting_notification_outbox_path_check
+    CHECK (alert_path IN ('fast_ci', 'full_ci', 'main_ci', 'infra'));
+
+-- Durable per-subject scan state carried between five-minute scans. An
+-- episode opens only after consecutive_breaches reaches the configured
+-- consecutive_scans, and a host absent from every expected source and silent
+-- for seven days is retired here so the dashboard can show it.
+CREATE TABLE IF NOT EXISTS alerting_infra_host_states (
+    alert_type           text NOT NULL
+        CHECK (alert_type IN ('unreporting', 'disk_usage', 'gpu_temperature')),
+    subject_key          text NOT NULL,
+    consecutive_breaches integer NOT NULL DEFAULT 0
+        CHECK (consecutive_breaches >= 0),
+    last_reported_at     timestamptz,
+    retired_at           timestamptz,
+    details              jsonb NOT NULL DEFAULT '{}'::jsonb,
+    updated_at           timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (alert_type, subject_key),
+    CHECK (subject_key = lower(subject_key)),
+    CHECK (retired_at IS NULL OR alert_type = 'unreporting')
+);
+
+-- An alert is one breach episode. Exactly two notifications exist per
+-- episode (open and resolve); the partial unique index guarantees at most
+-- one open episode per subject.
+CREATE TABLE IF NOT EXISTS alerting_infra_alerts (
+    alert_id     bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    alert_type   text NOT NULL
+        CHECK (alert_type IN ('unreporting', 'disk_usage', 'gpu_temperature')),
+    subject_key  text NOT NULL,
+    status       text NOT NULL CHECK (status IN ('open', 'resolved')),
+    opened_at    timestamptz NOT NULL,
+    resolved_at  timestamptz,
+    details      jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    updated_at   timestamptz NOT NULL DEFAULT now(),
+    CHECK (
+        (status = 'open' AND resolved_at IS NULL)
+        OR (status = 'resolved' AND resolved_at IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS alerting_infra_alerts_open_idx
+    ON alerting_infra_alerts (alert_type, subject_key)
+    WHERE status = 'open';
+
+CREATE INDEX IF NOT EXISTS alerting_infra_alerts_history_idx
+    ON alerting_infra_alerts (
+        status, (COALESCE(resolved_at, opened_at)) DESC
+    );
+
+-- These tables are reachable only through trusted server-side connections.
+ALTER TABLE public.alerting_infra_host_states ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.alerting_infra_alerts ENABLE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE
+    api_role name;
+    protected_tables constant text :=
+        'public.alerting_infra_host_states, public.alerting_infra_alerts';
+BEGIN
+    FOREACH api_role IN ARRAY ARRAY['anon'::name, 'authenticated'::name]
+    LOOP
+        IF EXISTS (SELECT FROM pg_roles WHERE rolname = api_role) THEN
+            EXECUTE format(
+                'REVOKE ALL PRIVILEGES ON TABLE %s FROM %I',
+                protected_tables,
+                api_role
+            );
+            EXECUTE format(
+                'REVOKE ALL PRIVILEGES ON SEQUENCE public.alerting_infra_alerts_alert_id_seq FROM %I',
+                api_role
+            );
+        END IF;
+    END LOOP;
+END;
+$$;

--- a/migrations/tests/test_migrations.py
+++ b/migrations/tests/test_migrations.py
@@ -63,6 +63,8 @@ def test_expected_tables_are_created() -> None:
         "alerting_main_ci_job_states",
         "alerting_main_ci_job_alerts",
         "alerting_main_ci_job_analysis",
+        "alerting_infra_host_states",
+        "alerting_infra_alerts",
     }
 
     for table in expected_tables:
@@ -220,6 +222,22 @@ def test_host_ingest_schema_is_normalized_protected_and_seeded() -> None:
     assert "('gpu_temperature', 85, 'celsius', 2)" in sql
     assert "ON CONFLICT (alert_type) DO NOTHING" in sql
     for table in ("host_snapshots", "host_history_5m", "alert_thresholds"):
+        assert f"ALTER TABLE public.{table} ENABLE ROW LEVEL SECURITY" in sql
+
+
+def test_infra_schema_preserves_one_open_episode_per_subject_and_widens_path() -> None:
+    sql = (MIGRATIONS_DIR / "0019_infra_alerts.sql").read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS alerting_infra_host_states" in sql
+    assert "CREATE TABLE IF NOT EXISTS alerting_infra_alerts" in sql
+    assert "ON alerting_infra_alerts (alert_type, subject_key)" in sql
+    assert "WHERE status = 'open'" in sql
+    assert "status       text NOT NULL CHECK (status IN ('open', 'resolved'))" in sql
+    assert "'unreporting', 'disk_usage', 'gpu_temperature'" in sql
+    assert "'fast_ci', 'full_ci', 'main_ci', 'infra'" in sql
+    assert "alerting_infra_alerts_alert_id_seq" in sql
+    assert "DROP CONSTRAINT IF EXISTS alerting_notification_outbox_path_check" in sql
+    for table in ("alerting_infra_host_states", "alerting_infra_alerts"):
         assert f"ALTER TABLE public.{table} ENABLE ROW LEVEL SECURITY" in sql
 
 

--- a/src/app/alerts/alerts-content.tsx
+++ b/src/app/alerts/alerts-content.tsx
@@ -4,12 +4,18 @@ import { useMemo, type ReactNode } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { FastCIAlerts } from "@/components/fast-ci-alerts";
+import { InfraAlerts } from "@/components/infra-alerts";
 import { MainCIAlerts } from "@/components/main-ci-alerts";
 import { SegmentedControl } from "@/components/segmented-control";
 import {
   groupFastFailureEvents,
   type FastFailureEvent,
 } from "@/lib/alerts-fast-ci";
+import {
+  viewInfraAlerts,
+  type InfraAlertEpisode,
+  type InfraRetiredHost,
+} from "@/lib/alerts-infra";
 import {
   viewMainCiJobAlerts,
   type MainCiJobAlert,
@@ -24,7 +30,7 @@ import {
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
-type AlertTab = "main-ci" | "fast-ci";
+type AlertTab = "main-ci" | "fast-ci" | "infra";
 
 const ALERT_TABS: readonly {
   value: AlertTab;
@@ -43,6 +49,12 @@ const ALERT_TABS: readonly {
     label: "Fast failures (<30s)",
     description:
       "Fast CI jobs that finished in a failure state within 30 seconds, over the last 7 days, grouped by the build and commit they came from. These are observations with no resolution lifecycle; each one shows how far its Slack notification got.",
+  },
+  {
+    value: "infra",
+    label: "Infra",
+    description:
+      "Infra health episodes: hosts that stopped reporting, shared disks over their usage threshold, and GPUs over their temperature threshold. An episode opens only after a breach sustains across consecutive five-minute scans and resolves on the first healthy observation; a host absent for seven days is auto-retired and stops alerting. This view is read-only — there is nothing to resolve by hand.",
   },
 ];
 
@@ -116,6 +128,13 @@ interface FastCIAlertsResponse {
 
 interface MainCIAlertsResponse {
   alerts?: MainCiJobAlert[];
+  schemaStatus?: "ready" | "pending";
+  error?: string;
+}
+
+interface InfraAlertsResponse {
+  episodes?: InfraAlertEpisode[];
+  retiredHosts?: InfraRetiredHost[];
   schemaStatus?: "ready" | "pending";
   error?: string;
 }
@@ -292,6 +311,41 @@ function FastCISection({
   );
 }
 
+function InfraSection({ timeWindow }: { timeWindow: AlertTimeWindow }) {
+  const { data, isLoading, error } = useSWR<InfraAlertsResponse>(
+    "/api/alerts/infra",
+    fetcher,
+    { refreshInterval: 5 * 60 * 1000 },
+  );
+
+  const view = useMemo(
+    () =>
+      viewInfraAlerts(
+        data?.episodes ?? [],
+        data?.retiredHosts ?? [],
+        alertWindowCutoff(timeWindow),
+      ),
+    [data, timeWindow],
+  );
+
+  return (
+    <AlertSection
+      title="Infra"
+      isLoading={isLoading}
+      failed={Boolean(error || data?.error)}
+    >
+      {data?.schemaStatus === "pending" ? (
+        <div className="flex h-48 items-center justify-center rounded-lg border border-dashed border-amber-300 px-6 text-center text-sm text-amber-700 dark:border-amber-800 dark:text-amber-300">
+          Backend rollout pending. Migration 0019 and the infra alerting worker
+          must be deployed before this preview can show alerts.
+        </div>
+      ) : (
+        <InfraAlerts view={view} />
+      )}
+    </AlertSection>
+  );
+}
+
 export default function AlertsContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -414,6 +468,8 @@ export default function AlertsContent() {
 
       {tab === "main-ci" ? (
         <MainCISection timeWindow={timeWindow} options={options} />
+      ) : tab === "infra" ? (
+        <InfraSection timeWindow={timeWindow} />
       ) : (
         <FastCISection
           timeWindow={timeWindow}

--- a/src/app/api/alerts/infra/route.ts
+++ b/src/app/api/alerts/infra/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import type {
+  InfraAlertEpisode,
+  InfraAlertStatus,
+  InfraAlertType,
+  InfraRetiredHost,
+} from "@/lib/alerts-infra";
+import { hasPostgresErrorCode } from "@/lib/postgres-errors";
+
+export const dynamic = "force-dynamic";
+
+// Infra episodes are an operational feed like the Fast CI view: every open
+// episode plus a week of resolved history, capped so a flapping fleet cannot
+// produce an unbounded response.
+const WINDOW_DAYS = 7;
+const MAX_EPISODES = 500;
+
+interface InfraAlertEpisodeRow {
+  alert_id: number | string;
+  alert_type: InfraAlertType;
+  subject_key: string;
+  status: InfraAlertStatus;
+  opened_at: Date;
+  resolved_at: Date | null;
+  details: Record<string, unknown>;
+}
+
+interface InfraRetiredHostRow {
+  subject_key: string;
+  last_reported_at: Date | null;
+  retired_at: Date;
+}
+
+function toEpisode(row: InfraAlertEpisodeRow): InfraAlertEpisode {
+  return {
+    alertId: String(row.alert_id),
+    alertType: row.alert_type,
+    subjectKey: row.subject_key,
+    status: row.status,
+    openedAt: row.opened_at.toISOString(),
+    resolvedAt: row.resolved_at?.toISOString() ?? null,
+    details: row.details,
+  };
+}
+
+function toRetiredHost(row: InfraRetiredHostRow): InfraRetiredHost {
+  return {
+    subjectKey: row.subject_key,
+    lastReportedAt: row.last_reported_at?.toISOString() ?? null,
+    retiredAt: row.retired_at.toISOString(),
+  };
+}
+
+export async function GET() {
+  try {
+    const db = getDb();
+
+    // Postgres alone answers this view: the breach episodes, and the hosts
+    // the worker auto-retired after seven days absent from every expected
+    // source (only unreporting hosts can retire).
+    const episodes = await db<InfraAlertEpisodeRow[]>`
+      SELECT alert_id, alert_type, subject_key, status, opened_at,
+             resolved_at, details
+      FROM alerting_infra_alerts
+      WHERE status = 'open' OR resolved_at >= now() - ${`${WINDOW_DAYS} days`}::interval
+      ORDER BY (status = 'open') DESC,
+               COALESCE(resolved_at, opened_at) DESC
+      LIMIT ${MAX_EPISODES}
+    `;
+    const retiredHosts = await db<InfraRetiredHostRow[]>`
+      SELECT subject_key, last_reported_at, retired_at
+      FROM alerting_infra_host_states
+      WHERE retired_at IS NOT NULL
+      ORDER BY retired_at DESC
+    `;
+
+    return NextResponse.json(
+      {
+        episodes: episodes.map(toEpisode),
+        retiredHosts: retiredHosts.map(toRetiredHost),
+        windowDays: WINDOW_DAYS,
+        schemaStatus: "ready",
+      },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    // Preview deployments are created before migration 0019 is intentionally
+    // applied to the shared database. Treat that ordered rollout state as a
+    // neutral, explicit response instead of a broken dashboard.
+    if (hasPostgresErrorCode(error, "42P01")) {
+      return NextResponse.json(
+        { episodes: [], retiredHosts: [], schemaStatus: "pending" },
+        { headers: { "Cache-Control": "no-store" } },
+      );
+    }
+    console.error("Failed to load infra alerts:", error);
+    return NextResponse.json(
+      { error: "Infra alerts could not be loaded." },
+      { status: 500, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/src/components/infra-alerts.test.ts
+++ b/src/components/infra-alerts.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { InfraAlerts } from "./infra-alerts";
+import {
+  viewInfraAlerts,
+  type InfraAlertEpisode,
+  type InfraRetiredHost,
+} from "../lib/alerts-infra";
+
+const CUTOFF = new Date("2026-08-20T00:00:00.000Z");
+
+function episode(overrides: Partial<InfraAlertEpisode> = {}): InfraAlertEpisode {
+  return {
+    alertId: "1",
+    alertType: "unreporting",
+    subjectKey: "gpu-worker-1",
+    status: "open",
+    openedAt: "2026-08-28T10:00:00.000Z",
+    resolvedAt: null,
+    details: {
+      hostname: "gpu-worker-1",
+      last_reported_at: "2026-08-28T09:30:00.000Z",
+      threshold_minutes: 30,
+      consecutive_scans: 3,
+    },
+    ...overrides,
+  };
+}
+
+function retiredHost(
+  overrides: Partial<InfraRetiredHost> = {},
+): InfraRetiredHost {
+  return {
+    subjectKey: "gpu-worker-9",
+    lastReportedAt: "2026-08-20T09:30:00.000Z",
+    retiredAt: "2026-08-27T09:30:00.000Z",
+    ...overrides,
+  };
+}
+
+function render(
+  episodes: InfraAlertEpisode[],
+  retiredHosts: InfraRetiredHost[] = [],
+): string {
+  return renderToStaticMarkup(
+    createElement(InfraAlerts, {
+      view: viewInfraAlerts(episodes, retiredHosts, CUTOFF),
+    }),
+  );
+}
+
+test("Infra alerts offer no resolution controls", () => {
+  const markup = render([
+    episode({ alertId: "1" }),
+    episode({
+      alertId: "2",
+      status: "resolved",
+      resolvedAt: "2026-08-28T11:00:00.000Z",
+      details: { resolution: "reporting" },
+    }),
+  ]);
+
+  assert.doesNotMatch(markup, /<button|<form|<input|<select|<textarea/i);
+});
+
+test("every episode type renders with its subject, type, and status", () => {
+  const markup = render([
+    episode({ alertId: "1" }),
+    episode({
+      alertId: "2",
+      alertType: "disk_usage",
+      subjectKey: "disk:nfs4:nas:/share",
+      details: {
+        device: "nas:/share",
+        fstype: "nfs4",
+        max_used_percent: 94.5,
+        threshold_percent: 90,
+      },
+    }),
+    episode({
+      alertId: "3",
+      alertType: "gpu_temperature",
+      subjectKey: "gpu:gpu-worker-1:3",
+      status: "resolved",
+      resolvedAt: "2026-08-28T11:00:00.000Z",
+      details: {
+        gpu_index: 3,
+        temperature_c: 71,
+        threshold_celsius: 85,
+        resolution: "below_threshold",
+      },
+    }),
+  ]);
+
+  assert.match(markup, /gpu-worker-1/);
+  assert.match(markup, /disk:nfs4:nas:\/share/);
+  assert.match(markup, /gpu:gpu-worker-1:3/);
+  assert.match(markup, /Stopped reporting/);
+  assert.match(markup, /Disk/);
+  assert.match(markup, /GPU temperature/);
+  assert.match(markup, /Open/);
+  assert.match(markup, /Resolved/);
+  assert.match(markup, /94\.5% used \(threshold 90%\)/);
+  assert.match(markup, /back below 85°C \(now 71°C\)/);
+});
+
+test("unreporting episodes say the host stopped reporting and never that a machine is down", () => {
+  const markup = render([episode()], [retiredHost()]);
+
+  assert.match(markup, /stopped reporting/i);
+  assert.doesNotMatch(markup, /machine is down/i);
+});
+
+test("retired hosts are visibly marked, in the episode list and in their own section", () => {
+  const markup = render(
+    [episode({ alertId: "1" })],
+    [retiredHost({ subjectKey: "gpu-worker-1" })],
+  );
+
+  assert.match(markup, /Retired/);
+  assert.match(markup, /Retired hosts/);
+  assert.match(markup, /no longer alerts/);
+});
+
+test("an empty window says so instead of rendering empty sections", () => {
+  const markup = render([]);
+
+  assert.match(markup, /No infra alerts were recorded in this window/);
+  assert.doesNotMatch(markup, /<button|<form|<input/i);
+});
+
+test("open and resolved episodes render under their own sections", () => {
+  const markup = render([
+    episode({ alertId: "1" }),
+    episode({
+      alertId: "2",
+      subjectKey: "gpu-worker-2",
+      status: "resolved",
+      resolvedAt: "2026-08-28T11:00:00.000Z",
+      details: { resolution: "reporting" },
+    }),
+  ]);
+
+  assert.match(markup, /Open/);
+  assert.match(markup, /Recently resolved/);
+  assert.match(markup, /reporting again/);
+});

--- a/src/components/infra-alerts.tsx
+++ b/src/components/infra-alerts.tsx
@@ -1,0 +1,138 @@
+import {
+  type InfraAlertEpisodeView,
+  type InfraAlertView,
+  type InfraRetiredHost,
+} from "@/lib/alerts-infra";
+import { formatAlertDateTime } from "@/lib/alerts-shared";
+
+function StatusBadge({ status }: { status: InfraAlertEpisodeView["status"] }) {
+  return status === "open" ? (
+    <span className="shrink-0 rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-950/60 dark:text-red-300">
+      Open
+    </span>
+  ) : (
+    <span className="shrink-0 rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+      Resolved
+    </span>
+  );
+}
+
+function RetiredBadge() {
+  return (
+    <span className="shrink-0 rounded-full border border-dashed border-amber-300 px-2 py-0.5 text-xs font-medium text-amber-700 dark:border-amber-800 dark:text-amber-300">
+      Retired
+    </span>
+  );
+}
+
+function EpisodeRow({ episode }: { episode: InfraAlertEpisodeView }) {
+  return (
+    <li className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2 text-sm sm:px-5">
+      <span className="min-w-0 truncate font-mono text-zinc-900 dark:text-zinc-100">
+        {episode.subjectKey}
+      </span>
+      <span className="shrink-0 text-xs font-medium text-zinc-500 dark:text-zinc-400">
+        {episode.typeLabel}
+      </span>
+      <StatusBadge status={episode.status} />
+      {episode.retired && <RetiredBadge />}
+      <span className="ml-auto shrink-0 text-xs text-zinc-500 dark:text-zinc-400">
+        Opened {formatAlertDateTime(episode.openedAt)}
+        {episode.resolvedAt !== null &&
+          ` · Resolved ${formatAlertDateTime(episode.resolvedAt)}`}
+      </span>
+      <p className="w-full text-xs text-zinc-500 dark:text-zinc-400">
+        {episode.summary}
+      </p>
+    </li>
+  );
+}
+
+function EpisodeSection({
+  title,
+  episodes,
+}: {
+  title: string;
+  episodes: InfraAlertEpisodeView[];
+}) {
+  if (episodes.length === 0) return null;
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+        {title}{" "}
+        <span className="font-normal text-zinc-400 dark:text-zinc-500">
+          {episodes.length}
+        </span>
+      </h2>
+      <ul className="divide-y divide-zinc-100 overflow-hidden rounded-xl border border-zinc-200 bg-white dark:divide-zinc-800/60 dark:border-zinc-800 dark:bg-zinc-950">
+        {episodes.map((episode) => (
+          <EpisodeRow key={episode.alertId} episode={episode} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function RetiredHosts({ hosts }: { hosts: InfraRetiredHost[] }) {
+  if (hosts.length === 0) return null;
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+        Retired hosts{" "}
+        <span className="font-normal text-zinc-400 dark:text-zinc-500">
+          {hosts.length}
+        </span>
+      </h2>
+      <ul className="divide-y divide-zinc-100 overflow-hidden rounded-xl border border-dashed border-zinc-300 bg-white dark:divide-zinc-800/60 dark:border-zinc-700 dark:bg-zinc-950">
+        {hosts.map((host) => (
+          <li
+            key={host.subjectKey}
+            className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2 text-sm sm:px-5"
+          >
+            <span className="min-w-0 truncate font-mono text-zinc-500 dark:text-zinc-400">
+              {host.subjectKey}
+            </span>
+            <RetiredBadge />
+            <span className="ml-auto shrink-0 text-xs text-zinc-500 dark:text-zinc-400">
+              {host.lastReportedAt !== null &&
+                `Last report ${formatAlertDateTime(host.lastReportedAt)} · `}
+              Retired {formatAlertDateTime(host.retiredAt)}
+            </span>
+            <p className="w-full text-xs text-zinc-500 dark:text-zinc-400">
+              Stopped reporting and was auto-retired after 7 days absent from
+              every expected source; it no longer alerts.
+            </p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/**
+ * Infra alert episodes are per-subject breach episodes with exactly two Slack
+ * notifications each, so this view reports them read-only: it deliberately
+ * exposes no resolution, acknowledgement, or suppression controls.
+ *
+ * Episodes are per subject rather than per job run, so the lists stay short
+ * enough to render without pagination.
+ */
+export function InfraAlerts({ view }: { view: InfraAlertView }) {
+  const { open, resolved, retiredHosts } = view;
+
+  if (open.length === 0 && resolved.length === 0 && retiredHosts.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center rounded-xl border border-dashed border-zinc-300 text-sm text-zinc-400 dark:border-zinc-700">
+        No infra alerts were recorded in this window.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <EpisodeSection title="Open" episodes={open} />
+      <EpisodeSection title="Recently resolved" episodes={resolved} />
+      <RetiredHosts hosts={retiredHosts} />
+    </div>
+  );
+}

--- a/src/lib/alerts-infra.test.ts
+++ b/src/lib/alerts-infra.test.ts
@@ -1,0 +1,273 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  INFRA_ALERT_TYPE_LABELS,
+  summarizeInfraEpisode,
+  viewInfraAlerts,
+  type InfraAlertEpisode,
+  type InfraRetiredHost,
+} from "./alerts-infra";
+
+const CUTOFF = new Date("2026-08-27T00:00:00.000Z");
+
+function episode(overrides: Partial<InfraAlertEpisode> = {}): InfraAlertEpisode {
+  return {
+    alertId: "1",
+    alertType: "unreporting",
+    subjectKey: "gpu-worker-1",
+    status: "open",
+    openedAt: "2026-08-28T10:00:00.000Z",
+    resolvedAt: null,
+    details: {
+      hostname: "gpu-worker-1",
+      last_reported_at: "2026-08-28T09:30:00.000Z",
+      threshold_minutes: 30,
+      consecutive_scans: 3,
+    },
+    ...overrides,
+  };
+}
+
+function retiredHost(
+  overrides: Partial<InfraRetiredHost> = {},
+): InfraRetiredHost {
+  return {
+    subjectKey: "gpu-worker-1",
+    lastReportedAt: "2026-08-20T09:30:00.000Z",
+    retiredAt: "2026-08-27T09:30:00.000Z",
+    ...overrides,
+  };
+}
+
+test("every alert type has a display label", () => {
+  assert.equal(INFRA_ALERT_TYPE_LABELS.unreporting, "Stopped reporting");
+  assert.equal(INFRA_ALERT_TYPE_LABELS.disk_usage, "Disk");
+  assert.equal(INFRA_ALERT_TYPE_LABELS.gpu_temperature, "GPU temperature");
+});
+
+test("open episodes stay visible regardless of age; resolved history obeys the window", () => {
+  const view = viewInfraAlerts(
+    [
+      episode({ alertId: "old-open", openedAt: "2026-08-01T10:00:00.000Z" }),
+      episode({
+        alertId: "recent-resolved",
+        status: "resolved",
+        openedAt: "2026-08-26T10:00:00.000Z",
+        resolvedAt: "2026-08-27T12:00:00.000Z",
+        details: { resolution: "reporting" },
+      }),
+      episode({
+        alertId: "stale-resolved",
+        status: "resolved",
+        openedAt: "2026-08-01T10:00:00.000Z",
+        resolvedAt: "2026-08-02T12:00:00.000Z",
+        details: { resolution: "reporting" },
+      }),
+    ],
+    [],
+    CUTOFF,
+  );
+
+  assert.deepEqual(
+    view.open.map((entry) => entry.alertId),
+    ["old-open"],
+  );
+  assert.deepEqual(
+    view.resolved.map((entry) => entry.alertId),
+    ["recent-resolved"],
+  );
+});
+
+test("open episodes sort newest first, resolved by resolvedAt descending", () => {
+  const view = viewInfraAlerts(
+    [
+      episode({ alertId: "open-old", openedAt: "2026-08-20T10:00:00.000Z" }),
+      episode({
+        alertId: "open-new",
+        subjectKey: "gpu-worker-2",
+        openedAt: "2026-08-28T10:00:00.000Z",
+      }),
+      episode({
+        alertId: "resolved-old",
+        status: "resolved",
+        resolvedAt: "2026-08-27T10:00:00.000Z",
+        details: { resolution: "reporting" },
+      }),
+      episode({
+        alertId: "resolved-new",
+        status: "resolved",
+        resolvedAt: "2026-08-28T10:00:00.000Z",
+        details: { resolution: "reporting" },
+      }),
+    ],
+    [],
+    CUTOFF,
+  );
+
+  assert.deepEqual(
+    view.open.map((entry) => entry.alertId),
+    ["open-new", "open-old"],
+  );
+  assert.deepEqual(
+    view.resolved.map((entry) => entry.alertId),
+    ["resolved-new", "resolved-old"],
+  );
+});
+
+test("episodes whose host was auto-retired are marked; other types are not", () => {
+  const view = viewInfraAlerts(
+    [
+      episode({ alertId: "unreporting" }),
+      episode({
+        alertId: "disk",
+        alertType: "disk_usage",
+        subjectKey: "disk:nfs4:nas:/share",
+        details: {},
+      }),
+    ],
+    [
+      retiredHost(),
+      retiredHost({
+        subjectKey: "disk:nfs4:nas:/share",
+      }),
+    ],
+    CUTOFF,
+  );
+
+  assert.equal(view.open[0].retired, true);
+  assert.equal(view.open[1].retired, false);
+});
+
+test("retired hosts sort newest retirement first", () => {
+  const view = viewInfraAlerts(
+    [],
+    [
+      retiredHost({ subjectKey: "host-a", retiredAt: "2026-08-25T09:30:00.000Z" }),
+      retiredHost({ subjectKey: "host-b", retiredAt: "2026-08-28T09:30:00.000Z" }),
+    ],
+    CUTOFF,
+  );
+
+  assert.deepEqual(
+    view.retiredHosts.map((host) => host.subjectKey),
+    ["host-b", "host-a"],
+  );
+});
+
+test("an open unreporting episode says the host stopped reporting, never that a machine is down", () => {
+  const summary = summarizeInfraEpisode(episode());
+
+  assert.match(summary, /No successful report for over 30 minutes/);
+  assert.match(summary, /3 consecutive scans/);
+  assert.match(summary, /Last report/);
+  assert.doesNotMatch(summary, /machine is down/i);
+});
+
+test("an unreporting episode with no report ever received says so", () => {
+  const summary = summarizeInfraEpisode(
+    episode({ details: { threshold_minutes: 30, last_reported_at: null } }),
+  );
+
+  assert.match(summary, /No report has ever been received/);
+});
+
+test("a resolved unreporting episode reads as reporting again or retired", () => {
+  const reporting = summarizeInfraEpisode(
+    episode({
+      status: "resolved",
+      resolvedAt: "2026-08-28T11:00:00.000Z",
+      details: { resolution: "reporting" },
+    }),
+  );
+  const retired = summarizeInfraEpisode(
+    episode({
+      status: "resolved",
+      resolvedAt: "2026-08-28T11:00:00.000Z",
+      details: { resolution: "retired" },
+    }),
+  );
+
+  assert.match(reporting, /reporting again/);
+  assert.match(retired, /Auto-retired/);
+  assert.match(retired, /no longer alerts/);
+});
+
+test("an open disk episode reads as percent used against its threshold", () => {
+  const summary = summarizeInfraEpisode(
+    episode({
+      alertType: "disk_usage",
+      subjectKey: "disk:nfs4:nas:/share",
+      details: {
+        device: "nas:/share",
+        fstype: "nfs4",
+        max_used_percent: 94.5,
+        threshold_percent: 90,
+        consecutive_scans: 3,
+        mounts: [
+          { hostname: "gpu-worker-1", mount_point: "/data", used_percent: 94.5 },
+        ],
+      },
+    }),
+  );
+
+  assert.match(summary, /nas:\/share \(nfs4\) at 94\.5% used \(threshold 90%\)/);
+  assert.match(summary, /Breaching mounts: gpu-worker-1:\/data \(94\.5%\)/);
+});
+
+test("a resolved disk episode reads as back below its threshold", () => {
+  const summary = summarizeInfraEpisode(
+    episode({
+      alertType: "disk_usage",
+      subjectKey: "disk:nfs4:nas:/share",
+      status: "resolved",
+      resolvedAt: "2026-08-28T11:00:00.000Z",
+      details: {
+        device: "nas:/share",
+        fstype: "nfs4",
+        threshold_percent: 90,
+        max_used_percent: 81.2,
+        resolution: "below_threshold",
+      },
+    }),
+  );
+
+  assert.match(summary, /back below 90% used \(now 81\.2%\)/);
+});
+
+test("an open GPU temperature episode reads as degrees against its threshold", () => {
+  const summary = summarizeInfraEpisode(
+    episode({
+      alertType: "gpu_temperature",
+      subjectKey: "gpu:gpu-worker-1:3",
+      details: {
+        hostname: "gpu-worker-1",
+        gpu_index: 3,
+        temperature_c: 87,
+        threshold_celsius: 85,
+        consecutive_scans: 2,
+      },
+    }),
+  );
+
+  assert.match(summary, /GPU 3 at 87°C \(threshold 85°C\)/);
+  assert.match(summary, /2 consecutive scans/);
+});
+
+test("a resolved GPU temperature episode reads as back below its threshold", () => {
+  const summary = summarizeInfraEpisode(
+    episode({
+      alertType: "gpu_temperature",
+      subjectKey: "gpu:gpu-worker-1:3",
+      status: "resolved",
+      resolvedAt: "2026-08-28T11:00:00.000Z",
+      details: {
+        gpu_index: 3,
+        temperature_c: 71,
+        threshold_celsius: 85,
+        resolution: "below_threshold",
+      },
+    }),
+  );
+
+  assert.match(summary, /GPU 3 back below 85°C \(now 71°C\)/);
+});

--- a/src/lib/alerts-infra.ts
+++ b/src/lib/alerts-infra.ts
@@ -1,0 +1,201 @@
+/**
+ * Presentation logic for the Infra view of the alerts tab.
+ *
+ * Infra alerts are per-subject breach episodes written by the alerting worker:
+ * a host that stopped reporting, a shared (fstype, device) disk group over its
+ * usage threshold, or one GPU on one host over its temperature threshold.
+ * Unlike Main CI there is nothing to resolve by hand — an episode closes when
+ * the worker observes the breach clear, and a host absent from every expected
+ * source for seven days is auto-retired instead. Unreporting wording always
+ * says a host "stopped reporting"; the view never claims a machine is down.
+ */
+
+import { formatAlertDateTime, withinAlertWindow } from "./alerts-shared";
+
+export type InfraAlertType = "unreporting" | "disk_usage" | "gpu_temperature";
+
+export type InfraAlertStatus = "open" | "resolved";
+
+/** One breach episode as the infra alerts API returns it. */
+export interface InfraAlertEpisode {
+  alertId: string;
+  alertType: InfraAlertType;
+  subjectKey: string;
+  status: InfraAlertStatus;
+  openedAt: string;
+  resolvedAt: string | null;
+  details: Record<string, unknown>;
+}
+
+/** A host the worker auto-retired after seven days absent and silent. */
+export interface InfraRetiredHost {
+  subjectKey: string;
+  lastReportedAt: string | null;
+  retiredAt: string;
+}
+
+export const INFRA_ALERT_TYPE_LABELS: Record<InfraAlertType, string> = {
+  unreporting: "Stopped reporting",
+  disk_usage: "Disk",
+  gpu_temperature: "GPU temperature",
+};
+
+export interface InfraAlertEpisodeView extends InfraAlertEpisode {
+  typeLabel: string;
+  /** The episode's one-line reading of its details payload. */
+  summary: string;
+  /** True when the episode's host has been auto-retired. */
+  retired: boolean;
+}
+
+/** The Infra tab's open and recently resolved episodes plus retired hosts. */
+export interface InfraAlertView {
+  open: InfraAlertEpisodeView[];
+  resolved: InfraAlertEpisodeView[];
+  retiredHosts: InfraRetiredHost[];
+}
+
+function numberDetail(
+  details: Record<string, unknown>,
+  key: string,
+): number | null {
+  const value = details[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function stringDetail(
+  details: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = details[key];
+  return typeof value === "string" && value ? value : null;
+}
+
+function scansSuffix(details: Record<string, unknown>): string {
+  const scans = numberDetail(details, "consecutive_scans");
+  return scans === null ? "" : ` (${scans} consecutive scans)`;
+}
+
+function summarizeUnreporting(episode: InfraAlertEpisode): string {
+  const { details } = episode;
+  if (episode.status === "resolved") {
+    return details.resolution === "retired"
+      ? "Auto-retired after 7 days absent from every expected source; it no longer alerts."
+      : "The host is reporting again.";
+  }
+  const minutes = numberDetail(details, "threshold_minutes");
+  const silence =
+    minutes === null
+      ? "No successful report within the configured threshold"
+      : `No successful report for over ${minutes} minutes`;
+  const lastReportedAt = stringDetail(details, "last_reported_at");
+  const seen = lastReportedAt
+    ? `Last report ${formatAlertDateTime(lastReportedAt)}.`
+    : "No report has ever been received.";
+  return `${silence}${scansSuffix(details)}. ${seen}`;
+}
+
+function summarizeDiskUsage(episode: InfraAlertEpisode): string {
+  const { details } = episode;
+  const device = stringDetail(details, "device");
+  const fstype = stringDetail(details, "fstype");
+  const disk = device && fstype ? `${device} (${fstype})` : episode.subjectKey;
+  const threshold = numberDetail(details, "threshold_percent");
+  const percent = numberDetail(details, "max_used_percent");
+  if (episode.status === "resolved") {
+    const now =
+      percent === null ? "" : ` (now ${percent}%)`;
+    return `${disk} back below ${threshold ?? "?"}% used${now}.`;
+  }
+  const usage =
+    percent === null
+      ? `${disk} over its usage threshold`
+      : `${disk} at ${percent}% used`;
+  const limit = threshold === null ? "" : ` (threshold ${threshold}%)`;
+  const mounts = Array.isArray(details.mounts) ? details.mounts : [];
+  const breaching = mounts
+    .filter(
+      (mount): mount is Record<string, unknown> =>
+        typeof mount === "object" && mount !== null,
+    )
+    .map((mount) => {
+      const hostname = stringDetail(mount, "hostname");
+      const mountPoint = stringDetail(mount, "mount_point");
+      const used = numberDetail(mount, "used_percent");
+      return hostname && mountPoint && used !== null
+        ? `${hostname}:${mountPoint} (${used}%)`
+        : null;
+    })
+    .filter((entry): entry is string => entry !== null);
+  const mountLine = breaching.length
+    ? ` Breaching mounts: ${breaching.join(", ")}.`
+    : "";
+  return `${usage}${limit}${scansSuffix(details)}.${mountLine}`;
+}
+
+function summarizeGpuTemperature(episode: InfraAlertEpisode): string {
+  const { details } = episode;
+  const gpuIndex = numberDetail(details, "gpu_index");
+  const gpu = gpuIndex === null ? "GPU" : `GPU ${gpuIndex}`;
+  const threshold = numberDetail(details, "threshold_celsius");
+  const temperature = numberDetail(details, "temperature_c");
+  if (episode.status === "resolved") {
+    const now = temperature === null ? "" : ` (now ${temperature}°C)`;
+    return `${gpu} back below ${threshold ?? "?"}°C${now}.`;
+  }
+  const heat =
+    temperature === null
+      ? `${gpu} over its temperature threshold`
+      : `${gpu} at ${temperature}°C`;
+  const limit = threshold === null ? "" : ` (threshold ${threshold}°C)`;
+  return `${heat}${limit}${scansSuffix(details)}.`;
+}
+
+/** The one-line reading of an episode's details, per alert type and status. */
+export function summarizeInfraEpisode(episode: InfraAlertEpisode): string {
+  if (episode.alertType === "unreporting") return summarizeUnreporting(episode);
+  if (episode.alertType === "disk_usage") return summarizeDiskUsage(episode);
+  return summarizeGpuTemperature(episode);
+}
+
+/**
+ * Shape episodes for display: open episodes stay visible regardless of age,
+ * resolved history obeys the window (matching the Main CI view), and episodes
+ * whose host the worker has auto-retired are marked so the list can say so.
+ */
+export function viewInfraAlerts(
+  episodes: readonly InfraAlertEpisode[],
+  retiredHosts: readonly InfraRetiredHost[],
+  cutoff: Date,
+): InfraAlertView {
+  const retiredKeys = new Set(retiredHosts.map((host) => host.subjectKey));
+  const views: InfraAlertEpisodeView[] = episodes.map((episode) => ({
+    ...episode,
+    typeLabel: INFRA_ALERT_TYPE_LABELS[episode.alertType],
+    summary: summarizeInfraEpisode(episode),
+    retired:
+      episode.alertType === "unreporting" && retiredKeys.has(episode.subjectKey),
+  }));
+
+  const open = views
+    .filter((episode) => episode.status === "open")
+    .sort((a, b) => b.openedAt.localeCompare(a.openedAt));
+  const resolved = views
+    .filter(
+      (episode) =>
+        episode.status === "resolved" &&
+        episode.resolvedAt !== null &&
+        withinAlertWindow(episode.resolvedAt, cutoff),
+    )
+    .sort((a, b) =>
+      (b.resolvedAt ?? "").localeCompare(a.resolvedAt ?? ""),
+    );
+
+  return {
+    open,
+    resolved,
+    retiredHosts: [...retiredHosts].sort((a, b) =>
+      b.retiredAt.localeCompare(a.retiredAt),
+    ),
+  };
+}


### PR DESCRIPTION
Stacked on #113.

## What

A new `infra` alert path in the alerting worker, scanned every 5 minutes:

- **Unreporting detection** — expected host set = `kubectl get nodes` on both clusters ∪ Buildkite GPU-queue agents (hostname join) ∪ hostnames seen in `gpu_snapshots` (7-day window). A host silent past the threshold for 2 consecutive scans opens an episode; the first fresh report resolves it; a host absent from every source AND silent 7 days auto-retires (shown on the dashboard). Wording is always "stopped reporting", never "machine is down"
- **Threshold alerts** — disk ≥90% on job-critical roles, deduplicated by `(fstype, device)` so the shared NFS volume pages once fleet-wide; GPU temp ≥85°C sustained across consecutive scans. Thresholds are read from the `alert_thresholds` Postgres table **on every scan** — tune via Supabase, no redeploy
- **Exactly two Slack messages per episode** (open/resolve) via the existing outbox, posted to `SLACK_CI_INFRA_ALERT_CHANNEL` (fallback: shared channel until the secret lands)
- **Migration 0019** — `alerting_infra_host_states` + `alerting_infra_alerts` (partial unique index enforces one open episode per subject), outbox `alert_path` CHECK widened to `'infra'`. **Already applied to production**
- **/alerts Infra tab** — open + 7-day resolved history, retired hosts marked, read-only; schema-pending fallback for preview deploys
- **Per-alert docs** — `alerting/docs/{fast-ci,full-ci,main-ci,infra}.md` + `docs/alerts/queue-wait.md`, linked from the READMEs
- systemd `alerting-infra.{service,timer}` + worker consumer wiring

## Test plan

- alerting pytest: 188 passed (in-memory scan/episode/retirement/dedup coverage + Postgres adapter conformance)
- `npm test`: 92/92; ruff clean; mypy clean on changed files (2 pre-existing boto3-stub errors on main unchanged)

## Deploy notes

The infra unit runs with `ProtectHome=true`/`ProtectSystem=strict`: the per-cluster kubeconfigs from `GPU_REPORTER_KUBECONFIG_H100`/`_DGX` must live outside `/home` (e.g. rendered under `/run/alerting/` by load-secrets) on the alerting worker.