### PR TITLE
fix(alerting): resolve Main CI alerts when the job passes on latest main

### DIFF
--- a/alerting/main_ci.py
+++ b/alerting/main_ci.py
@@ -66,6 +66,13 @@ class MainCIOpenAlertRef:
 
 
 @dataclass(frozen=True)
+class MainCILatestBuildRef:
+    """The newest finished main build the sweep can resolve alerts against."""
+
+    build_number: int
+
+
+@dataclass(frozen=True)
 class MainCIJobAlert:
     """One open-or-resolved failure episode for a logical main CI job."""
 
@@ -258,6 +265,8 @@ class MainCIBackstopBuildPort(Protocol):
 class MainCIBackstopStore(MainCIStore, Protocol):
     def open_main_ci_alert_builds(self) -> list[MainCIOpenAlertRef]: ...
 
+    def latest_finished_main_ci_build(self) -> MainCILatestBuildRef | None: ...
+
 
 class MainCIBackstopHandler:
     """Hourly full sweep of recent main builds plus open-alert builds.
@@ -274,7 +283,11 @@ class MainCIBackstopHandler:
        reprocessing the same builds idempotent.
     2. Targeted re-check: each open alert's last-failure build is fetched
        directly, so a retry pass on a build older than the wide window
-       still resolves its alert.
+       still resolves its alert. The newest finished main build is fetched
+       too: a fix merged after the failure makes the job pass there, and
+       that newer pass resolves the alert even when the job's pass fell
+       outside the sweep window (or the job no longer runs at all, in
+       which case nothing changes and the alert stays open).
 
     The sweep never advances the poller's scan cursor: it only re-checks
     data, and moving the cursor could make the poller skip failures that
@@ -306,6 +319,12 @@ class MainCIBackstopHandler:
         job_keys_by_build: dict[int, set[str]] = {}
         for ref in refs:
             job_keys_by_build.setdefault(ref.build_number, set()).add(ref.job_key)
+        latest = self._store.latest_finished_main_ci_build()
+        if latest is not None:
+            for ref in refs:
+                job_keys_by_build.setdefault(latest.build_number, set()).add(
+                    ref.job_key
+                )
         for build_number in sorted(job_keys_by_build):
             build = self._builds.get_build(
                 build_number, include_retried_jobs=True

--- a/alerting/memory.py
+++ b/alerting/memory.py
@@ -45,6 +45,7 @@ from alerting.infra import (
 from alerting.main_ci import (
     MainCIJobAlert,
     MainCIJobObservation,
+    MainCILatestBuildRef,
     MainCIOpenAlertRef,
     ordered_unique_observations,
 )
@@ -540,6 +541,15 @@ class InMemoryMainCIStore:
             MainCIOpenAlertRef(job_key=job_key, build_number=build_number)
             for job_key, build_number in sorted(refs)
         ]
+
+    def latest_finished_main_ci_build(self) -> MainCILatestBuildRef | None:
+        if not self._states:
+            return None
+        return MainCILatestBuildRef(
+            build_number=max(
+                observation.build_number for observation in self._states.values()
+            )
+        )
 
     def state(self, job_key: str) -> MainCIJobObservation | None:
         return self._states.get(job_key)

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -46,6 +46,7 @@ from alerting.infra import (
 )
 from alerting.main_ci import (
     MainCIJobObservation,
+    MainCILatestBuildRef,
     MainCIOpenAlertRef,
     ordered_unique_observations,
 )
@@ -1058,6 +1059,20 @@ class PostgresAlertStore:
             MainCIOpenAlertRef(job_key=row[0], build_number=int(row[1]))
             for row in rows
         ]
+
+    def latest_finished_main_ci_build(self) -> MainCILatestBuildRef | None:
+        with self._connection_factory() as connection:
+            row = connection.execute(
+                """
+                SELECT latest_build_number
+                FROM alerting_main_ci_job_states
+                ORDER BY latest_build_number DESC
+                LIMIT 1
+                """
+            ).fetchone()
+        if row is None:
+            return None
+        return MainCILatestBuildRef(build_number=int(row[0]))
 
     def infra_thresholds(self) -> list[InfraThreshold]:
         with self._connection_factory() as connection:

--- a/alerting/tests/test_main_ci.py
+++ b/alerting/tests/test_main_ci.py
@@ -74,12 +74,14 @@ def observation(
     state: str,
     minutes: int,
     job_id: str | None = None,
+    job_key: str = "step:gpu-test|name:GPU correctness",
+    job_name: str = "GPU correctness",
 ) -> MainCIJobObservation:
     actual_job_id = job_id or f"job-{build_number}-{state}"
     return MainCIJobObservation(
-        job_key="step:gpu-test|name:GPU correctness",
+        job_key=job_key,
         job_id=actual_job_id,
-        job_name="GPU correctness",
+        job_name=job_name,
         job_url=f"https://buildkite.com/vllm/ci/builds/{build_number}#{actual_job_id}",
         state=state,
         finished_at=START + timedelta(minutes=minutes),
@@ -729,3 +731,146 @@ def test_sweep_is_idempotent_across_reruns() -> None:
     assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
         ("open", 1)
     ]
+
+
+def test_backstop_resolves_alert_via_latest_build_recheck() -> None:
+    # The job failed on build 300, a fix merged, and the job passed on
+    # newer main builds — but those passes finished outside the sweep
+    # window, so the poller and the wide sweep never saw them. The
+    # backstop's targeted re-check of the latest main build resolves it.
+    source = FixtureSource()
+    builds = FixtureBuilds({})
+    runtime, store, _ = combined_runtime_for(source, builds)
+    open_alert(runtime, source)
+    # Record a newer build in the job-state table without resolving: the
+    # job did not run on build 305, so no observation exists for it there.
+    source.observations.append(
+        observation(
+            build_number=305,
+            state="passed",
+            minutes=-100,
+            job_id="unrelated-pass",
+            job_key="step:other|name:Other job",
+            job_name="Other job",
+        )
+    )
+    reconcile(runtime, START - timedelta(hours=1, minutes=30))
+    assert [alert.status for alert in store.alerts()] == ["open"]
+
+    builds.builds[300] = buildkite_build(
+        300,
+        [
+            buildkite_job(
+                job_id="orig", state="failed", finished_at=START - timedelta(hours=3)
+            )
+        ],
+    )
+    builds.builds[305] = buildkite_build(
+        305,
+        [
+            buildkite_job(
+                job_id="fixed",
+                state="passed",
+                finished_at=START - timedelta(hours=1, minutes=40),
+            )
+        ],
+    )
+    backstop(runtime, START + timedelta(hours=2))
+
+    alert = store.alerts()[0]
+    assert alert.status == "resolved"
+    assert alert.resolution is not None
+    assert alert.resolution.job_id == "fixed"
+    assert sorted(builds.calls) == [(300, True), (305, True)]
+
+
+def test_backstop_keeps_alert_open_when_job_absent_from_latest_build() -> None:
+    # The job no longer runs on main (removed/renamed): no newer pass can
+    # exist, so the alert must stay open rather than silently resolving.
+    source = FixtureSource()
+    builds = FixtureBuilds({})
+    runtime, store, _ = combined_runtime_for(source, builds)
+    open_alert(runtime, source)
+    source.observations.append(
+        observation(
+            build_number=305,
+            state="passed",
+            minutes=-100,
+            job_id="unrelated-pass",
+            job_key="step:other|name:Other job",
+            job_name="Other job",
+        )
+    )
+    reconcile(runtime, START - timedelta(hours=1, minutes=30))
+    assert [alert.status for alert in store.alerts()] == ["open"]
+
+    builds.builds[300] = buildkite_build(
+        300,
+        [
+            buildkite_job(
+                job_id="orig", state="failed", finished_at=START - timedelta(hours=3)
+            )
+        ],
+    )
+    builds.builds[305] = buildkite_build(
+        305,
+        [
+            buildkite_job(
+                job_id="other-job",
+                name="Other job",
+                step_key="other",
+                state="passed",
+                finished_at=START - timedelta(hours=1, minutes=40),
+            )
+        ],
+    )
+    backstop(runtime, START + timedelta(hours=2))
+
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("open", 1)
+    ]
+
+
+def test_backstop_latest_build_failure_does_not_resolve_alert() -> None:
+    # The job still fails on the newest main build: the alert stays open
+    # and picks up the newer failure.
+    source = FixtureSource()
+    builds = FixtureBuilds({})
+    runtime, store, _ = combined_runtime_for(source, builds)
+    open_alert(runtime, source)
+    source.observations.append(
+        observation(
+            build_number=305,
+            state="passed",
+            minutes=-100,
+            job_id="unrelated-pass",
+            job_key="step:other|name:Other job",
+            job_name="Other job",
+        )
+    )
+    reconcile(runtime, START - timedelta(hours=1, minutes=30))
+
+    builds.builds[300] = buildkite_build(
+        300,
+        [
+            buildkite_job(
+                job_id="orig", state="failed", finished_at=START - timedelta(hours=3)
+            )
+        ],
+    )
+    builds.builds[305] = buildkite_build(
+        305,
+        [
+            buildkite_job(
+                job_id="still-broken",
+                state="failed",
+                finished_at=START - timedelta(hours=1, minutes=40),
+            )
+        ],
+    )
+    backstop(runtime, START + timedelta(hours=2))
+
+    assert [(alert.status, alert.failure_count) for alert in store.alerts()] == [
+        ("open", 2)
+    ]
+    assert store.alerts()[0].last_failure.job_id == "still-broken"


### PR DESCRIPTION
## Problem

Main CI alerts were going stale: a job fails, a fix lands on main, the job goes green again — but the alert stays open.

Root cause: the hourly backstop's targeted re-check (`MainCIBackstopHandler`) only refetched **the build where the alert last failed** (`open_main_ci_alert_builds`). When the fix lands in a later commit, the passing execution exists only on *newer* builds, which were never refetched. The 2-minute poller can also miss a pass if it finished while the worker was down and the scan window moved past. Either way, no newer pass ever reaches reconciliation, so the alert sits open indefinitely.

## Change

The backstop now also fetches the **newest finished main build** and reconciles every open alert's job key against it:

- `alerting/main_ci.py` — new `MainCILatestBuildRef` + `MainCIBackstopStore.latest_finished_main_ci_build()`; the handler adds the latest build to its targeted re-check set.
- `alerting/postgres.py` / `alerting/memory.py` — implement `latest_finished_main_ci_build()` from `alerting_main_ci_job_states` (max `latest_build_number`).

Resolution flows through the existing order-guarded path in `commit_main_ci_scan`, so an older failure finishing late still cannot overwrite a newer pass, and the sweep still never advances the poller's scan cursor.

**Deliberate boundary:** if a job no longer runs on main at all (removed/renamed — e.g. a deleted model's test job), no pass observation exists, so the alert stays open for manual close rather than silently auto-resolving.

## Tests

Three new tests in `alerting/tests/test_main_ci.py`:
- resolves an open alert via the latest-build re-check when the pass was never observed by poller or sweep
- keeps the alert open when the job is absent from the latest build (removed/renamed)
- keeps the alert open (and increments failure count) when the job still fails on the latest build

`uv run --extra dev pytest`: 197 passed. `ruff check` clean on touched files; the two mypy errors in `analyzer.py` (boto3 stubs) are pre-existing.

AI assistance: this change was made with AI assistance (Kimi Code CLI).