### PR TITLE
feat(alerts): require operator token for Main CI alert resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Open http://localhost:3000.
 | `BUILDKITE_API_TOKEN` | Buildkite personal API token; needs `read_suites` for Test Engine, GraphQL API access and `write_builds` for queue promotion, and notification-service scopes only when running the OTel setup script |
 | `BUILDKITE_ORGANIZATION`, `BUILDKITE_TEST_SUITE` | Test Engine organization and suite slug (defaults: `vllm`, `ci-1`) |
 | `BUILDKITE_QUEUE_OPERATOR_TOKEN` | Required to enable queue-job promotion; authorized operators enter it for the current browser tab |
+| `ALERT_OPERATOR_TOKEN` | Required to enable manual Main CI alert resolution; authorized operators enter it for the current browser tab, which sends it as a Bearer token |
 | `OTEL_INGEST_TOKEN` | Shared Bearer token used by Buildkite's OTel notification service |
 | `OTEL_MAX_REQUEST_BYTES` | Optional OTLP request limit; defaults to 4 MiB |
 | `OTEL_ENDPOINT` | Buildkite notification-service base URL; defaults operationally to `https://ci.vllm.ai/api/otel` |

--- a/src/app/alerts/alerts-content.tsx
+++ b/src/app/alerts/alerts-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, type ReactNode } from "react";
+import { useMemo, useState, useSyncExternalStore, type ReactNode } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { FastCIAlerts } from "@/components/fast-ci-alerts";
@@ -117,6 +117,7 @@ interface FastCIAlertsResponse {
 interface MainCIAlertsResponse {
   alerts?: MainCiJobAlert[];
   schemaStatus?: "ready" | "pending";
+  resolutionEnabled?: boolean;
   error?: string;
 }
 
@@ -199,6 +200,45 @@ function AlertSection({
   return <>{children}</>;
 }
 
+/**
+ * The operator token for manual alert resolution lives only in this tab's
+ * sessionStorage — never in the URL — and is sent as a Bearer header. It is
+ * exposed through useSyncExternalStore so the server render always shows the
+ * locked state and the stored token is picked up on the client.
+ */
+const ALERT_OPERATOR_TOKEN_KEY = "alert-operator-token";
+
+let cachedOperatorToken: string | null = null;
+const operatorTokenListeners = new Set<() => void>();
+
+function readOperatorToken(): string {
+  if (cachedOperatorToken === null) {
+    cachedOperatorToken = sessionStorage.getItem(ALERT_OPERATOR_TOKEN_KEY) ?? "";
+  }
+  return cachedOperatorToken;
+}
+
+function subscribeOperatorToken(onChange: () => void): () => void {
+  operatorTokenListeners.add(onChange);
+  return () => {
+    operatorTokenListeners.delete(onChange);
+  };
+}
+
+function saveOperatorToken(value: string) {
+  cachedOperatorToken = value;
+  if (value) {
+    sessionStorage.setItem(ALERT_OPERATOR_TOKEN_KEY, value);
+  } else {
+    sessionStorage.removeItem(ALERT_OPERATOR_TOKEN_KEY);
+  }
+  for (const listener of operatorTokenListeners) listener();
+}
+
+function useAlertOperatorToken(): string {
+  return useSyncExternalStore(subscribeOperatorToken, readOperatorToken, () => "");
+}
+
 function MainCISection({
   timeWindow,
   options,
@@ -211,6 +251,8 @@ function MainCISection({
     fetcher,
     { refreshInterval: 5 * 60 * 1000 },
   );
+  const operatorToken = useAlertOperatorToken();
+  const [showAccess, setShowAccess] = useState(false);
 
   const alerts = useMemo(
     () =>
@@ -224,10 +266,15 @@ function MainCISection({
   const resolveAlert = async (alertId: string) => {
     const response = await fetch("/api/alerts/main-ci/resolve", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${operatorToken}`,
+      },
       body: JSON.stringify({ alertId: Number(alertId) }),
     });
     if (!response.ok) {
+      // A rejected token is dropped so the Resolve buttons lock again.
+      if (response.status === 401) saveOperatorToken("");
       throw new Error(`Resolve failed with ${response.status}`);
     }
     await mutate();
@@ -245,13 +292,41 @@ function MainCISection({
           must be deployed before this preview can show alerts.
         </div>
       ) : (
-        <MainCIAlerts
-          alerts={alerts}
-          onResolve={resolveAlert}
-          hideSoftFail={options.hide.has("softfail")}
-          hideOptional={options.hide.has("optional")}
-          hideAmd={options.hide.has("amd")}
-        />
+        <div className="space-y-3">
+          {data?.resolutionEnabled && (
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowAccess((open) => !open)}
+                aria-expanded={showAccess}
+                className="dashboard-control text-xs font-medium text-zinc-600 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-zinc-100"
+              >
+                {operatorToken
+                  ? "Operator access enabled for this tab"
+                  : "Unlock resolve actions"}
+              </button>
+              {showAccess && (
+                <label className="mt-2 flex max-w-md flex-col gap-1.5 text-xs text-zinc-500 dark:text-zinc-400 sm:flex-row sm:items-center">
+                  <span className="shrink-0">Operator token</span>
+                  <input
+                    type="password"
+                    value={operatorToken}
+                    onChange={(event) => saveOperatorToken(event.target.value)}
+                    autoComplete="off"
+                    className="min-h-10 min-w-0 flex-1 rounded-md border border-zinc-200 bg-zinc-50 px-3 text-sm text-zinc-900 shadow-sm outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-500/15 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+                  />
+                </label>
+              )}
+            </div>
+          )}
+          <MainCIAlerts
+            alerts={alerts}
+            onResolve={operatorToken ? resolveAlert : undefined}
+            hideSoftFail={options.hide.has("softfail")}
+            hideOptional={options.hide.has("optional")}
+            hideAmd={options.hide.has("amd")}
+          />
+        </div>
       )}
     </AlertSection>
   );

--- a/src/app/api/alerts/main-ci/resolve/route.ts
+++ b/src/app/api/alerts/main-ci/resolve/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { bearerTokenMatches } from "@/lib/operator-auth";
 import { hasPostgresErrorCode } from "@/lib/postgres-errors";
 
 export const dynamic = "force-dynamic";
@@ -9,8 +10,26 @@ export const dynamic = "force-dynamic";
  * alerting_main_ci_job_alerts requires resolution job fields on every resolved
  * row, so a manual close points them at the alert's own last failure and sets
  * resolution_kind = 'manual' to record that no passing job was observed.
+ *
+ * The dashboard is public, so this mutating endpoint requires the
+ * ALERT_OPERATOR_TOKEN bearer credential: 503 when it is not configured, 401
+ * when the supplied token is missing or wrong.
  */
 export async function POST(request: Request) {
+  const operatorToken = process.env.ALERT_OPERATOR_TOKEN;
+  if (!operatorToken) {
+    return NextResponse.json(
+      { error: "Manual alert resolution is not configured on this dashboard." },
+      { status: 503, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+  if (!bearerTokenMatches(request.headers.get("authorization"), operatorToken)) {
+    return NextResponse.json(
+      { error: "Resolving an alert requires the configured operator token." },
+      { status: 401, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
   let body: unknown;
   try {
     body = await request.json();

--- a/src/app/api/alerts/main-ci/route.ts
+++ b/src/app/api/alerts/main-ci/route.ts
@@ -44,7 +44,11 @@ export async function GET() {
       LIMIT ${MAX_ALERTS}
     `;
     return NextResponse.json(
-      { alerts: rows.map(toMainCiJobAlert), schemaStatus: "ready" },
+      {
+        alerts: rows.map(toMainCiJobAlert),
+        schemaStatus: "ready",
+        resolutionEnabled: Boolean(process.env.ALERT_OPERATOR_TOKEN),
+      },
       { headers: { "Cache-Control": "no-store" } },
     );
   } catch (error) {

--- a/src/lib/operator-auth.test.ts
+++ b/src/lib/operator-auth.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { bearerTokenMatches } from "./operator-auth";
+
+test("accepts the configured bearer token", () => {
+  assert.equal(bearerTokenMatches("Bearer secret-token", "secret-token"), true);
+});
+
+test("rejects a wrong token", () => {
+  assert.equal(bearerTokenMatches("Bearer other-token", "secret-token"), false);
+});
+
+test("rejects a token of a different length", () => {
+  assert.equal(bearerTokenMatches("Bearer secret", "secret-token"), false);
+  assert.equal(
+    bearerTokenMatches("Bearer secret-token-extra", "secret-token"),
+    false,
+  );
+});
+
+test("rejects a missing or malformed Authorization header", () => {
+  assert.equal(bearerTokenMatches(null, "secret-token"), false);
+  assert.equal(bearerTokenMatches("", "secret-token"), false);
+  assert.equal(bearerTokenMatches("secret-token", "secret-token"), false);
+  assert.equal(bearerTokenMatches("Basic c2VjcmV0", "secret-token"), false);
+  assert.equal(bearerTokenMatches("Bearer ", "secret-token"), false);
+});
+
+test("rejects everything when no token is configured", () => {
+  assert.equal(bearerTokenMatches("Bearer secret-token", undefined), false);
+  assert.equal(bearerTokenMatches("Bearer ", ""), false);
+});

--- a/src/lib/operator-auth.ts
+++ b/src/lib/operator-auth.ts
@@ -1,0 +1,19 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Constant-time check of an `Authorization: Bearer <token>` header against the
+ * operator token configured for a mutating endpoint. Returns false when no
+ * token is configured; callers that need to distinguish "not configured" (503)
+ * from "wrong token" (401) check `process.env` themselves first.
+ */
+export function bearerTokenMatches(
+  authorization: string | null,
+  expectedToken: string | undefined,
+): boolean {
+  if (!expectedToken || !authorization?.startsWith("Bearer ")) return false;
+  const expected = Buffer.from(expectedToken);
+  const received = Buffer.from(authorization.slice("Bearer ".length));
+  return (
+    expected.length === received.length && timingSafeEqual(expected, received)
+  );
+}


### PR DESCRIPTION
## What / why

`POST /api/alerts/main-ci/resolve` accepted `{alertId}` with no authentication and marked the alert resolved in Postgres. The dashboard is public, so anyone could close Main CI alerts, and the Resolve button rendered for every visitor.

This PR authenticates the endpoint with the same operator-token pattern as queue-job promotion, but under a separate env var since resolving alerts is a different scope than reprioritizing queue jobs:

- **Route** (`src/app/api/alerts/main-ci/resolve/route.ts`): requires `Authorization: Bearer $ALERT_OPERATOR_TOKEN`. Returns **503** when no token is configured and **401** on a missing or invalid token. Comparison is constant-time via the new `bearerTokenMatches` helper (`src/lib/operator-auth.ts`), modeled on the existing OTel shared-token check.
- **GET route** (`src/app/api/alerts/main-ci/route.ts`): now reports `resolutionEnabled` so the client only offers the unlock control when the dashboard is configured for manual resolution.
- **Client** (`src/app/alerts/alerts-content.tsx`): mirrors the queue page UX — an "Unlock resolve actions" toggle with a password input. The token lives in `sessionStorage` for the current tab only (exposed via `useSyncExternalStore` so SSR always renders the locked state), never the URL, and is sent as the Bearer header from `resolveAlert`. Resolve buttons only render once a token is entered (`onResolve` is passed conditionally; `main-ci-alerts.tsx` already hid the button without it, so that component is untouched). A 401 clears the stored token so the buttons lock again.
- **README**: documents the new `ALERT_OPERATOR_TOKEN` env var.

## Verification

- `npm run lint` — clean
- `npm test` (tsx --test) — 65/65 pass, including 5 new tests for `bearerTokenMatches` (match, wrong token, length mismatch, missing/malformed header, unconfigured token) in `src/lib/operator-auth.test.ts`
- `npx tsc --noEmit` — clean

## Deployment note

Set `ALERT_OPERATOR_TOKEN` in the Vercel environment to enable manual alert resolution; without it the endpoint returns 503 and the UI hides the unlock control.