### PR TITLE
feat: render Buildkite emoji shortcodes as icons in all job names

### DIFF
--- a/src/app/cost/page.tsx
+++ b/src/app/cost/page.tsx
@@ -15,6 +15,7 @@ import {
 import { StatCard } from "@/components/stat-card";
 import { SearchableSelect } from "@/components/searchable-select";
 import { DateRangePicker } from "@/components/date-range-picker";
+import { JobName, jobNameText } from "@/components/job-name";
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
@@ -640,8 +641,8 @@ export default function CostPage() {
                   return (
                     <tr key={j.job_name} className="border-b border-zinc-100 last:border-0 dark:border-zinc-800/50">
                       <td className="px-5 py-2.5 text-zinc-400">{i + 1}</td>
-                      <td className="max-w-[24rem] truncate px-5 py-2.5 font-medium" title={j.job_name}>
-                        {j.job_name}
+                      <td className="max-w-[24rem] truncate px-5 py-2.5 font-medium" title={jobNameText(j.job_name)}>
+                        <JobName name={j.job_name} />
                       </td>
                       <td className="px-5 py-2.5 text-right tabular-nums text-zinc-500">
                         {j.total_runs.toLocaleString()}

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -6,6 +6,7 @@ import { StatCard } from "@/components/stat-card";
 import { SearchableSelect } from "@/components/searchable-select";
 import { DateRangePicker } from "@/components/date-range-picker";
 import { isOptionalJob, isSoftFailJob } from "@/lib/optional-jobs";
+import { JobName, jobNameText } from "@/components/job-name";
 import { JobRunsChart, JobRun } from "@/components/job-runs-chart";
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
@@ -170,7 +171,7 @@ function JobAnalysisTab({
     .filter((row) => {
       if (hideSoftFail && (isSoftFailJob(row.name) || row.has_soft_fail === "1")) return false;
       if (hideOptional && isOptionalJob(row.name)) return false;
-      if (searchQuery && !row.name.toLowerCase().includes(searchQuery.toLowerCase())) return false;
+      if (searchQuery && !jobNameText(row.name).toLowerCase().includes(searchQuery.toLowerCase())) return false;
       return true;
     })
     .sort((a, b) => {
@@ -182,7 +183,7 @@ function JobAnalysisTab({
   const filteredDuration = durationStats
     .filter((row) => {
       if (hideOptional && isOptionalJob(row.name)) return false;
-      if (searchQuery && !row.name.toLowerCase().includes(searchQuery.toLowerCase())) return false;
+      if (searchQuery && !jobNameText(row.name).toLowerCase().includes(searchQuery.toLowerCase())) return false;
       return true;
     })
     .sort((a, b) => {
@@ -269,13 +270,13 @@ function JobAnalysisTab({
         <StatCard
           label="Highest Failure Rate"
           value={worstJob ? `${worstJob.failure_rate}%` : "—"}
-          detail={worstJob?.name}
+          detail={worstJob ? jobNameText(worstJob.name) : undefined}
           color="red"
         />
         <StatCard
           label="Slowest Job (p50)"
           value={slowestJob ? formatDuration(parseInt(slowestJob.p50_duration, 10)) : "—"}
-          detail={slowestJob?.name}
+          detail={slowestJob ? jobNameText(slowestJob.name) : undefined}
         />
         <StatCard
           label="Total Jobs Tracked"
@@ -366,7 +367,7 @@ function JobAnalysisTab({
                     >
                       <td className="px-5 py-2.5 text-zinc-400">{page * pageSize + i + 1}</td>
                       <td className="px-5 py-2.5 font-medium">
-                        {row.name}
+                        <JobName name={row.name} />
                         <JobBadges name={row.name} hasSoftFail={row.has_soft_fail === "1"} />
                       </td>
                       <td className="px-5 py-2.5">
@@ -432,7 +433,7 @@ function JobAnalysisTab({
                     >
                       <td className="px-5 py-2.5 text-zinc-400">{page * pageSize + i + 1}</td>
                       <td className="px-5 py-2.5 font-medium">
-                        {row.name}
+                        <JobName name={row.name} />
                         <JobBadges name={row.name} hasSoftFail={false} />
                       </td>
                       <td className="px-5 py-2.5">

--- a/src/components/build-waterfall.tsx
+++ b/src/components/build-waterfall.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import useSWR from "swr";
+import { JobName, jobNameText } from "@/components/job-name";
 
 type LaneKind = "job" | "step" | "command" | "test";
 
@@ -462,7 +463,7 @@ export function BuildWaterfall({
                 detailErrors.has(lane.jobId),
               );
               const depth = laneDepth(lane);
-              const detail = `${lane.label} · ${formatTime(lane.startTime)}–${formatTime(lane.endTime)} · ${formatDuration(lane.durationMs)}${lane.outcome ? ` · ${lane.outcome}` : ""}`;
+              const detail = `${jobNameText(lane.label)} · ${formatTime(lane.startTime)}–${formatTime(lane.endTime)} · ${formatDuration(lane.durationMs)}${lane.outcome ? ` · ${lane.outcome}` : ""}`;
               const rowTone = depth === 0 ? "" : depth === 1 ? "bg-cyan-50/35 dark:bg-cyan-950/10" : "bg-emerald-50/30 dark:bg-emerald-950/10";
 
               return (
@@ -471,12 +472,12 @@ export function BuildWaterfall({
                     {depth > 0 && <span aria-hidden="true" className={`absolute inset-y-0 w-px ${depth === 1 ? "left-2 bg-cyan-200 dark:bg-cyan-900" : "left-6 bg-emerald-200 dark:bg-emerald-900"}`} />}
                     <div className="flex items-center gap-1.5">
                       {isExpandable ? (
-                        <button type="button" onClick={() => toggleExpanded(lane)} aria-expanded={expanded.has(lane.id)} aria-label={`${expanded.has(lane.id) ? "Collapse" : "Expand"} ${lane.label}`} className="dashboard-control flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-500 hover:bg-zinc-200/70 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-100">
+                        <button type="button" onClick={() => toggleExpanded(lane)} aria-expanded={expanded.has(lane.id)} aria-label={`${expanded.has(lane.id) ? "Collapse" : "Expand"} ${jobNameText(lane.label)}`} className="dashboard-control flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-500 hover:bg-zinc-200/70 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-100">
                           <span aria-hidden="true" className={`transition-transform ${expanded.has(lane.id) ? "rotate-90" : ""}`}>›</span>
                         </button>
                       ) : <span className="w-6 shrink-0" />}
                       {lane.critical && <span aria-label="Inferred build-limiting job" className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" />}
-                      <span className={`truncate text-xs text-zinc-800 dark:text-zinc-200 ${depth === 0 ? "font-medium" : "font-mono text-[11px]"}`} title={lane.label}>{lane.label}</span>
+                      <span className={`truncate text-xs text-zinc-800 dark:text-zinc-200 ${depth === 0 ? "font-medium" : "font-mono text-[11px]"}`} title={jobNameText(lane.label)}><JobName name={lane.label} /></span>
                       {isExpandable && <span className="shrink-0 rounded bg-zinc-200/70 px-1.5 py-0.5 font-mono text-[9px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">{displayedChildCount}</span>}
                       {isLoadingDetails && <span className="shrink-0 text-[9px] text-cyan-600 dark:text-cyan-400">loading tests…</span>}
                       {hasDetailError && <span className="shrink-0 text-[9px] text-red-600 dark:text-red-400">test trace load failed; select again to retry</span>}

--- a/src/components/builds-table.tsx
+++ b/src/components/builds-table.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useState, useCallback, useMemo, type MouseEvent, type ReactNode } from "react";
 import useSWR from "swr";
 import { BuildWaterfall } from "@/components/build-waterfall";
+import { JobName, jobNameText } from "@/components/job-name";
 import type { GroupStatus } from "@/lib/test-groups";
 import { isOptionalJob, isSoftFailJob } from "@/lib/optional-jobs";
 
@@ -650,7 +651,7 @@ export function BuildsTable({
                               {failedJobLinks.length > 0 && (
                                 <ul className="mt-1 text-red-600 dark:text-red-400">
                                   {failedJobLinks.slice(0, 5).map((job) => (
-                                    <li key={job.name}>✕ {job.name}</li>
+                                    <li key={job.name}>✕ <JobName name={job.name} /></li>
                                   ))}
                                   {failedJobLinks.length > 5 && (
                                     <li className="text-zinc-500 dark:text-zinc-400">
@@ -697,10 +698,10 @@ export function BuildsTable({
                       <DotWithTooltip
                         key={key}
                         color={dotColor(job.state)}
-                        ariaLabel={`${job.name}: ${job.state}`}
+                        ariaLabel={`${jobNameText(job.name)}: ${job.state}`}
                         tooltip={
                           <>
-                            <p className="font-medium">{job.name}</p>
+                            <p className="font-medium"><JobName name={job.name} /></p>
                             <p className="text-zinc-500 dark:text-zinc-400">{col.group}</p>
                             <p className={`capitalize ${stateTextColor(job.state)}`}>
                               {job.state.replace(/_/g, " ")}

--- a/src/components/job-name.test.ts
+++ b/src/components/job-name.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { splitJobName } from "./job-name";
+import { jobNameText, splitJobName } from "./job-name";
 
 test("a known vendor shortcode becomes an icon segment", () => {
   const segments = splitJobName(":nvidia: (H200) Language Models Shard 3");
@@ -33,4 +33,23 @@ test("an unknown shortcode is stripped, not shown literally", () => {
 
 test("a name without shortcodes passes through unchanged", () => {
   assert.deepEqual(splitJobName("lint"), [{ type: "text", text: "lint" }]);
+});
+
+test("jobNameText strips a leading shortcode and its following space", () => {
+  assert.equal(
+    jobNameText(":nvidia: (H200) Language Models Shard 3"),
+    "(H200) Language Models Shard 3",
+  );
+});
+
+test("jobNameText strips shortcodes in the middle without joining words", () => {
+  assert.equal(jobNameText("unit test :amd: shard 1"), "unit test shard 1");
+});
+
+test("jobNameText strips unknown shortcodes too", () => {
+  assert.equal(jobNameText(":tensorrt: engine build"), "engine build");
+});
+
+test("jobNameText leaves shortcode-free names unchanged", () => {
+  assert.equal(jobNameText("lint"), "lint");
 });

--- a/src/components/job-name.tsx
+++ b/src/components/job-name.tsx
@@ -56,6 +56,18 @@ export function splitJobName(name: string): JobNameSegment[] {
   return segments;
 }
 
+/**
+ * Plain-text form of a job name with all emoji shortcodes removed, for
+ * contexts that cannot render icons: title attributes, stat card details,
+ * search and sort keys.
+ */
+export function jobNameText(name: string): string {
+  return splitJobName(name)
+    .flatMap((segment) => (segment.type === "text" ? [segment.text] : []))
+    .join("")
+    .trim();
+}
+
 export function JobName({ name }: { name: string }) {
   const nodes: ReactNode[] = splitJobName(name).map((segment, index) =>
     segment.type === "text" ? (

--- a/src/components/main-ci-alerts.tsx
+++ b/src/components/main-ci-alerts.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from "react";
-import { JobName, splitJobName } from "@/components/job-name";
+import { JobName, jobNameText } from "@/components/job-name";
 import { SegmentedControl } from "@/components/segmented-control";
 import {
   isAmdJobName,
@@ -117,20 +117,9 @@ function sortColumn(key: SortKey) {
   return SORT_COLUMNS.find((column) => column.key === key) ?? SORT_COLUMNS[0];
 }
 
-/**
- * Buildkite job names lead with vendor shortcodes (":nvidia: (B200) …") that
- * the list never shows, so sorting must use the text a reader actually sees.
- */
-function displayJobName(jobName: string): string {
-  return splitJobName(jobName)
-    .flatMap((segment) => (segment.type === "text" ? [segment.text] : []))
-    .join("")
-    .trim();
-}
-
 function compareJobNames(a: MainCiJobAlert, b: MainCiJobAlert): number {
-  return displayJobName(a.jobName).localeCompare(
-    displayJobName(b.jobName),
+  return jobNameText(a.jobName).localeCompare(
+    jobNameText(b.jobName),
     undefined,
     { sensitivity: "base", numeric: true },
   );

--- a/src/components/queue-waiting-jobs.tsx
+++ b/src/components/queue-waiting-jobs.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import useSWR from "swr";
+import { JobName, jobNameText } from "@/components/job-name";
 
 export interface QueueJob {
   uuid: string;
@@ -71,7 +72,7 @@ export function QueueWaitingJobs({
       return;
     }
 
-    const name = job.label || "this job";
+    const name = job.label ? jobNameText(job.label) : "this job";
     if (!window.confirm(`Move ${name} to the front of ${queue}? Its priority will be calculated from the current queue.`)) {
       return;
     }
@@ -93,7 +94,7 @@ export function QueueWaitingJobs({
         throw new Error(body.error ?? "This job could not be promoted.");
       }
 
-      setNotice(`${job.label || "Job"} moved to the front at priority ${body.priority}.`);
+      setNotice(`${job.label ? jobNameText(job.label) : "Job"} moved to the front at priority ${body.priority}.`);
       await mutate();
     } catch (promotionError) {
       setNotice(promotionError instanceof Error ? promotionError.message : "This job could not be promoted.");
@@ -244,9 +245,9 @@ export function QueueWaitingJobs({
                         target="_blank"
                         rel="noopener noreferrer"
                         className="block truncate font-medium text-blue-700 hover:underline dark:text-blue-400"
-                        title={job.label || job.uuid}
+                        title={job.label ? jobNameText(job.label) : job.uuid}
                       >
-                        {job.label || "Unnamed command job"}
+                        {job.label ? <JobName name={job.label} /> : "Unnamed command job"}
                       </a>
                       <span className="mt-0.5 block font-mono text-[11px] text-zinc-400 dark:text-zinc-500">
                         {job.uuid}


### PR DESCRIPTION
## What

Job names contain Buildkite emoji shortcodes (`:nvidia:`, `:amd:`, `:docker:`, `:database:`, `:computer:`, `:github:`) that printed as raw text on most pages. `JobName` (`src/components/job-name.tsx`) already rendered them as brand icons on the Alerts pages; this swaps the remaining raw renderings over to it.

- `src/app/jobs/page.tsx` — both ranking tables now render `<JobName>`; the Highest Failure Rate / Slowest Job stat card details and the job search use the new plain-text helper, so searching matches the name a reader actually sees (no shortcode text).
- `src/app/cost/page.tsx` — Cost by Job table renders `<JobName>`; the truncated cell's `title` uses the stripped text.
- `src/components/build-waterfall.tsx` — timeline row labels render `<JobName>`; `title`/`aria-label` and the bar `detail` strings use the stripped text.
- `src/components/builds-table.tsx` — failed-job tooltip lists and the expanded-job tooltip render `<JobName>`; the dot's `aria-label` uses the stripped text.
- `src/components/queue-waiting-jobs.tsx` — waiting-job labels render `<JobName>`; `title`, confirm dialog, and notice strings use the stripped text.
- `src/components/job-name.tsx` — new exported `jobNameText()` helper (shortcode-free plain text), replacing the local `displayJobName()` copy in `main-ci-alerts.tsx`.

No layout, color, or spacing changes.

## How verified

- `npm run lint` — clean
- `npm test` — 64/64 pass, including 4 new `jobNameText` tests (leading/middle/unknown shortcodes, plain names)
- `npx tsc --noEmit` — clean