### PR TITLE
gpu-reporter-k8s: skip zero-capacity devices in disk reports

### DIFF
--- a/scripts/gpu-reporter/gpu-reporter-k8s.py
+++ b/scripts/gpu-reporter/gpu-reporter-k8s.py
@@ -323,8 +323,13 @@ def build_disk_entries(node_name, fs_map, rootfs_capacity):
     disks = []
     for device in sorted(fs_map):
         entry = fs_map[device]
-        # Skip zero-capacity devices (e.g. unbacked /dev/loopN): nothing can
+        # Skip loop devices (snap/squashfs images, e.g. 30 of them on the
+        # dgx hosts that also run a host-level buildkite-agent): read-only
+        # mounts that can never fill, pure noise in the drill-down. Also
+        # skip zero-capacity devices (e.g. unbacked /dev/loopN): nothing can
         # fill them, and the ingestion contract requires total_bytes >= 1.
+        if device.startswith("/dev/loop"):
+            continue
         if not entry["total_bytes"]:
             continue
         disks.append({

--- a/scripts/gpu-reporter/gpu-reporter-k8s.py
+++ b/scripts/gpu-reporter/gpu-reporter-k8s.py
@@ -323,6 +323,10 @@ def build_disk_entries(node_name, fs_map, rootfs_capacity):
     disks = []
     for device in sorted(fs_map):
         entry = fs_map[device]
+        # Skip zero-capacity devices (e.g. unbacked /dev/loopN): nothing can
+        # fill them, and the ingestion contract requires total_bytes >= 1.
+        if not entry["total_bytes"]:
+            continue
         disks.append({
             # cAdvisor labels by device, so the true mount point is unknown
             # and mount_point stays null (the server accepts a disk with

--- a/scripts/gpu-reporter/gpu-reporter.py
+++ b/scripts/gpu-reporter/gpu-reporter.py
@@ -66,8 +66,8 @@ SKIP_FSTYPES = frozenset({
     "autofs", "binfmt_misc", "bpf", "cgroup", "cgroup2", "configfs",
     "debugfs", "devpts", "devtmpfs", "efivarfs", "fuse.gvfsd-fuse",
     "fuse.portal", "fusectl", "hugetlbfs", "mqueue", "nsfs", "overlay",
-    "proc", "pstore", "ramfs", "securityfs", "selinuxfs", "squashfs",
-    "sysfs", "tracefs",
+    "proc", "pstore", "ramfs", "rpc_pipefs", "securityfs", "selinuxfs",
+    "squashfs", "sysfs", "tracefs",
 })
 
 
@@ -213,13 +213,19 @@ def collect_host_metrics():
 
     disks = []
     for m in mounts:
-        disks.append({
+        entry = {
             "mount_point": m["mount"],
             "device": m["device"],
             "fstype": m["fstype"],
             "role": classify_mount(m["mount"]),
             **stat_mount(m["mount"]),
-        })
+        }
+        # Skip zero-capacity mounts (kernel pseudo-filesystems that slip the
+        # fstype filter): nothing can fill them, and the ingestion contract
+        # requires total_bytes >= 1, so one would fail the whole report.
+        if entry["error"] is None and not entry["total_bytes"]:
+            continue
+        disks.append(entry)
 
     return {
         "cpu_util": cpu_util_percent(),

--- a/scripts/gpu-reporter/tests/test_gpu_reporter.py
+++ b/scripts/gpu-reporter/tests/test_gpu_reporter.py
@@ -81,6 +81,34 @@ def test_parse_proc_mounts_filters_kernel_filesystems(reporter):
     assert kept["/mnt/vllm-ci"]["fstype"] == "nfs4"
 
 
+def test_rpc_pipefs_and_zero_capacity_mounts_are_skipped(reporter, monkeypatch):
+    # Live failure: h200-ci-1's /run/rpc_pipefs stats to total_bytes 0, and
+    # the ingestion contract requires total >= 1 — the whole report was
+    # rejected (HTTP 400) until these mounts are dropped.
+    mounts = "sunrpc /run/rpc_pipefs rpc_pipefs rw,relatime 0 0\n" \
+             "/dev/md0 / ext4 rw,relatime 0 0\n"
+    assert [m["mount"] for m in reporter.parse_proc_mounts(mounts)] == ["/"]
+
+    # Defense in depth: even a mount that slips the fstype filter is dropped
+    # when its capacity stats to zero.
+    monkeypatch.setattr(reporter, "PROC_MOUNTS", "/dev/null")
+    monkeypatch.setattr(reporter, "parse_meminfo",
+                        lambda text: {"total": 16, "available": 8})
+    monkeypatch.setattr(reporter, "cpu_util_percent", lambda: 1.0)
+    monkeypatch.setattr(reporter, "parse_proc_mounts",
+                        lambda text: [{"device": "x", "mount": "/zero",
+                                       "fstype": "ext4"},
+                                      {"device": "y", "mount": "/real",
+                                       "fstype": "ext4"}])
+    def fake_stat(mount, timeout=5):
+        if mount == "/zero":
+            return {"used_bytes": 0, "total_bytes": 0, "error": None}
+        return {"used_bytes": 1, "total_bytes": 10, "error": None}
+    monkeypatch.setattr(reporter, "stat_mount", fake_stat)
+    host = reporter.collect_host_metrics()
+    assert [d["mount_point"] for d in host["disks"]] == ["/real"]
+
+
 def test_h200_mount_role_map(reporter):
     assert reporter.classify_mount("/") == "system"
     assert reporter.classify_mount("/dev/shm") == "workspace"

--- a/scripts/gpu-reporter/tests/test_gpu_reporter.py
+++ b/scripts/gpu-reporter/tests/test_gpu_reporter.py
@@ -92,6 +92,7 @@ def test_rpc_pipefs_and_zero_capacity_mounts_are_skipped(reporter, monkeypatch):
     # Defense in depth: even a mount that slips the fstype filter is dropped
     # when its capacity stats to zero.
     monkeypatch.setattr(reporter, "PROC_MOUNTS", "/dev/null")
+    monkeypatch.setattr(reporter, "PROC_MEMINFO", "/dev/null")
     monkeypatch.setattr(reporter, "parse_meminfo",
                         lambda text: {"total": 16, "available": 8})
     monkeypatch.setattr(reporter, "cpu_util_percent", lambda: 1.0)

--- a/scripts/gpu-reporter/tests/test_gpu_reporter_k8s.py
+++ b/scripts/gpu-reporter/tests/test_gpu_reporter_k8s.py
@@ -180,6 +180,19 @@ def test_zero_capacity_devices_are_skipped(reporter_k8s):
     assert [d["device"] for d in disks] == ["/dev/vda1"]
 
 
+def test_loop_devices_are_skipped(reporter_k8s):
+    # dgxb200-12/-14 (host-level buildkite-agent, snap packages) report ~30
+    # snap loop mounts via cAdvisor: read-only squashfs, can never fill,
+    # pure drill-down noise.
+    fs_map = {
+        "/dev/loop0": {"used_bytes": 66846720, "total_bytes": 66846720},
+        "/dev/loop17": {"used_bytes": 52428800, "total_bytes": 52428800},
+        "/dev/md0": {"used_bytes": 1, "total_bytes": 1800000000000},
+    }
+    disks = reporter_k8s.build_disk_entries("dgxb200-12", fs_map, 1800000000000)
+    assert [d["device"] for d in disks] == ["/dev/md0"]
+
+
 def test_disk_scrape_cadence(reporter_k8s, monkeypatch):
     calls = []
 

--- a/scripts/gpu-reporter/tests/test_gpu_reporter_k8s.py
+++ b/scripts/gpu-reporter/tests/test_gpu_reporter_k8s.py
@@ -168,6 +168,18 @@ def test_unknown_pool_root_falls_back_to_system(reporter_k8s):
     assert roles == {"/dev/md127": "system", "/dev/md0": "other"}
 
 
+def test_zero_capacity_devices_are_skipped(reporter_k8s):
+    # Live failure: inf-4x8h100-4's cAdvisor reports an unbacked /dev/loop0
+    # with total_bytes 0, and the ingestion contract requires total >= 1 —
+    # the whole node payload was rejected (HTTP 400) until these are dropped.
+    fs_map = {
+        "/dev/loop0": {"used_bytes": 0, "total_bytes": 0},
+        "/dev/vda1": {"used_bytes": 1, "total_bytes": 243379802112},
+    }
+    disks = reporter_k8s.build_disk_entries("inf-4x8h100-4", fs_map, 243379802112)
+    assert [d["device"] for d in disks] == ["/dev/vda1"]
+
+
 def test_disk_scrape_cadence(reporter_k8s, monkeypatch):
     calls = []
 


### PR DESCRIPTION
## Why

Found during the h100-cp rollout: `inf-4x8h100-4`'s cAdvisor endpoint reports an unbacked `/dev/loop0` with limit 0. The ingestion contract requires `total_bytes >= 1`, so the node's whole payload was rejected (HTTP 400) and the host went dark on /gpu while its 7 sibling nodes reported fine.

Zero-capacity devices carry no signal — nothing can fill them — so drop them at the source.

## Test plan

- New regression test `test_zero_capacity_devices_are_skipped` (payload-shape level)
- Reporter suite: 27 passed