### PR TITLE
feat(alerts): collapse repeated jobs in Fast failures view

### DIFF
--- a/src/components/fast-ci-alerts.test.ts
+++ b/src/components/fast-ci-alerts.test.ts
@@ -93,3 +93,72 @@ test("an empty window with soft failures hidden says they are hidden", () => {
 
   assert.match(markup, /soft failures are hidden/);
 });
+
+const ROW_CLASS = "flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2";
+
+test("repeated runs of one job collapse into a single row with a count badge", () => {
+  const markup = render([
+    event({ buildkiteJobId: "job-1" }),
+    event({
+      buildkiteJobId: "job-2",
+      jobUrl: "https://buildkite.com/vllm/ci/builds/9001#job-2",
+      finishedAt: "2026-08-27T10:05:00.000Z",
+    }),
+  ]);
+
+  assert.match(markup, /×2/);
+  assert.match(markup, /<details/);
+  // Both attempts stay reachable behind the disclosure.
+  assert.match(markup, /#job-1/);
+  assert.match(markup, /#job-2/);
+  assert.equal(markup.split(ROW_CLASS).length - 1, 2);
+});
+
+test("a job that failed once renders as a plain row with no disclosure", () => {
+  const markup = render([event()]);
+
+  assert.doesNotMatch(markup, /<details/);
+  assert.doesNotMatch(markup, /×\d/);
+  assert.equal(markup.split(ROW_CLASS).length - 1, 1);
+});
+
+test("a collapsed row shows the worst Slack state across its attempts", () => {
+  const markup = render([
+    event({ buildkiteJobId: "job-1", notificationStatuses: ["delivered"] }),
+    event({
+      buildkiteJobId: "job-2",
+      notificationStatuses: ["dead_letter"],
+      finishedAt: "2026-08-27T10:05:00.000Z",
+    }),
+  ]);
+
+  assert.match(markup, /Slack dead-lettered/);
+});
+
+test("builds with more than ten job groups collapse the rest behind a toggle", () => {
+  const events = Array.from({ length: 12 }, (_, i) =>
+    event({
+      buildkiteJobId: `job-${i}`,
+      jobName: `Job ${String(i).padStart(2, "0")}`,
+      finishedAt: `2026-08-27T10:${String(i).padStart(2, "0")}:00.000Z`,
+    }),
+  );
+  const markup = render(events);
+
+  assert.match(markup, /Show all 12 jobs/);
+  // Only the ten newest job groups render before the toggle.
+  assert.equal(markup.split(ROW_CLASS).length - 1, 10);
+  assert.match(markup, /Job 11/);
+  assert.doesNotMatch(markup, /Job 00/);
+  assert.doesNotMatch(markup, /Job 01/);
+});
+
+test("builds with ten or fewer job groups render every row", () => {
+  const events = Array.from({ length: 10 }, (_, i) =>
+    event({ buildkiteJobId: `job-${i}`, jobName: `Job ${i}` }),
+  );
+  const markup = render(events);
+
+  assert.doesNotMatch(markup, /Show all/);
+  assert.equal(markup.split(ROW_CLASS).length - 1, 10);
+});

--- a/src/components/fast-ci-alerts.tsx
+++ b/src/components/fast-ci-alerts.tsx
@@ -2,15 +2,118 @@ import { useState } from "react";
 import { NotificationBadge } from "@/components/alert-notification-badge";
 import { AlertPagination } from "@/components/alert-pagination";
 import { JobName } from "@/components/job-name";
-import { type FastFailureGroup } from "@/lib/alerts-fast-ci";
+import {
+  type FastFailureEventView,
+  type FastFailureGroup,
+  type FastFailureJobGroup,
+} from "@/lib/alerts-fast-ci";
 import {
   commitUrl,
   formatAlertDateTime,
   pullRequestUrl,
 } from "@/lib/alerts-shared";
 
+function EventRow({ event }: { event: FastFailureEventView }) {
+  return (
+    <li className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2 text-sm sm:px-5">
+      <a
+        href={event.jobUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="min-w-0 truncate text-blue-600 hover:underline dark:text-blue-400"
+      >
+        <JobName name={event.jobName} />
+      </a>
+      <span className="shrink-0 text-xs font-medium text-red-600 dark:text-red-400">
+        {event.state}
+      </span>
+      {event.softFailed && (
+        <span className="shrink-0 text-xs text-zinc-500 dark:text-zinc-400">
+          soft failed
+        </span>
+      )}
+      <span className="shrink-0 text-xs tabular-nums text-zinc-500 dark:text-zinc-400">
+        {event.durationSeconds}s
+      </span>
+      <span className="ml-auto flex shrink-0 items-center gap-3">
+        <span className="text-xs text-zinc-500 dark:text-zinc-400">
+          {formatAlertDateTime(event.finishedAt)}
+        </span>
+        <NotificationBadge state={event.notificationState} />
+      </span>
+    </li>
+  );
+}
+
+/**
+ * One row per job. A job that failed repeatedly shows the latest attempt with
+ * a "×N" badge and the worst Slack state across attempts; the individual
+ * attempts stay available behind a disclosure.
+ */
+function JobGroupRow({ jobGroup }: { jobGroup: FastFailureJobGroup }) {
+  const latest = jobGroup.events[0];
+
+  if (jobGroup.count === 1) {
+    return <EventRow event={latest} />;
+  }
+
+  return (
+    <li>
+      <details className="group/details">
+        <summary className="flex cursor-pointer list-none flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2 text-sm sm:px-5 [&::-webkit-details-marker]:hidden">
+          <span
+            aria-hidden="true"
+            className="shrink-0 text-xs text-zinc-400 transition-transform group-open/details:rotate-90 dark:text-zinc-500"
+          >
+            ›
+          </span>
+          <a
+            href={latest.jobUrl}
+            target="_blank"
+            rel="noreferrer"
+            onClick={(event) => event.stopPropagation()}
+            className="min-w-0 truncate text-blue-600 hover:underline dark:text-blue-400"
+          >
+            <JobName name={jobGroup.jobName} />
+          </a>
+          <span className="shrink-0 rounded-full bg-zinc-100 px-1.5 text-xs font-medium tabular-nums text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+            ×{jobGroup.count}
+          </span>
+          <span className="shrink-0 text-xs font-medium text-red-600 dark:text-red-400">
+            {latest.state}
+          </span>
+          {latest.softFailed && (
+            <span className="shrink-0 text-xs text-zinc-500 dark:text-zinc-400">
+              soft failed
+            </span>
+          )}
+          <span className="ml-auto flex shrink-0 items-center gap-3">
+            <span className="text-xs text-zinc-500 dark:text-zinc-400">
+              {formatAlertDateTime(jobGroup.lastFinishedAt)}
+            </span>
+            <NotificationBadge state={jobGroup.notificationState} />
+          </span>
+        </summary>
+        <ul className="divide-y divide-zinc-100 border-t border-zinc-100 dark:divide-zinc-800/60 dark:border-zinc-800/60">
+          {jobGroup.events.map((event) => (
+            <EventRow key={event.buildkiteJobId} event={event} />
+          ))}
+        </ul>
+      </details>
+    </li>
+  );
+}
+
+/** Past this many distinct jobs, the rest of a build stays collapsed. */
+const VISIBLE_JOB_GROUPS = 10;
+
 function GroupCard({ group }: { group: FastFailureGroup }) {
   const prUrl = pullRequestUrl(group.prNumber);
+  const [showAllJobs, setShowAllJobs] = useState(false);
+
+  const jobGroups = showAllJobs
+    ? group.jobGroups
+    : group.jobGroups.slice(0, VISIBLE_JOB_GROUPS);
 
   return (
     <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
@@ -54,39 +157,23 @@ function GroupCard({ group }: { group: FastFailureGroup }) {
         </p>
       </div>
       <ul className="divide-y divide-zinc-100 dark:divide-zinc-800/60">
-        {group.events.map((event) => (
-          <li
-            key={event.buildkiteJobId}
-            className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2 text-sm sm:px-5"
-          >
-            <a
-              href={event.jobUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="min-w-0 truncate text-blue-600 hover:underline dark:text-blue-400"
-            >
-              <JobName name={event.jobName} />
-            </a>
-            <span className="shrink-0 text-xs font-medium text-red-600 dark:text-red-400">
-              {event.state}
-            </span>
-            {event.softFailed && (
-              <span className="shrink-0 text-xs text-zinc-500 dark:text-zinc-400">
-                soft failed
-              </span>
-            )}
-            <span className="shrink-0 text-xs tabular-nums text-zinc-500 dark:text-zinc-400">
-              {event.durationSeconds}s
-            </span>
-            <span className="ml-auto flex shrink-0 items-center gap-3">
-              <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                {formatAlertDateTime(event.finishedAt)}
-              </span>
-              <NotificationBadge state={event.notificationState} />
-            </span>
-          </li>
+        {jobGroups.map((jobGroup) => (
+          <JobGroupRow key={jobGroup.key} jobGroup={jobGroup} />
         ))}
       </ul>
+      {group.jobGroups.length > VISIBLE_JOB_GROUPS && (
+        <div className="border-t border-zinc-100 px-4 py-2 sm:px-5 dark:border-zinc-800/60">
+          <button
+            type="button"
+            onClick={() => setShowAllJobs((value) => !value)}
+            className="text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
+          >
+            {showAllJobs
+              ? "Show fewer jobs"
+              : `Show all ${group.jobGroups.length} jobs`}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/alerts-fast-ci.test.ts
+++ b/src/lib/alerts-fast-ci.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   groupFastFailureEvents,
+  worstNotificationState,
   type FastFailureEvent,
 } from "./alerts-fast-ci";
 
@@ -104,4 +105,93 @@ test("each event carries its own notification state", () => {
     group.events.map((e) => e.notificationState),
     ["dead_letter", "unnotified"],
   );
+});
+
+test("repeated runs of one job collapse into a job group within a build", () => {
+  const [group] = groupFastFailureEvents([
+    event({
+      buildkiteJobId: "job-1",
+      jobName: "Async engine test",
+      finishedAt: "2026-08-27T10:00:00.000Z",
+    }),
+    event({
+      buildkiteJobId: "job-2",
+      jobName: "Async engine test",
+      finishedAt: "2026-08-27T10:06:00.000Z",
+    }),
+    event({
+      buildkiteJobId: "job-3",
+      jobName: "Entrypoints test",
+      finishedAt: "2026-08-27T10:04:00.000Z",
+    }),
+  ]);
+
+  assert.equal(group.jobGroups.length, 2);
+  const [asyncGroup, entrypointsGroup] = group.jobGroups;
+  assert.equal(asyncGroup.jobName, "Async engine test");
+  assert.equal(asyncGroup.count, 2);
+  assert.equal(asyncGroup.firstFinishedAt, "2026-08-27T10:00:00.000Z");
+  assert.equal(asyncGroup.lastFinishedAt, "2026-08-27T10:06:00.000Z");
+  assert.deepEqual(
+    asyncGroup.events.map((e) => e.buildkiteJobId),
+    ["job-2", "job-1"],
+  );
+  assert.equal(entrypointsGroup.count, 1);
+});
+
+test("job groups are ordered by their latest finish", () => {
+  const [group] = groupFastFailureEvents([
+    event({
+      buildkiteJobId: "job-1",
+      jobName: "Async engine test",
+      finishedAt: "2026-08-27T10:00:00.000Z",
+    }),
+    event({
+      buildkiteJobId: "job-2",
+      jobName: "Entrypoints test",
+      finishedAt: "2026-08-27T10:04:00.000Z",
+    }),
+    event({
+      buildkiteJobId: "job-3",
+      jobName: "Async engine test",
+      finishedAt: "2026-08-27T10:02:00.000Z",
+    }),
+  ]);
+
+  assert.deepEqual(
+    group.jobGroups.map((jobGroup) => jobGroup.jobName),
+    ["Entrypoints test", "Async engine test"],
+  );
+});
+
+test("a job group reports the worst Slack state across its attempts", () => {
+  const [group] = groupFastFailureEvents([
+    event({ buildkiteJobId: "job-1", notificationStatuses: ["delivered"] }),
+    event({
+      buildkiteJobId: "job-2",
+      notificationStatuses: ["dead_letter"],
+      finishedAt: "2026-08-27T10:05:00.000Z",
+    }),
+    event({
+      buildkiteJobId: "job-3",
+      notificationStatuses: ["pending"],
+      finishedAt: "2026-08-27T10:04:00.000Z",
+    }),
+  ]);
+
+  assert.equal(group.jobGroups.length, 1);
+  assert.equal(group.jobGroups[0].notificationState, "dead_letter");
+});
+
+test("worstNotificationState ranks undelivered states above delivered", () => {
+  assert.equal(
+    worstNotificationState(["delivered", "retrying"]),
+    "retrying",
+  );
+  assert.equal(
+    worstNotificationState(["delivered", "unnotified"]),
+    "unnotified",
+  );
+  assert.equal(worstNotificationState(["delivered"]), "delivered");
+  assert.equal(worstNotificationState([]), "unnotified");
 });

--- a/src/lib/alerts-fast-ci.ts
+++ b/src/lib/alerts-fast-ci.ts
@@ -35,6 +35,21 @@ export interface FastFailureEventView extends FastFailureEvent {
   notificationState: NotificationState;
 }
 
+/**
+ * A retried job produces one event per attempt, and a broadly broken build
+ * retries the same job several times, so events sharing a job name collapse
+ * into one row with the attempts kept as evidence behind it.
+ */
+export interface FastFailureJobGroup {
+  key: string;
+  jobName: string;
+  count: number;
+  firstFinishedAt: string;
+  lastFinishedAt: string;
+  notificationState: NotificationState;
+  events: FastFailureEventView[];
+}
+
 /** The events one build produced for one commit. */
 export interface FastFailureGroup {
   key: string;
@@ -47,6 +62,28 @@ export interface FastFailureGroup {
   prNumber: string | null;
   latestFinishedAt: string;
   events: FastFailureEventView[];
+  jobGroups: FastFailureJobGroup[];
+}
+
+/**
+ * A job group summarizes several notification attempts, so the state a
+ * responder must act on first wins: a dead-lettered attempt outranks one
+ * still retrying, and anything undelivered outranks a success.
+ */
+const JOB_GROUP_SEVERITY: NotificationState[] = [
+  "dead_letter",
+  "retrying",
+  "pending",
+  "unnotified",
+  "delivered",
+];
+
+export function worstNotificationState(
+  states: readonly NotificationState[],
+): NotificationState {
+  return (
+    JOB_GROUP_SEVERITY.find((state) => states.includes(state)) ?? "unnotified"
+  );
 }
 
 /**
@@ -82,15 +119,57 @@ export function groupFastFailureEvents(
       prNumber: event.prNumber,
       latestFinishedAt: event.finishedAt,
       events: [view],
+      // Filled in once every event of the build has been collected.
+      jobGroups: [],
     });
   }
 
   for (const group of groups.values()) {
     group.events.sort((a, b) => b.finishedAt.localeCompare(a.finishedAt));
     group.latestFinishedAt = group.events[0].finishedAt;
+    group.jobGroups = groupEventsByJob(group.events);
   }
 
   return [...groups.values()].sort((a, b) =>
     b.latestFinishedAt.localeCompare(a.latestFinishedAt),
+  );
+}
+
+/** Collapse repeated runs of one job within a build group, newest first. */
+function groupEventsByJob(
+  events: readonly FastFailureEventView[],
+): FastFailureJobGroup[] {
+  const jobGroups = new Map<string, FastFailureJobGroup>();
+
+  for (const event of events) {
+    const jobGroup = jobGroups.get(event.jobName);
+    if (jobGroup) {
+      jobGroup.events.push(event);
+      continue;
+    }
+    jobGroups.set(event.jobName, {
+      key: event.jobName,
+      jobName: event.jobName,
+      count: 0,
+      firstFinishedAt: event.finishedAt,
+      lastFinishedAt: event.finishedAt,
+      notificationState: event.notificationState,
+      events: [event],
+    });
+  }
+
+  for (const jobGroup of jobGroups.values()) {
+    // Incoming events are already newest-first, so the ends of the list are
+    // the group's first and last finishes.
+    jobGroup.count = jobGroup.events.length;
+    jobGroup.lastFinishedAt = jobGroup.events[0].finishedAt;
+    jobGroup.firstFinishedAt = jobGroup.events[jobGroup.events.length - 1].finishedAt;
+    jobGroup.notificationState = worstNotificationState(
+      jobGroup.events.map((event) => event.notificationState),
+    );
+  }
+
+  return [...jobGroups.values()].sort((a, b) =>
+    b.lastFinishedAt.localeCompare(a.lastFinishedAt),
   );
 }


### PR DESCRIPTION
## What

On `/alerts?tab=fast-ci&window=7d`, a broadly broken build retries the same job several times and each attempt was its own row — one recent build (`584e8f0`) listed 48 rows, many the same job repeated 4–6 times.

This PR collapses repeats:

- **`src/lib/alerts-fast-ci.ts`** — `groupFastFailureEvents` now additionally groups each build group's events by job name into `FastFailureJobGroup`s: `count`, `firstFinishedAt`, `lastFinishedAt`, the worst Slack delivery state across attempts (`worstNotificationState`: dead_letter > retrying > pending > unnotified > delivered), and the underlying events (newest first). Job groups are ordered by latest finish.
- **`src/components/fast-ci-alerts.tsx`** — one row per job group. Repeated jobs render the latest attempt with a ×N badge and the worst Slack badge; the individual attempts stay reachable behind a native `<details>` disclosure using the existing event-row markup. Single-attempt rows render exactly as before. Builds with more than 10 distinct jobs collapse the remainder behind a "Show all N jobs" toggle.

No changes to `alerts-content.tsx` were needed — the grouping is internal to `groupFastFailureEvents`, so this should merge cleanly with concurrent work on the Main CI tab. No new colors, radii, or controls; existing row markup and classes are reused.

## How verified

- `npm test` (tsx --test): 69 pass, 0 fail — including new unit tests for job grouping (collapse, count, first/last finish, worst Slack state, ordering) and component tests (×N badge + disclosure, unchanged single rows, worst-state badge, >10 job groups hidden behind the toggle).
- `npm run lint`: clean.
- `npx tsc --noEmit`: clean.

Not verified: visual check against live data (no local backend); row rendering is covered by static-markup component tests instead.
