### PR TITLE
gpu page: keep drill-down summary visible and stop clipping disk labels

### DIFF
--- a/src/components/gpu-host-table.tsx
+++ b/src/components/gpu-host-table.tsx
@@ -88,7 +88,7 @@ function EmptyMetric() {
 
 function RamBackedBadge() {
   return (
-    <span className="ml-1 rounded bg-violet-100 px-1 py-0.5 text-[10px] font-medium whitespace-nowrap text-violet-700 dark:bg-violet-900/40 dark:text-violet-400">
+    <span className="shrink-0 rounded bg-violet-100 px-1 py-0.5 text-[10px] font-medium whitespace-nowrap text-violet-700 dark:bg-violet-900/40 dark:text-violet-400">
       RAM-backed
     </span>
   );
@@ -185,10 +185,12 @@ function DiskDetail({ disks }: { disks: NormalizedDiskMetric[] | null }) {
         return (
           <div key={`${mountLabel(disk)}-${index}`}>
             <div className="flex items-center gap-2">
-              <span className="w-28 truncate font-mono text-xs text-zinc-500 dark:text-zinc-400">
-                {mountLabel(disk)}
+              <div className="flex w-44 shrink-0 items-center gap-1 text-xs text-zinc-500 dark:text-zinc-400">
+                <span className="truncate font-mono" title={mountLabel(disk)}>
+                  {mountLabel(disk)}
+                </span>
                 {isRamBackedMount(disk) && <RamBackedBadge />}
-              </span>
+              </div>
               {usedPct == null ? (
                 <span className="text-xs text-red-600 dark:text-red-400">
                   {disk.error ?? "no usage reported"}
@@ -205,13 +207,13 @@ function DiskDetail({ disks }: { disks: NormalizedDiskMetric[] | null }) {
                       style={{ width: `${Math.min(usedPct, 100)}%` }}
                     />
                   </div>
-                  <span className="w-28 tabular-nums text-xs text-zinc-500 dark:text-zinc-400">
+                  <span className="w-28 shrink-0 whitespace-nowrap tabular-nums text-xs text-zinc-500 dark:text-zinc-400">
                     {Math.round(usedPct)}% of {formatBytes(disk.total_bytes!)}
                   </span>
                 </>
               )}
             </div>
-            <div className="mt-0.5 pl-0 text-[11px] text-zinc-400">{detail}</div>
+            <div className="mt-0.5 break-all text-[11px] text-zinc-400">{detail}</div>
           </div>
         );
       })}
@@ -229,6 +231,15 @@ function HostDrillDown({ row, host }: { row: HostRow; host: HostLatest | undefin
         <div className="mb-3 flex flex-wrap items-center gap-2 text-xs">
           {host ? (
             <>
+              <span className="whitespace-nowrap font-medium tabular-nums text-zinc-700 dark:text-zinc-200">
+                {host.cpu_count != null && `${host.cpu_count} CPUs`}
+                {host.cpu_count != null &&
+                  host.ram_total_bytes != null &&
+                  " · "}
+                {host.ram_used_bytes != null &&
+                  host.ram_total_bytes != null &&
+                  `RAM ${formatBytes(host.ram_used_bytes)} / ${formatBytes(host.ram_total_bytes)}`}
+              </span>
               <span
                 className={`rounded-full px-2 py-0.5 font-medium ${
                   host.reporter_status === "ok"
@@ -246,15 +257,6 @@ function HostDrillDown({ row, host }: { row: HostRow; host: HostLatest | undefin
               {host.node_conditions && (
                 <NodeConditionChips conditions={host.node_conditions} />
               )}
-              <span className="ml-auto tabular-nums text-zinc-500 dark:text-zinc-400">
-                {host.cpu_count != null && `${host.cpu_count} CPUs`}
-                {host.cpu_count != null &&
-                  host.ram_total_bytes != null &&
-                  " · "}
-                {host.ram_used_bytes != null &&
-                  host.ram_total_bytes != null &&
-                  `RAM ${formatBytes(host.ram_used_bytes)} / ${formatBytes(host.ram_total_bytes)}`}
-              </span>
             </>
           ) : (
             <span className="text-zinc-500 dark:text-zinc-400">
@@ -407,7 +409,7 @@ export function GpuHostTable({
                           Stale
                         </span>
                       ) : null}
-                      <span className="ml-2 text-xs text-zinc-400">
+                      <span className="ml-2 inline-block w-4 text-center text-base leading-none text-zinc-500 dark:text-zinc-400">
                         {isOpen ? "▾" : "▸"}
                       </span>
                     </td>


### PR DESCRIPTION
## What

Three layout fixes in the `/gpu` host drill-down (`src/components/gpu-host-table.tsx`):

- **CPU/RAM summary hidden behind the scrollbar.** `N CPUs · RAM used / total` was pushed to the right edge of the 1200px table row with `ml-auto`, so on narrower viewports the total disappeared under the horizontal scrollbar. It now leads the status line, before the reporter badge.
- **Disk labels clipped.** The mount label and the `RAM-backed` badge shared a fixed `w-28 truncate` span, so `/dev/shm` + badge rendered as `RAM ba…`. The label column is wider (`w-44`), the badge sits outside the truncating span, the usage column no longer wraps, and long device strings (the NFS source on `/mnt/vllm-ci`) `break-all` instead of being cut off.
- **Expand chevron too small.** `▸`/`▾` next to the hostname goes from `text-xs` to `text-base` with a fixed width so rows stay aligned.

No data or query changes.

## Verification

- `npm test`: 116 passed.
- `tsc --noEmit`: clean on `src/`.
- `eslint` on the changed file: clean.
- `next build`: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)