### PR TITLE
fix(alerting): bound Main CI analysis latency

### DIFF
--- a/alerting/kimi.py
+++ b/alerting/kimi.py
@@ -185,8 +185,16 @@ class UrllibTransport:
         self._timeout_seconds = timeout_seconds
 
     def __call__(
-        self, url: str, headers: dict[str, str], payload: dict[str, Any]
+        self,
+        url: str,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+        *,
+        timeout_seconds: float | None = None,
     ) -> dict[str, Any]:
+        timeout = self._timeout_seconds
+        if timeout_seconds is not None:
+            timeout = min(timeout, timeout_seconds)
         request = urllib.request.Request(
             url,
             data=json.dumps(payload).encode("utf-8"),
@@ -194,7 +202,7 @@ class UrllibTransport:
             method="POST",
         )
         try:
-            with urllib.request.urlopen(request, timeout=self._timeout_seconds) as resp:
+            with urllib.request.urlopen(request, timeout=timeout) as resp:
                 result: Any = json.load(resp)
         except urllib.error.HTTPError as exc:
             body = exc.read().decode("utf-8", errors="replace")
@@ -274,7 +282,7 @@ class KimiCodeRunner:
         for _ in range(self._max_turns):
             if self._clock() >= deadline:
                 raise AnalyzerError("kimi analyzer exceeded its time budget")
-            message = self._complete(messages, tools)
+            message = self._complete(messages, tools, deadline)
             messages.append(message)
             calls = message.get("tool_calls")
             if not calls:
@@ -294,7 +302,10 @@ class KimiCodeRunner:
         raise AnalyzerError(f"kimi analyzer exceeded {self._max_turns} turns")
 
     def _complete(
-        self, messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        deadline: float,
     ) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "model": self._model,
@@ -306,14 +317,23 @@ class KimiCodeRunner:
             # sequential investigation calls fast enough for the time budget.
             "reasoning_effort": self._reasoning_effort,
         }
-        response = self._transport(
-            f"{self._base_url}/chat/completions",
-            {
-                "Authorization": f"Bearer {self._api_key}",
-                "Content-Type": "application/json",
-            },
-            payload,
-        )
+        url = f"{self._base_url}/chat/completions"
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        remaining = deadline - self._clock()
+        if remaining <= 0:
+            raise AnalyzerError("kimi analyzer exceeded its time budget")
+        if isinstance(self._transport, UrllibTransport):
+            response = self._transport(
+                url,
+                headers,
+                payload,
+                timeout_seconds=remaining,
+            )
+        else:
+            response = self._transport(url, headers, payload)
         try:
             message = cast(list[dict[str, Any]], response["choices"])[0]["message"]
         except (KeyError, IndexError, TypeError) as exc:
@@ -368,7 +388,14 @@ class KimiCodeRunner:
                     str(argument_map.get("path") or ""),
                 )
             if name == "Bash":
-                return _tool_bash(workdir, str(argument_map.get("command") or ""))
+                remaining = deadline - self._clock()
+                if remaining <= 0:
+                    raise AnalyzerError("kimi analyzer exceeded its time budget")
+                return _tool_bash(
+                    workdir,
+                    str(argument_map.get("command") or ""),
+                    timeout_seconds=remaining,
+                )
             if name == "Task":
                 if not allow_task:
                     return "error: nested Task calls are not allowed"
@@ -485,7 +512,12 @@ def _tool_grep(workdir: Path, pattern: str, path: str) -> str:
     return "\n".join(results) if results else "no matches"
 
 
-def _tool_bash(workdir: Path, command: str) -> str:
+def _tool_bash(
+    workdir: Path,
+    command: str,
+    *,
+    timeout_seconds: float = BASH_TIMEOUT_SECONDS,
+) -> str:
     try:
         tokens = shlex.split(command)
     except ValueError as exc:
@@ -498,7 +530,7 @@ def _tool_bash(workdir: Path, command: str) -> str:
             cwd=workdir,
             capture_output=True,
             text=True,
-            timeout=BASH_TIMEOUT_SECONDS,
+            timeout=min(BASH_TIMEOUT_SECONDS, timeout_seconds),
             check=False,
         )
     except subprocess.TimeoutExpired:

--- a/alerting/tests/test_kimi.py
+++ b/alerting/tests/test_kimi.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from alerting.analyzer import AnalyzerError
-from alerting.kimi import KimiCodeRunner
+from alerting.kimi import KimiCodeRunner, UrllibTransport
 
 
 def tool_call(
@@ -51,6 +52,24 @@ class ScriptedTransport:
     ) -> dict[str, Any]:
         self.payloads.append({**payload, "messages": list(payload["messages"])})
         return self._responses.pop(0)
+
+
+class RecordingUrllibTransport(UrllibTransport):
+    def __init__(self, response: dict[str, Any]) -> None:
+        super().__init__()
+        self.response = response
+        self.timeout_seconds: float | None = None
+
+    def __call__(
+        self,
+        url: str,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+        *,
+        timeout_seconds: float | None = None,
+    ) -> dict[str, Any]:
+        self.timeout_seconds = timeout_seconds
+        return self.response
 
 
 def tool_messages(transport: ScriptedTransport) -> list[str]:
@@ -209,3 +228,46 @@ def test_requests_default_to_low_reasoning_effort(tmp_path: Path) -> None:
     KimiCodeRunner(api_key="key", transport=transport).run(tmp_path)
 
     assert transport.payloads[0]["reasoning_effort"] == "low"
+
+
+def test_model_request_timeout_is_clamped_to_remaining_analysis_budget(
+    tmp_path: Path,
+) -> None:
+    ticks = iter((100.0, 100.0, 104.0))
+    transport = RecordingUrllibTransport(final())
+    runner = KimiCodeRunner(
+        api_key="key",
+        transport=transport,
+        timeout_seconds=10,
+        clock=lambda: next(ticks),
+    )
+
+    runner.run(tmp_path)
+
+    assert transport.timeout_seconds == 6.0
+
+
+def test_curl_timeout_is_clamped_to_remaining_analysis_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    observed_timeouts: list[float] = []
+
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        observed_timeouts.append(kwargs["timeout"])
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    ticks = iter((100.0, 100.0, 100.0, 106.0, 106.0, 106.0))
+    transport = ScriptedTransport(
+        [tool_call("Bash", {"command": "curl https://example.test"}), final()]
+    )
+    runner = KimiCodeRunner(
+        api_key="key",
+        transport=transport,
+        timeout_seconds=10,
+        clock=lambda: next(ticks),
+    )
+
+    runner.run(tmp_path)
+
+    assert observed_timeouts == [4.0]

--- a/alerting/tests/test_worker.py
+++ b/alerting/tests/test_worker.py
@@ -141,7 +141,7 @@ def _capture_full_ci_analysis_kwargs(
     return captured
 
 
-def test_main_ci_analysis_defaults_to_max_effort_and_longer_timeout(
+def test_main_ci_analysis_defaults_to_high_effort_and_ten_minute_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _set_analysis_environment(monkeypatch)
@@ -157,8 +157,8 @@ def test_main_ci_analysis_defaults_to_max_effort_and_longer_timeout(
 
     worker._runtime("main-ci-analyze", worker.SystemClock(), DeliveryMode.SHADOW)
 
-    assert captured["kimi_reasoning_effort"] == "max"
-    assert captured["kimi_timeout_seconds"] == 1200
+    assert captured["kimi_reasoning_effort"] == "high"
+    assert captured["kimi_timeout_seconds"] == 600
 
 
 def test_main_ci_analysis_honors_dedicated_env_overrides(

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -117,15 +117,15 @@ def _runtime(
             ),
             kimi_model=os.environ.get("KIMI_MODEL", "moonshotai/Kimi-K3"),
             # Main CI analysis is intentionally independent of the shared
-            # KIMI_REASONING_EFFORT / KIMI_TIMEOUT_SECONDS so it can run
-            # hotter (max reasoning, longer budget) than the Full CI analyzer.
-            # The 10-minute timer cadence and 30-minute execution lease still
-            # fence the larger timeout.
+            # KIMI_REASONING_EFFORT / KIMI_TIMEOUT_SECONDS so its latency and
+            # reasoning budget stay independently bounded.
+            # The per-job budget matches the ten-minute timer cadence; the
+            # 30-minute execution lease still fences retries.
             kimi_timeout_seconds=int(
-                os.environ.get("KIMI_MAIN_CI_TIMEOUT_SECONDS", "1200")
+                os.environ.get("KIMI_MAIN_CI_TIMEOUT_SECONDS", "600")
             ),
             kimi_reasoning_effort=os.environ.get(
-                "KIMI_MAIN_CI_REASONING_EFFORT", "max"
+                "KIMI_MAIN_CI_REASONING_EFFORT", "high"
             ),
             slack=_slack(),
             clock=clock,

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -34,11 +34,12 @@ Two stack parameters tune the Kimi analyzers and are written to
 
 - `KimiReasoningEffort` (default `high`) sets `KIMI_REASONING_EFFORT`, the
   shared effort used by the Full CI analyzer.
-- `KimiMainCIReasoningEffort` (default `max`) sets
+- `KimiMainCIReasoningEffort` (default `high`) sets
   `KIMI_MAIN_CI_REASONING_EFFORT`, used only by the Main CI failure analyzer.
   It is intentionally independent — Main CI does not fall back to
-  `KIMI_REASONING_EFFORT` — so it can run hotter than Full CI, together with
-  its longer default timeout (`KIMI_MAIN_CI_TIMEOUT_SECONDS`, 1200s).
+  `KIMI_REASONING_EFFORT`. Each Main CI analysis has a ten-minute default
+  budget (`KIMI_MAIN_CI_TIMEOUT_SECONDS`, 600s), including any model and curl
+  calls made by the Kimi runner.
 
 ## Deploy
 

--- a/deploy/aws/alerting-worker.yaml
+++ b/deploy/aws/alerting-worker.yaml
@@ -36,8 +36,8 @@ Parameters:
     Type: String
     Description: >-
       Thinking effort for the Main CI failure analyzer; independent of
-      KimiReasoningEffort so Main CI can run hotter than Full CI
-    Default: max
+      KimiReasoningEffort
+    Default: high
     AllowedValues:
       - low
       - high

--- a/deploy/aws/install.sh
+++ b/deploy/aws/install.sh
@@ -10,7 +10,7 @@ checkpoint_bucket=$1
 worker_secret_arn=$2
 github_secret_arn=$3
 kimi_reasoning_effort=${4:-high}
-kimi_main_ci_reasoning_effort=${5:-max}
+kimi_main_ci_reasoning_effort=${5:-high}
 source_root=$(cd "$(dirname "$0")/../.." && pwd)
 
 if ! id alerting >/dev/null 2>&1; then

--- a/deploy/aws/tests/test_alerting_worker_infrastructure.py
+++ b/deploy/aws/tests/test_alerting_worker_infrastructure.py
@@ -172,6 +172,9 @@ def test_main_ci_kimi_effort_is_an_independent_deploy_knob() -> None:
     assert "Ref: KimiMainCIReasoningEffort" in template
     assert "KIMI_MAIN_CI_REASONING_EFFORT" in installer
     assert installer.count("KIMI_MAIN_CI_REASONING_EFFORT") == 2
+    assert "kimi_main_ci_reasoning_effort=${5:-high}" in installer
+    main_ci_parameter = template.split("KimiMainCIReasoningEffort:", 1)[1]
+    assert "Default: high" in main_ci_parameter.split("Resources:", 1)[0]
 
 
 def test_s3_control_reconciles_each_path_without_cloudwatch_or_sqs() -> None:


### PR DESCRIPTION
## Summary
- lower Main CI analysis reasoning from `max` to `high`
- reduce the default per-analysis budget from 20 minutes to 10 minutes
- clamp model HTTP and analyzer curl calls to the remaining budget so a blocking call cannot overrun the deadline
- update AWS deployment defaults and documentation

## Validation
- `python -m pytest alerting/tests deploy/aws/tests migrations/tests` (210 passed)
- `ruff check` on changed Python files
- `mypy --follow-imports=skip kimi.py worker.py`
- `git diff --check origin/main...HEAD`

## Deployment note
The existing worker instance must be replaced after merge because CloudFormation user data only runs on first boot; updating the parameter alone does not rewrite `/etc/alerting/worker.env`.