### PR TITLE
feat(compare): add baseline/candidate presets and kind-grouped image selects

### DIFF
--- a/src/app/api/eval/filters/route.ts
+++ b/src/app/api/eval/filters/route.ts
@@ -6,6 +6,7 @@ import { cachedJson } from "@/lib/api-response";
 
 interface RawRow {
   m: string;
+  d: number | null;
 }
 
 interface LmEvalCore {
@@ -63,7 +64,8 @@ export async function GET(request: Request) {
     }
 
     const rawRows = await queryDatabricks<RawRow>(`
-      SELECT CAST(message AS STRING) AS m
+      SELECT CAST(message AS STRING) AS m,
+        COALESCE(message:date::DOUBLE, message:data:date::DOUBLE) AS d
       FROM vllm_data_warehouse.default.vllm_eval_data_ingest
       WHERE ${conditions.join(" AND ")}
     `);
@@ -73,6 +75,7 @@ export async function GET(request: Request) {
     const filters = new Set<string>();
     const metrics = new Set<string>();
     const images = new Set<string>();
+    const imageEpochs = new Map<string, number>();
     const imageLookups: Promise<void>[] = [];
 
     for (const r of rawRows) {
@@ -88,9 +91,14 @@ export async function GET(request: Request) {
       if (modelName) models.add(modelName);
       for (const taskName of Object.keys(core.results)) {
         tasks.add(taskName);
+        const epoch = Number(r.d);
         imageLookups.push(
           resolveEvalImage(raw, core, taskName).then((image) => {
-            if (image) images.add(image);
+            if (!image) return;
+            images.add(image);
+            if (Number.isFinite(epoch) && epoch > (imageEpochs.get(image) ?? 0)) {
+              imageEpochs.set(image, epoch);
+            }
           })
         );
         for (const key of Object.keys(core.results[taskName])) {
@@ -106,10 +114,16 @@ export async function GET(request: Request) {
 
     await Promise.all(imageLookups);
 
+    const imageDates: Record<string, string> = {};
+    for (const [image, epoch] of imageEpochs) {
+      imageDates[image] = new Date(epoch * 1000).toISOString();
+    }
+
     const result = {
       models: [...models].sort(),
       tasks: [...tasks].sort(),
       images: [...images].sort(),
+      imageDates,
       filters: [...filters].sort(),
       metrics: [...metrics].sort(),
     };

--- a/src/app/api/perf/filters/route.ts
+++ b/src/app/api/perf/filters/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: Request) {
 
     // Per-model datapoint counts, so the UI can sort models by how much data
     // they have (and show the count). Other dims come from a DISTINCT scan.
-    const [modelRows, dimRows] = await Promise.all([
+    const [modelRows, dimRows, imageDateRows] = await Promise.all([
       queryDatabricks<{ model: string; n: number }>(`
         SELECT message:model::STRING AS model, COUNT(*) AS n
         FROM vllm_data_warehouse.default.vllm_perf_data_ingest
@@ -59,6 +59,15 @@ export async function GET(request: Request) {
         FROM vllm_data_warehouse.default.vllm_perf_data_ingest
         WHERE ${where}
       `),
+      // Last run date per image, so the UI can order images newest first.
+      queryDatabricks<{ image: string; last_date: string }>(`
+        SELECT
+          message:image::STRING AS image,
+          MAX(message:date::STRING) AS last_date
+        FROM vllm_data_warehouse.default.vllm_perf_data_ingest
+        WHERE ${where}
+        GROUP BY message:image::STRING
+      `),
     ]);
 
     const modelCounts: Record<string, number> = {};
@@ -74,8 +83,12 @@ export async function GET(request: Request) {
     const concs = [...new Set(dimRows.map((r) => r.conc).filter(Boolean))].sort((a, b) => +a - +b);
     const precisions = [...new Set(dimRows.map((r) => r.precision).filter(Boolean))].sort();
     const images = [...new Set(dimRows.map((r) => r.image).filter(Boolean))].sort();
+    const imageDates: Record<string, string> = {};
+    for (const r of imageDateRows) {
+      if (r.image && r.last_date) imageDates[r.image] = r.last_date;
+    }
 
-    const result = { models, modelCounts, devices, tps, concs, precisions, images };
+    const result = { models, modelCounts, devices, tps, concs, precisions, images, imageDates };
     setCache(cacheKey, result, TTL);
 
     return cachedJson(result, CDN_CACHE);

--- a/src/app/compare/compare-content.tsx
+++ b/src/app/compare/compare-content.tsx
@@ -5,7 +5,12 @@ import { useRouter, useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { SearchableSelect } from "@/components/searchable-select";
 import { DateRangePicker } from "@/components/date-range-picker";
-import { commitFromImage } from "@/lib/commit-from-image";
+import {
+  commitFromImage,
+  describeImage,
+  resolveComparePresets,
+  sortImagesByKind,
+} from "@/lib/commit-from-image";
 
 type Area = "perf" | "eval";
 type DeltaStatus = "regression" | "improvement" | "unchanged" | "noisy";
@@ -15,12 +20,14 @@ interface PerfFilters {
   models: string[];
   devices: string[];
   images: string[];
+  imageDates?: Record<string, string>;
 }
 
 interface EvalFilters {
   models: string[];
   tasks: string[];
   images: string[];
+  imageDates?: Record<string, string>;
 }
 
 interface DeltaItem {
@@ -1312,10 +1319,46 @@ export default function ComparePage() {
     fetcher
   );
 
+  const imageDates = useMemo(() => {
+    const merged: Record<string, string> = {};
+    for (const source of [perfFilters?.imageDates, evalFilters?.imageDates]) {
+      for (const [image, date] of Object.entries(source ?? {})) {
+        if (!merged[image] || Date.parse(date) > Date.parse(merged[image])) {
+          merged[image] = date;
+        }
+      }
+    }
+    return merged;
+  }, [perfFilters?.imageDates, evalFilters?.imageDates]);
+
   const imageOptions = useMemo(
-    () => uniqueSorted([...(perfFilters?.images ?? []), ...(evalFilters?.images ?? [])]),
-    [perfFilters?.images, evalFilters?.images]
+    () =>
+      sortImagesByKind(
+        [
+          ...new Set(
+            [...(perfFilters?.images ?? []), ...(evalFilters?.images ?? [])].filter(
+              Boolean
+            )
+          ),
+        ],
+        imageDates
+      ),
+    [perfFilters?.images, evalFilters?.images, imageDates]
   );
+
+  const presets = useMemo(
+    () => resolveComparePresets(imageOptions, imageDates),
+    [imageOptions, imageDates]
+  );
+
+  const applyPreset = (presetBaseline: string, presetCandidate: string) => {
+    setBaseline(presetBaseline);
+    setCandidate(presetCandidate);
+    updateCompareUrl({
+      baseline: presetBaseline,
+      candidate: presetCandidate,
+    });
+  };
 
   useEffect(() => {
     if (imageOptions.length === 0) return;
@@ -1442,6 +1485,32 @@ export default function ComparePage() {
       </div>
 
       <div className="overflow-hidden rounded-xl border border-zinc-200/80 bg-white dark:border-zinc-800/80 dark:bg-zinc-950">
+        {presets.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2 border-b border-zinc-200 px-4 py-3 sm:px-5 dark:border-zinc-800">
+            <span className="font-mono text-[10px] uppercase tracking-wider text-zinc-400">
+              Presets
+            </span>
+            {presets.map((preset) => {
+              const active =
+                baseline === preset.baseline && candidate === preset.candidate;
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => applyPreset(preset.baseline, preset.candidate)}
+                  title={`${preset.baseline} → ${preset.candidate}`}
+                  className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[11px] transition ${
+                    active
+                      ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
+                      : "border-zinc-200 bg-white text-zinc-600 hover:border-zinc-300 hover:text-zinc-900 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-400 dark:hover:text-zinc-100"
+                  }`}
+                >
+                  {preset.label}
+                </button>
+              );
+            })}
+          </div>
+        )}
         <div className="grid gap-3 px-4 py-4 sm:px-5 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] md:items-end">
           <div className="order-1 min-w-0">
             <SearchableSelect
@@ -1451,6 +1520,14 @@ export default function ComparePage() {
               options={imageOptions}
               allLabel="Select baseline"
             />
+            {baseline && (
+              <div
+                className="mt-1 truncate font-mono text-[11px] text-zinc-400"
+                title={baseline}
+              >
+                {describeImage(baseline, imageDates)}
+              </div>
+            )}
           </div>
           <div className="order-2 min-w-0 md:order-3">
             <SearchableSelect
@@ -1460,6 +1537,14 @@ export default function ComparePage() {
               options={imageOptions}
               allLabel="Select candidate"
             />
+            {candidate && (
+              <div
+                className="mt-1 truncate font-mono text-[11px] text-zinc-400"
+                title={candidate}
+              >
+                {describeImage(candidate, imageDates)}
+              </div>
+            )}
           </div>
           <button
             type="button"

--- a/src/lib/commit-from-image.test.ts
+++ b/src/lib/commit-from-image.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyImage,
+  describeImage,
+  groupImagesByKind,
+  resolveComparePresets,
+  sortImagesByKind,
+} from "./commit-from-image";
+
+test("classifies release tags", () => {
+  assert.deepEqual(classifyImage("vllm/vllm-openai:v0.26.0"), {
+    kind: "release",
+    version: "0.26.0",
+  });
+  assert.deepEqual(classifyImage("vllm/vllm-openai-rocm:v0.25.1"), {
+    kind: "release",
+    version: "0.25.1",
+  });
+  // Release tag with a build suffix must not be misread as a commit sha.
+  assert.deepEqual(classifyImage("vllm-openai-rocm:v0.25.1-aiter-1ba09a47"), {
+    kind: "release",
+    version: "0.25.1",
+  });
+});
+
+test("classifies nightly tags", () => {
+  assert.deepEqual(classifyImage("vllm/vllm-openai:nightly"), {
+    kind: "nightly",
+  });
+  assert.deepEqual(
+    classifyImage(
+      "vllm/vllm-openai:nightly-94c0ef300180f8fd1071d9cbe7270a8348155f94"
+    ),
+    { kind: "nightly", sha: "94c0ef300180f8fd1071d9cbe7270a8348155f94" }
+  );
+  assert.deepEqual(classifyImage("vllm/vllm-openai-rocm:nightly-v0.23.0"), {
+    kind: "nightly",
+    version: "0.23.0",
+  });
+  assert.deepEqual(classifyImage("repo/image:nightly-2026-09-01"), {
+    kind: "nightly",
+    date: "2026-09-01",
+  });
+});
+
+test("classifies commit-sha tags", () => {
+  assert.deepEqual(
+    classifyImage(
+      "public.ecr.aws/q9t5s3a7/vllm-release-repo:33898f832c53c3e98999e0ec2c689f61ee92a9bc-x86_64"
+    ),
+    { kind: "commit", sha: "33898f832c53c3e98999e0ec2c689f61ee92a9bc" }
+  );
+  assert.deepEqual(
+    classifyImage(
+      "public.ecr.aws/q9t5s3a7/vllm-release-repo:2dfaae752b4db0d43cfc0715c780e33be030d0f1"
+    ),
+    { kind: "commit", sha: "2dfaae752b4db0d43cfc0715c780e33be030d0f1" }
+  );
+  // Short-sha-only tags still count as commits.
+  assert.deepEqual(classifyImage("glm52-vllm-0251-aiter:91f582c134c3"), {
+    kind: "commit",
+    sha: "91f582c134c3",
+  });
+});
+
+test("classifies other images", () => {
+  assert.deepEqual(classifyImage("lmsysorg/sglang:latest"), { kind: "other" });
+  assert.deepEqual(classifyImage("vllm/vllm-openai:minimax-m3"), {
+    kind: "other",
+  });
+  assert.deepEqual(classifyImage("auth-smoke"), { kind: "other" });
+  // Digest-pinned images carry no usable tag.
+  assert.deepEqual(
+    classifyImage(
+      "vllm/vllm-openai@sha256:e90e2603b2781936651ba019804137714367c69e10a7b25a2e57b46995225616"
+    ),
+    { kind: "other" }
+  );
+  assert.deepEqual(classifyImage(null), { kind: "other" });
+  assert.deepEqual(classifyImage(undefined), { kind: "other" });
+});
+
+const DATES = {
+  "vllm/vllm-openai:nightly-aaa1111111111111111111111111111111111111":
+    "2026-08-30",
+  "vllm/vllm-openai:nightly-bbb2222222222222222222222222222222222222":
+    "2026-09-01",
+  "vllm/vllm-openai:nightly-ccc3333333333333333333333333333333333333":
+    "2026-09-02",
+  "vllm/vllm-openai:v0.25.1": "2026-08-10",
+  "vllm/vllm-openai:v0.26.0": "2026-08-20",
+  "public.ecr.aws/q9t5s3a7/vllm-release-repo:33898f832c53c3e98999e0ec2c689f61ee92a9bc-x86_64":
+    "2026-09-01",
+  "lmsysorg/sglang:latest": "2026-07-01",
+};
+
+const IMAGES = Object.keys(DATES);
+
+test("groupImagesByKind sorts each group newest first", () => {
+  const groups = groupImagesByKind(IMAGES, DATES);
+  assert.deepEqual(
+    groups.nightly,
+    [
+      "vllm/vllm-openai:nightly-ccc3333333333333333333333333333333333333",
+      "vllm/vllm-openai:nightly-bbb2222222222222222222222222222222222222",
+      "vllm/vllm-openai:nightly-aaa1111111111111111111111111111111111111",
+    ]
+  );
+  // Releases sort by version even without run dates.
+  assert.deepEqual(groups.release, [
+    "vllm/vllm-openai:v0.26.0",
+    "vllm/vllm-openai:v0.25.1",
+  ]);
+  assert.deepEqual(groups.commit, [
+    "public.ecr.aws/q9t5s3a7/vllm-release-repo:33898f832c53c3e98999e0ec2c689f61ee92a9bc-x86_64",
+  ]);
+  assert.deepEqual(groups.other, ["lmsysorg/sglang:latest"]);
+});
+
+test("sortImagesByKind flattens groups in kind order", () => {
+  const sorted = sortImagesByKind(IMAGES, DATES);
+  assert.deepEqual(
+    sorted.map((image) => classifyImage(image).kind),
+    ["nightly", "nightly", "nightly", "release", "release", "commit", "other"]
+  );
+});
+
+test("resolveComparePresets resolves all four presets", () => {
+  const presets = resolveComparePresets(IMAGES, DATES);
+  const byId = new Map(presets.map((p) => [p.id, p]));
+
+  assert.equal(presets.length, 4);
+  assert.equal(
+    byId.get("nightly-vs-previous-nightly")?.baseline,
+    "vllm/vllm-openai:nightly-bbb2222222222222222222222222222222222222"
+  );
+  assert.equal(
+    byId.get("nightly-vs-previous-nightly")?.candidate,
+    "vllm/vllm-openai:nightly-ccc3333333333333333333333333333333333333"
+  );
+  assert.equal(
+    byId.get("release-vs-previous-release")?.baseline,
+    "vllm/vllm-openai:v0.25.1"
+  );
+  assert.equal(
+    byId.get("release-vs-previous-release")?.candidate,
+    "vllm/vllm-openai:v0.26.0"
+  );
+  assert.equal(
+    byId.get("nightly-vs-release")?.baseline,
+    "vllm/vllm-openai:v0.26.0"
+  );
+  assert.equal(
+    byId.get("main-commit-vs-release")?.candidate,
+    "public.ecr.aws/q9t5s3a7/vllm-release-repo:33898f832c53c3e98999e0ec2c689f61ee92a9bc-x86_64"
+  );
+});
+
+test("resolveComparePresets hides presets that do not resolve", () => {
+  // A single nightly and no releases: only no preset can resolve.
+  assert.deepEqual(
+    resolveComparePresets(["vllm/vllm-openai:nightly"], {}),
+    []
+  );
+  // Two nightlies but nothing else.
+  const presets = resolveComparePresets(
+    ["vllm/vllm-openai:nightly", "vllm/vllm-openai:nightly-abc1234"],
+    {}
+  );
+  assert.deepEqual(
+    presets.map((p) => p.id),
+    ["nightly-vs-previous-nightly"]
+  );
+});
+
+test("resolveComparePresets never mixes repos within a pair", () => {
+  // The ROCm nightly is the most recent; presets must stick to its repo.
+  const presets = resolveComparePresets(
+    [
+      "vllm/vllm-openai-rocm:nightly-ddd4444444444444444444444444444444444444",
+      ...IMAGES,
+    ],
+    { ...DATES, "vllm/vllm-openai-rocm:nightly-ddd4444444444444444444444444444444444444": "2026-09-03" }
+  );
+  const nightlyPreset = presets.find(
+    (p) => p.id === "nightly-vs-previous-nightly"
+  );
+  // Only one ROCm nightly exists, so the nightly pair cannot resolve.
+  assert.equal(nightlyPreset, undefined);
+  const crossPreset = presets.find((p) => p.id === "nightly-vs-release");
+  assert.equal(
+    crossPreset?.candidate,
+    "vllm/vllm-openai-rocm:nightly-ddd4444444444444444444444444444444444444"
+  );
+});
+
+test("describeImage renders human labels", () => {
+  assert.equal(
+    describeImage("vllm/vllm-openai:v0.26.0"),
+    "release v0.26.0"
+  );
+  assert.equal(
+    describeImage(
+      "vllm/vllm-openai:nightly-94c0ef300180f8fd1071d9cbe7270a8348155f94"
+    ),
+    "nightly 94c0ef3"
+  );
+  assert.equal(
+    describeImage(
+      "public.ecr.aws/q9t5s3a7/vllm-release-repo:33898f832c53c3e98999e0ec2c689f61ee92a9bc-rocm"
+    ),
+    "commit 33898f8"
+  );
+  assert.equal(describeImage("vllm/vllm-openai:nightly"), "nightly (moving tag)");
+  assert.equal(describeImage("lmsysorg/sglang:latest"), "latest");
+  // Run date appended when available.
+  const withDate = describeImage("vllm/vllm-openai:v0.26.0", {
+    "vllm/vllm-openai:v0.26.0": "2026-08-20",
+  });
+  assert.match(withDate, /^release v0\.26\.0 · /);
+});

--- a/src/lib/commit-from-image.ts
+++ b/src/lib/commit-from-image.ts
@@ -11,3 +11,237 @@ export function commitFromImage(image: string | null | undefined): string | null
   const shaMatch = tag.match(/(?:^|[-_.])([0-9a-f]{12,40})(?:$|[-_.])/i);
   return shaMatch?.[1] ?? null;
 }
+
+export type ImageKind = "release" | "nightly" | "commit" | "other";
+
+export interface ImageInfo {
+  kind: ImageKind;
+  /** Release version without the leading "v" (e.g. "0.26.0"). */
+  version?: string;
+  /** Date embedded in a date-based nightly tag (e.g. "2026-09-01"). */
+  date?: string;
+  /** Commit sha embedded in the tag, as found (7-40 hex chars). */
+  sha?: string;
+}
+
+const VERSION_RE = /^v?(\d+\.\d+\.\d+)(?:[-_.+].*)?$/;
+const NIGHTLY_RE = /^nightly(?:[-_.](.+))?$/i;
+const TAG_DATE_RE = /^(\d{4}[-.]\d{2}[-.]\d{2})/;
+const PURE_SHA_RE = /^[0-9a-f]{7,40}$/i;
+const SEGMENT_SHA_RE = /(?:^|[-_.])([0-9a-f]{12,40})(?:$|[-_.])/i;
+
+// Images built by the main vLLM CI and tagged with a bare commit sha.
+const CI_COMMIT_REPO_RE = /vllm-(release|ci-test)-repo/;
+
+function imageTag(image: string): string | null {
+  const withoutDigest = image.split("@")[0];
+  const slash = withoutDigest.lastIndexOf("/");
+  const colon = withoutDigest.lastIndexOf(":");
+  if (colon <= slash) return null;
+  return withoutDigest.slice(colon + 1);
+}
+
+function imageRepo(image: string): string {
+  const withoutDigest = image.split("@")[0];
+  const slash = withoutDigest.lastIndexOf("/");
+  const colon = withoutDigest.lastIndexOf(":");
+  return colon > slash ? withoutDigest.slice(0, colon) : withoutDigest;
+}
+
+export function classifyImage(image: string | null | undefined): ImageInfo {
+  const tag = image ? imageTag(image) : null;
+  if (!tag) return { kind: "other" };
+
+  const nightly = tag.match(NIGHTLY_RE);
+  if (nightly) {
+    const rest = nightly[1] ?? "";
+    const date = rest.match(TAG_DATE_RE);
+    if (date) return { kind: "nightly", date: date[1] };
+    if (PURE_SHA_RE.test(rest)) return { kind: "nightly", sha: rest };
+    const version = rest.match(VERSION_RE);
+    if (version) return { kind: "nightly", version: version[1] };
+    return { kind: "nightly" };
+  }
+
+  const version = tag.match(VERSION_RE);
+  if (version) return { kind: "release", version: version[1] };
+
+  if (PURE_SHA_RE.test(tag)) return { kind: "commit", sha: tag };
+  const sha = tag.match(SEGMENT_SHA_RE);
+  if (sha) return { kind: "commit", sha: sha[1] };
+
+  return { kind: "other" };
+}
+
+function compareVersionsDesc(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const diff = (pb[i] ?? 0) - (pa[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+function imageDateMs(
+  image: string,
+  dates?: Record<string, string>
+): number {
+  const raw = dates?.[image];
+  if (!raw) return 0;
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+export interface GroupedImages {
+  nightly: string[];
+  release: string[];
+  commit: string[];
+  other: string[];
+}
+
+/**
+ * Group images by kind and sort each group newest first.
+ * Recency comes from per-image run dates when available; releases fall
+ * back to semver order and everything else to a name tiebreak.
+ */
+export function groupImagesByKind(
+  images: string[],
+  dates?: Record<string, string>
+): GroupedImages {
+  const groups: GroupedImages = { nightly: [], release: [], commit: [], other: [] };
+  for (const image of images) {
+    groups[classifyImage(image).kind].push(image);
+  }
+
+  const byDateDesc = (a: string, b: string) =>
+    imageDateMs(b, dates) - imageDateMs(a, dates) || a.localeCompare(b);
+
+  groups.release.sort((a, b) => {
+    const va = classifyImage(a).version;
+    const vb = classifyImage(b).version;
+    if (va && vb) return compareVersionsDesc(va, vb) || byDateDesc(a, b);
+    return byDateDesc(a, b);
+  });
+  groups.nightly.sort(byDateDesc);
+  groups.commit.sort(byDateDesc);
+  groups.other.sort((a, b) => a.localeCompare(b));
+  return groups;
+}
+
+/** Images grouped by kind, flattened with the most actionable kinds first. */
+export function sortImagesByKind(
+  images: string[],
+  dates?: Record<string, string>
+): string[] {
+  const groups = groupImagesByKind(images, dates);
+  return [...groups.nightly, ...groups.release, ...groups.commit, ...groups.other];
+}
+
+// Restrict a sorted list to the repo of its first (most recent) entry, so a
+// preset never pairs images from different repos (e.g. CUDA vs ROCm nightlies).
+function topRepoSubset(sorted: string[]): string[] {
+  if (sorted.length === 0) return sorted;
+  const repo = imageRepo(sorted[0]);
+  return sorted.filter((image) => imageRepo(image) === repo);
+}
+
+export interface ComparePreset {
+  id: string;
+  label: string;
+  baseline: string;
+  candidate: string;
+}
+
+/**
+ * Resolve the fixed preset definitions against the available images.
+ * Only presets whose baseline and candidate both resolve are returned.
+ */
+export function resolveComparePresets(
+  images: string[],
+  dates?: Record<string, string>
+): ComparePreset[] {
+  const groups = groupImagesByKind(images, dates);
+  const nightlies = topRepoSubset(groups.nightly);
+  const releases = topRepoSubset(groups.release);
+  const mainCommits = groups.commit.filter((image) =>
+    CI_COMMIT_REPO_RE.test(image)
+  );
+
+  const presets: ComparePreset[] = [];
+  if (nightlies[0] && nightlies[1]) {
+    presets.push({
+      id: "nightly-vs-previous-nightly",
+      label: "Latest nightly vs previous nightly",
+      baseline: nightlies[1],
+      candidate: nightlies[0],
+    });
+  }
+  if (releases[0] && releases[1]) {
+    presets.push({
+      id: "release-vs-previous-release",
+      label: "Latest release vs previous release",
+      baseline: releases[1],
+      candidate: releases[0],
+    });
+  }
+  if (nightlies[0] && releases[0] && nightlies[0] !== releases[0]) {
+    presets.push({
+      id: "nightly-vs-release",
+      label: "Latest nightly vs latest release",
+      baseline: releases[0],
+      candidate: nightlies[0],
+    });
+  }
+  if (mainCommits[0] && releases[0] && mainCommits[0] !== releases[0]) {
+    presets.push({
+      id: "main-commit-vs-release",
+      label: "Latest main commit vs latest release",
+      baseline: releases[0],
+      candidate: mainCommits[0],
+    });
+  }
+  return presets;
+}
+
+function formatImageDate(raw: string): string | null {
+  const ms = Date.parse(raw);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/** Short human label for an image, e.g. "release v0.26.0" or "nightly 94c0ef3". */
+export function describeImage(
+  image: string,
+  dates?: Record<string, string>
+): string {
+  const info = classifyImage(image);
+  let label: string;
+  switch (info.kind) {
+    case "release":
+      label = `release v${info.version}`;
+      break;
+    case "nightly":
+      label = info.sha
+        ? `nightly ${info.sha.slice(0, 7)}`
+        : info.date
+          ? `nightly ${info.date}`
+          : info.version
+            ? `nightly v${info.version}`
+            : "nightly (moving tag)";
+      break;
+    case "commit":
+      label = `commit ${info.sha?.slice(0, 7)}`;
+      break;
+    default:
+      label = imageTag(image) ?? image;
+  }
+
+  const runDate = dates?.[image] ? formatImageDate(dates[image]) : null;
+  return runDate ? `${label} · ${runDate}` : label;
+}


### PR DESCRIPTION
## What

The `/compare` page opened with two empty selects over a long alphabetized list of raw image strings (`public.ecr.aws/.../vllm-release-repo:<sha>-x86_64`, `vllm/vllm-openai:nightly-<sha>`, ...), so users had to know exact tags. This adds:

- **`classifyImage(image)`** in `src/lib/commit-from-image.ts` — tags an image as `release` / `nightly` / `commit` / `other` (with `version` / `date` / `sha` where present), based on the real tag formats returned by the perf/eval filters endpoints (semver tags like `v0.26.0`, `nightly-<sha>` / `nightly-<date>` / `nightly-vX.Y.Z`, bare-sha CI builds like `vllm-release-repo:<40-hex>-x86_64`).
- **Preset row above the selects**: "Latest nightly vs previous nightly", "Latest release vs previous release", "Latest nightly vs latest release", "Latest main commit vs latest release". Only presets that resolve against the loaded images are shown, pairs never mix repos (e.g. CUDA vs ROCm nightlies), and clicking one sets the same `baseline`/`candidate` URL params the manual selects use.
- **Human label beside each select** once an image is chosen (e.g. `release v0.26.0 · Aug 20, 2026`, `nightly 94c0ef3`, `commit 33898f8`), and select options are ordered grouped by kind, newest first.
- `/api/perf/filters` and `/api/eval/filters` now also return `imageDates` (last run date per image) so ordering and presets can be recency-aware. The existing `images` field is unchanged.

## How verified

- `npm test` (tsx --test): 70/70 pass, including 10 new tests in `src/lib/commit-from-image.test.ts` covering classification of real tags from both filters endpoints, group ordering, preset resolution/hiding, and labels.
- `npm run lint`: clean.
- `npx tsc --noEmit`: clean.

Not verified: visual check against live data (no local Databricks creds); preset resolution logic is unit-tested against representative real tags.