### PR TITLE
alerting: retry transient Kimi requests and raise Full CI read timeout

### DIFF
--- a/alerting/docs/full-ci.md
+++ b/alerting/docs/full-ci.md
@@ -27,7 +27,11 @@ analysis report.
 
 - `BUILDKITE_TOKEN` (source reads), `GITHUB_TOKEN` (PR attribution),
   `KIMI_API_KEY` plus optional `KIMI_BASE_URL`, `KIMI_MODEL`,
-  `KIMI_TIMEOUT_SECONDS`, `KIMI_REASONING_EFFORT`.
+  `KIMI_TIMEOUT_SECONDS` (whole-analysis budget, default 3600),
+  `KIMI_REQUEST_TIMEOUT_SECONDS` (single completion read timeout, default
+  900), `KIMI_REASONING_EFFORT`. Transient request failures — read timeouts,
+  connection errors, HTTP 429/5xx — are retried up to 3 times with 5s/15s
+  backoff inside the whole-analysis budget before the analysis fails.
 - `ALERTING_CHECKPOINT_BUCKET` — the S3 bucket for immutable analyzer
   checkpoints and the per-path control objects.
 - Slack: `SLACK_BOT_TOKEN`; `SLACK_CHANNEL_ID` overrides the default

--- a/alerting/kimi.py
+++ b/alerting/kimi.py
@@ -48,6 +48,10 @@ BASH_OUTPUT_LIMIT = 40_000
 BASH_TIMEOUT_SECONDS = 60
 TASK_RESULT_LIMIT = 50_000
 REQUEST_TIMEOUT_SECONDS = 300.0
+# One slow or dropped completion should cost a retry, not the whole analysis:
+# a Full CI run is dozens of sequential requests and any of them can stall.
+MAX_REQUEST_ATTEMPTS = 3
+_REQUEST_RETRY_BACKOFF_SECONDS = (5.0, 15.0)
 # The inferact endpoint counts unset output budget as zero and rejects the
 # request when the prompt alone approaches the context window.
 MAX_OUTPUT_TOKENS = 16_384
@@ -79,7 +83,13 @@ def _prune_history(messages: list[dict[str, Any]]) -> None:
             total -= len(content) - len(_ELIDED)
             message["content"] = _ELIDED
 
+
 Transport = Callable[[str, dict[str, str], dict[str, Any]], dict[str, Any]]
+
+
+class TransientTransportError(AnalyzerError):
+    """A Kimi request failed in a way that a retry may fix."""
+
 
 _STRING = {"type": "string"}
 _TOOLS: list[dict[str, Any]] = [
@@ -198,10 +208,15 @@ class UrllibTransport:
                 result: Any = json.load(resp)
         except urllib.error.HTTPError as exc:
             body = exc.read().decode("utf-8", errors="replace")
-            raise AnalyzerError(
-                f"kimi API request failed with HTTP {exc.code}: {body[:1000]}"
-            ) from exc
-        except (OSError, TimeoutError, json.JSONDecodeError) as exc:
+            message = f"kimi API request failed with HTTP {exc.code}: {body[:1000]}"
+            if exc.code == 429 or exc.code >= 500:
+                raise TransientTransportError(message) from exc
+            raise AnalyzerError(message) from exc
+        except (OSError, TimeoutError) as exc:
+            # Read timeouts, resets, and DNS blips: the request may simply be
+            # retried. socket.timeout is an OSError subclass.
+            raise TransientTransportError(f"kimi API request failed: {exc}") from exc
+        except json.JSONDecodeError as exc:
             raise AnalyzerError(f"kimi API request failed: {exc}") from exc
         if not isinstance(result, dict):
             raise AnalyzerError("kimi API returned a malformed response")
@@ -222,6 +237,9 @@ class KimiCodeRunner:
         reasoning_effort: str = "low",
         transport: Transport | None = None,
         clock: Callable[[], float] | None = None,
+        request_timeout_seconds: float = REQUEST_TIMEOUT_SECONDS,
+        max_request_attempts: int = MAX_REQUEST_ATTEMPTS,
+        sleep: Callable[[float], None] | None = None,
     ) -> None:
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
@@ -229,8 +247,12 @@ class KimiCodeRunner:
         self._timeout_seconds = timeout_seconds
         self._max_turns = max_turns
         self._reasoning_effort = reasoning_effort
-        self._transport = transport or UrllibTransport()
+        self._transport = transport or UrllibTransport(
+            timeout_seconds=request_timeout_seconds
+        )
         self._clock = clock or time.monotonic
+        self._max_request_attempts = max(1, max_request_attempts)
+        self._sleep = sleep or time.sleep
 
     def run(
         self,
@@ -274,7 +296,7 @@ class KimiCodeRunner:
         for _ in range(self._max_turns):
             if self._clock() >= deadline:
                 raise AnalyzerError("kimi analyzer exceeded its time budget")
-            message = self._complete(messages, tools)
+            message = self._complete(messages, tools, deadline)
             messages.append(message)
             calls = message.get("tool_calls")
             if not calls:
@@ -294,7 +316,10 @@ class KimiCodeRunner:
         raise AnalyzerError(f"kimi analyzer exceeded {self._max_turns} turns")
 
     def _complete(
-        self, messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        deadline: float,
     ) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "model": self._model,
@@ -306,14 +331,7 @@ class KimiCodeRunner:
             # sequential investigation calls fast enough for the time budget.
             "reasoning_effort": self._reasoning_effort,
         }
-        response = self._transport(
-            f"{self._base_url}/chat/completions",
-            {
-                "Authorization": f"Bearer {self._api_key}",
-                "Content-Type": "application/json",
-            },
-            payload,
-        )
+        response = self._request(payload, deadline)
         try:
             message = cast(list[dict[str, Any]], response["choices"])[0]["message"]
         except (KeyError, IndexError, TypeError) as exc:
@@ -321,6 +339,29 @@ class KimiCodeRunner:
         if not isinstance(message, dict):
             raise AnalyzerError("kimi API returned a malformed response")
         return cast(dict[str, Any], message)
+
+    def _request(self, payload: dict[str, Any], deadline: float) -> dict[str, Any]:
+        """POST one completion, retrying transient failures inside the budget."""
+        url = f"{self._base_url}/chat/completions"
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        for attempt in range(1, self._max_request_attempts + 1):
+            try:
+                return self._transport(url, headers, payload)
+            except TransientTransportError as exc:
+                if attempt >= self._max_request_attempts:
+                    raise AnalyzerError(f"{exc} (after {attempt} attempts)") from exc
+                backoff = _REQUEST_RETRY_BACKOFF_SECONDS[
+                    min(attempt, len(_REQUEST_RETRY_BACKOFF_SECONDS)) - 1
+                ]
+                if self._clock() + backoff >= deadline:
+                    raise AnalyzerError(
+                        f"{exc} (no time budget left to retry after {attempt} attempts)"
+                    ) from exc
+                self._sleep(backoff)
+        raise AssertionError("unreachable: attempts loop always returns or raises")
 
     def _execute(
         self,

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -2011,6 +2011,7 @@ def build_full_ci_analysis_runtime(
     kimi_model: str = "moonshotai/Kimi-K3",
     kimi_timeout_seconds: int = 3600,
     kimi_reasoning_effort: str = "low",
+    kimi_request_timeout_seconds: float = 900.0,
     delivery_mode: DeliveryMode = DeliveryMode.LIVE,
 ) -> AlertingRuntime:
     """Wire the production analyzer compatibility adapter into the runtime."""
@@ -2034,6 +2035,7 @@ def build_full_ci_analysis_runtime(
             model=kimi_model,
             timeout_seconds=kimi_timeout_seconds,
             reasoning_effort=kimi_reasoning_effort,
+            request_timeout_seconds=kimi_request_timeout_seconds,
         ),
         checkpoints=S3CheckpointStore(bucket=checkpoint_bucket),
         github=GitHubRestClient(token=github_token),

--- a/alerting/tests/test_kimi.py
+++ b/alerting/tests/test_kimi.py
@@ -9,7 +9,7 @@ from typing import Any
 import pytest
 
 from alerting.analyzer import AnalyzerError
-from alerting.kimi import KimiCodeRunner
+from alerting.kimi import KimiCodeRunner, TransientTransportError
 
 
 def tool_call(
@@ -209,3 +209,142 @@ def test_requests_default_to_low_reasoning_effort(tmp_path: Path) -> None:
     KimiCodeRunner(api_key="key", transport=transport).run(tmp_path)
 
     assert transport.payloads[0]["reasoning_effort"] == "low"
+
+
+class FlakyTransport:
+    """Scripted transport whose entries may be exceptions to raise."""
+
+    def __init__(self, script: list[dict[str, Any] | Exception]) -> None:
+        self._script = list(script)
+        self.calls = 0
+
+    def __call__(
+        self, url: str, headers: dict[str, str], payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.calls += 1
+        item = self._script.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+def test_transient_request_failures_are_retried_with_backoff(
+    tmp_path: Path,
+) -> None:
+    transport = FlakyTransport(
+        [
+            TransientTransportError("kimi API request failed: timed out"),
+            TransientTransportError("kimi API request failed: timed out"),
+            final(),
+        ]
+    )
+    sleeps: list[float] = []
+
+    KimiCodeRunner(api_key="key", transport=transport, sleep=sleeps.append).run(
+        tmp_path
+    )
+
+    assert transport.calls == 3
+    assert sleeps == [5.0, 15.0]
+
+
+def test_transient_failures_give_up_after_max_attempts(tmp_path: Path) -> None:
+    transport = FlakyTransport(
+        [TransientTransportError("kimi API request failed: timed out")] * 3
+    )
+    sleeps: list[float] = []
+    runner = KimiCodeRunner(api_key="key", transport=transport, sleep=sleeps.append)
+
+    with pytest.raises(AnalyzerError, match=r"timed out \(after 3 attempts\)"):
+        runner.run(tmp_path)
+
+    assert transport.calls == 3
+    assert sleeps == [5.0, 15.0]
+
+
+def test_permanent_request_failures_are_not_retried(tmp_path: Path) -> None:
+    transport = FlakyTransport(
+        [AnalyzerError("kimi API request failed with HTTP 400: bad request")]
+    )
+    sleeps: list[float] = []
+    runner = KimiCodeRunner(api_key="key", transport=transport, sleep=sleeps.append)
+
+    with pytest.raises(AnalyzerError, match="HTTP 400"):
+        runner.run(tmp_path)
+
+    assert transport.calls == 1
+    assert sleeps == []
+
+
+def test_retry_does_not_outlive_the_analysis_budget(tmp_path: Path) -> None:
+    transport = FlakyTransport(
+        [TransientTransportError("kimi API request failed: timed out"), final()]
+    )
+    sleeps: list[float] = []
+    ticks = iter([0.0, 7.0, 7.0, 7.0])
+    runner = KimiCodeRunner(
+        api_key="key",
+        transport=transport,
+        sleep=sleeps.append,
+        timeout_seconds=10,
+        clock=lambda: next(ticks),
+    )
+
+    with pytest.raises(AnalyzerError, match="no time budget left to retry"):
+        runner.run(tmp_path)
+
+    assert transport.calls == 1
+    assert sleeps == []
+
+
+def test_urllib_transport_classifies_failures() -> None:
+    import io
+    import urllib.error
+    import urllib.request
+    from email.message import Message
+
+    from alerting.kimi import UrllibTransport
+
+    transport = UrllibTransport(timeout_seconds=1.0)
+
+    def failing(error: Exception) -> Any:
+        def opener(request: Any, timeout: float) -> Any:
+            raise error
+
+        return opener
+
+    def call(monkey: Any) -> None:
+        urllib.request.urlopen = monkey
+        transport("https://example.invalid/v1/chat/completions", {}, {})
+
+    original = urllib.request.urlopen
+    try:
+        with pytest.raises(TransientTransportError, match="timed out"):
+            call(failing(TimeoutError("The read operation timed out")))
+        with pytest.raises(TransientTransportError, match="HTTP 503"):
+            call(
+                failing(
+                    urllib.error.HTTPError(
+                        "u",
+                        503,
+                        "unavailable",
+                        Message(),
+                        io.BytesIO(b"busy"),
+                    )
+                )
+            )
+        with pytest.raises(AnalyzerError, match="HTTP 400") as info:
+            call(
+                failing(
+                    urllib.error.HTTPError(
+                        "u",
+                        400,
+                        "bad",
+                        Message(),
+                        io.BytesIO(b"bad"),
+                    )
+                )
+            )
+        assert not isinstance(info.value, TransientTransportError)
+    finally:
+        urllib.request.urlopen = original

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -89,6 +89,11 @@ def _runtime(
             kimi_model=os.environ.get("KIMI_MODEL", "moonshotai/Kimi-K3"),
             kimi_timeout_seconds=int(os.environ.get("KIMI_TIMEOUT_SECONDS", "3600")),
             kimi_reasoning_effort=os.environ.get("KIMI_REASONING_EFFORT", "low"),
+            # Full CI triage calls can legitimately think for several minutes;
+            # the default 300s read timeout killed a 24-minute analysis once.
+            kimi_request_timeout_seconds=float(
+                os.environ.get("KIMI_REQUEST_TIMEOUT_SECONDS", "900")
+            ),
             slack=_slack(),
             clock=clock,
             delivery_mode=delivery_mode,


### PR DESCRIPTION
## Why

The Full CI analysis for build #86943 (2026-09-03 02:00 UTC timer fire) failed 24 minutes in:

```
full_ci_analyze  status=failed  last_error: kimi API request failed: The read operation timed out
```

One completion exceeded the 300s `urllib` read timeout, `UrllibTransport` raised, and the analyzer discarded the entire run. No report row, no outbox entry, no Slack message. The build stayed pending until a manual `systemctl start alerting-full-ci.service`.

## What

- **Classify transport failures.** `TransientTransportError` for read timeouts, connection errors, HTTP 429 and 5xx; other 4xx and malformed JSON remain permanent `AnalyzerError`.
- **Retry inside the budget.** `KimiCodeRunner._request` retries transient failures up to 3 times with 5s/15s backoff and refuses to sleep past the whole-analysis deadline. The final error carries the attempt count so `last_error` in Postgres is self-explanatory.
- **Per-request timeout knob.** `KIMI_REQUEST_TIMEOUT_SECONDS`, default **900** for the Full CI analyzer (`worker.py`, `build_full_ci_analysis_runtime`). Main CI keeps 300s per request and gains the retry.
- Docs: `alerting/docs/full-ci.md` lists both knobs and the retry policy.

## Verification

- `pytest`: 194 passed (5 new in `tests/test_kimi.py` — retry-then-succeed with `[5.0, 15.0]` sleeps, give up after 3 attempts, permanent 400 not retried, retry refused near the deadline, urllib classification).
- `ruff check .`: clean.
- `mypy --strict`: clean on every touched file. Remaining errors (`control.py:92`, `analyzer.py:890`, `tests/test_worker.py:247-248`) are pre-existing on `main`.

## Deploy

Needs the worker's `/opt/alerting/source` refreshed via `deploy/aws/install.sh` after merge (operations doc §9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)