### PR TITLE
fix(queue): query Build.createdBy instead of removed author field

### DIFF
--- a/src/lib/buildkite-queue-jobs.ts
+++ b/src/lib/buildkite-queue-jobs.ts
@@ -42,7 +42,7 @@ interface GraphQLResponse {
               number?: number;
               url?: string;
               message?: string | null;
-              author?: { name?: string | null } | null;
+              createdBy?: { name?: string | null } | null;
             } | null;
           };
         }>;
@@ -414,7 +414,11 @@ async function graphqlQueueJobs(
                         number
                         url
                         message
-                        author { name }
+                        createdBy {
+                          ... on User {
+                            name
+                          }
+                        }
                       }
                     }
                   }
@@ -478,7 +482,7 @@ async function graphqlQueueJobs(
                 number: node.build.number,
                 url: node.build.url,
                 message: node.build.message ?? null,
-                author: node.build.author?.name ?? null,
+                author: node.build.createdBy?.name ?? null,
               }
             : null,
       });


### PR DESCRIPTION
## Problem

The Queue tab's **Waiting jobs** section failed to load with:

```
Field 'author' doesn't exist on type 'Build'
```

The GraphQL query in `src/lib/buildkite-queue-jobs.ts` requested `author { name }` on Buildkite's `Build` type, but that field does not exist in their schema.

## Fix

Buildkite exposes the build creator via `createdBy` (a `BuildCreator` interface). The query now uses an inline fragment on `User` to read the creator's `name`:

```graphql
build {
  number
  url
  message
  createdBy {
    ... on User {
      name
    }
  }
}
```

The response type and mapping were updated (`author` → `createdBy`). Downstream consumers (e.g. `/api/metrics/waiting-builds`) still receive `author` unchanged.

Verified with `tsc --noEmit` (clean).