### PR TITLE
alerting: make kubectl expected-host sources optional for infra

### DIFF
--- a/alerting/docs/infra.md
+++ b/alerting/docs/infra.md
@@ -45,10 +45,16 @@ episode.
   `unreporting` 10 minutes / 2 scans, `disk_usage` 90% / 2 scans,
   `gpu_temperature` 85°C / 2 scans.
 - The expected-host set is the union of: Kubernetes node names from both
-  clusters (`GPU_REPORTER_KUBECONFIG_H100`, `GPU_REPORTER_KUBECONFIG_DGX`),
-  Buildkite agents in the `gpu` queue (`BUILDKITE_TOKEN`, hostname
-  lowercased), and hostnames seen in `gpu_snapshots` within the last 7
-  days. All hostnames are lowercased.
+  clusters (`GPU_REPORTER_KUBECONFIG_H100`, `GPU_REPORTER_KUBECONFIG_DGX` —
+  **optional**; unset means the kubectl source is skipped, set-but-failing
+  fails the scan closed), Buildkite agents in the `gpu` queue
+  (`BUILDKITE_TOKEN`, hostname lowercased), and hostnames seen in
+  `gpu_snapshots` within the last 7 days. All hostnames are lowercased.
+  Note: the stock alerting worker's security group allows egress only on
+  443/5432/6543, so cluster API servers (6443) are unreachable from it and
+  the kubectl sources are normally skipped — coverage is preserved because
+  the control-plane scrapers report every cluster node (a dead scraper
+  silences, and therefore alerts, its whole cluster).
 - Slack: `SLACK_BOT_TOKEN`; channel `SLACK_CI_INFRA_ALERT_CHANNEL` (falls
   back to the shared alerts channel `C0ABTNM9L5U` until the secret exists).
 - Control plane: S3 `control/infra.mode` (`shadow` default / `live` /

--- a/alerting/tests/test_worker.py
+++ b/alerting/tests/test_worker.py
@@ -142,16 +142,26 @@ def test_infra_runtime_requires_both_kubeconfigs_and_buildkite_token(
     assert captured["delivery_mode"] is DeliveryMode.SHADOW
 
 
-def test_infra_runtime_fails_closed_without_kubeconfigs(
+def test_infra_runtime_skips_kubectl_sources_without_kubeconfigs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_build(**kwargs: object) -> RecordingRuntime:
+        captured.update(kwargs)
+        return RecordingRuntime()
+
     monkeypatch.setenv("DATABASE_URL", "postgresql://example.invalid/alerting")
     monkeypatch.setenv("BUILDKITE_TOKEN", "bk-token")
     monkeypatch.delenv("GPU_REPORTER_KUBECONFIG_H100", raising=False)
     monkeypatch.delenv("GPU_REPORTER_KUBECONFIG_DGX", raising=False)
+    monkeypatch.setattr(worker, "build_infra_runtime", fake_build)
 
-    with pytest.raises(RuntimeError, match="GPU_REPORTER_KUBECONFIG_H100"):
-        worker._runtime("infra", worker.SystemClock(), DeliveryMode.SHADOW)
+    worker._runtime("infra", worker.SystemClock(), DeliveryMode.SHADOW)
+
+    # No kubectl sources: the worker's egress SG cannot reach the cluster
+    # API servers, so kubeconfigs are optional and unset means "skip".
+    assert captured["kubeconfigs"] == []
 
 
 def _set_analysis_environment(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -108,13 +108,25 @@ def _runtime(
             clock=clock,
         )
     if consumer == "infra":
+        # kubectl node-list sources are optional: the worker's security group
+        # allows only 443/5432/6543 egress, so cluster API servers (6443) may
+        # be unreachable. Unset = skip the source; set-but-failing still
+        # fails the scan closed so misconfiguration is loud. Coverage without
+        # kubectl is preserved transitively: the control-plane scrapers report
+        # every cluster node, and a dead scraper silences (and alerts) all of
+        # them.
+        kubeconfigs = [
+            path
+            for name in (
+                "GPU_REPORTER_KUBECONFIG_H100",
+                "GPU_REPORTER_KUBECONFIG_DGX",
+            )
+            if (path := os.environ.get(name))
+        ]
         return build_infra_runtime(
             database_url=database_url,
             buildkite_token=_required_environment("BUILDKITE_TOKEN"),
-            kubeconfigs=[
-                _required_environment("GPU_REPORTER_KUBECONFIG_H100"),
-                _required_environment("GPU_REPORTER_KUBECONFIG_DGX"),
-            ],
+            kubeconfigs=kubeconfigs,
             slack=_slack(),
             clock=clock,
             delivery_mode=delivery_mode,

--- a/src/components/gpu-host-table.tsx
+++ b/src/components/gpu-host-table.tsx
@@ -393,7 +393,7 @@ export function GpuHostTable({
                     aria-expanded={isOpen}
                     className={`cursor-pointer border-b border-zinc-100 hover:bg-zinc-50 dark:border-zinc-800/50 dark:hover:bg-zinc-900/50 ${stale ? "opacity-50" : ""} ${isOpen ? "bg-zinc-50 dark:bg-zinc-900/50" : ""}`}
                   >
-                    <td className="px-5 py-3.5 font-medium sm:px-6">
+                    <td className="whitespace-nowrap px-5 py-3.5 font-medium sm:px-6">
                       <span className="mr-2 inline-flex">
                         <HealthDot status={status} />
                       </span>


### PR DESCRIPTION
## Why

Live finding while enabling the infra path: the alerting worker's security group egress is restricted to 443/5432/6543, and both cluster API servers live on private IPs:6443 — unreachable from the worker, so every `infra_scan` failed closed on the required `GPU_REPORTER_KUBECONFIG_*` env vars.

Unset kubeconfig env vars now skip the kubectl node-list sources (Buildkite + Postgres-history sources remain). Set-but-failing still fails closed, so a misconfigured path stays loud.

Coverage argument for why this is safe: the control-plane scrapers enumerate nodes and report every one of them, so `gpu_snapshots` already carries the full k8s roster; a dead scraper silences — and therefore alerts — its whole cluster.

## Test plan

- alerting pytest: 189 passed (the fail-closed test became a skips-when-unset test)
- ruff clean; mypy clean on changed files