### PR TITLE
feat(eval): dedupe runs and compare against rolling baseline

### DIFF
--- a/src/app/api/eval/route.ts
+++ b/src/app/api/eval/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { loadEvalRows } from "@/lib/eval-data";
+import { loadEvalRows, loadEvalTaskCount } from "@/lib/eval-data";
 import { getCached, setCache } from "@/lib/api-cache";
 import { cachedJson } from "@/lib/api-response";
 
@@ -13,13 +13,14 @@ export async function GET(request: NextRequest) {
     const cached = getCached(cacheKey);
     if (cached) return cachedJson(cached, CDN_CACHE);
 
-    const rows = await loadEvalRows({
-      model: sp.get("model"),
-      task: sp.get("task"),
-      image: sp.get("image"),
-    });
+    const model = sp.get("model");
+    const task = sp.get("task");
+    const [rows, taskCount] = await Promise.all([
+      loadEvalRows({ model, task, image: sp.get("image") }),
+      loadEvalTaskCount({ model, task }),
+    ]);
 
-    const result = { rows };
+    const result = { rows, taskCount };
     setCache(cacheKey, result, TTL);
 
     return cachedJson(result, CDN_CACHE);

--- a/src/app/eval/page.tsx
+++ b/src/app/eval/page.tsx
@@ -6,6 +6,7 @@ import dynamic from "next/dynamic";
 import { SearchableSelect } from "@/components/searchable-select";
 import { StatCard } from "@/components/stat-card";
 import { commitFromImage } from "@/lib/commit-from-image";
+import { compareToRollingBaseline } from "@/lib/eval-data";
 
 const Plot = dynamic(() => import("@/components/plotly-chart"), {
   ssr: false,
@@ -44,6 +45,7 @@ interface EvalRow {
   buildkite_commit: string | null;
   vllm_commit: string | null;
   workload: string | null;
+  duplicateCount: number;
 }
 
 interface FiltersResponse {
@@ -595,6 +597,14 @@ function LeaderboardTable({
                 </span>
                 <span className="mt-2 flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
                   <span>{formatTime(row.run_date)}</span>
+                  {row.duplicateCount > 1 && (
+                    <span
+                      className="text-zinc-400"
+                      title={`${row.duplicateCount} identical runs merged`}
+                    >
+                      ×{row.duplicateCount}
+                    </span>
+                  )}
                   <span aria-hidden="true">·</span>
                   <span className="font-mono text-blue-600 dark:text-blue-400">
                     {shortCommit(row)}
@@ -648,6 +658,14 @@ function LeaderboardTable({
                 >
                   <td className="px-4 py-2 text-zinc-500 whitespace-nowrap">
                     {formatTime(r.run_date)}
+                    {r.duplicateCount > 1 && (
+                      <span
+                        className="ml-1 text-zinc-400"
+                        title={`${r.duplicateCount} identical runs merged`}
+                      >
+                        ×{r.duplicateCount}
+                      </span>
+                    )}
                   </td>
                   <td className="px-4 py-2 font-mono text-xs text-zinc-500">
                     {r.buildkite_build_url ? (
@@ -734,20 +752,27 @@ function LatestStatCards({
       task: string;
       model: string;
       latest: EvalRow;
-      prev: EvalRow | null;
+      priors: { value: number; stderr: number }[];
       pm: { metric: string; filter: string } | null;
     }[] = [];
     for (const [key, runs] of byKey) {
       const sorted = [...runs].sort((a, b) => b.run_epoch - a.run_epoch);
       const latest = sorted[0];
-      const prev = sorted[1] ?? null;
+      const pm = primaryMetric(runs);
+      const priors = pm
+        ? sorted
+            .slice(1)
+            .map((r) => pickMetric(r, pm.metric, pm.filter))
+            .filter((mm): mm is EvalMetric => mm !== null)
+            .map((mm) => ({ value: mm.value, stderr: mm.stderr }))
+        : [];
       out.push({
         key,
         task: latest.task,
         model: latest.model,
         latest,
-        prev,
-        pm: primaryMetric(runs),
+        priors,
+        pm,
       });
     }
     return out.sort((a, b) => a.task.localeCompare(b.task));
@@ -760,27 +785,21 @@ function LatestStatCards({
       {cards.map((c) => {
         if (!c.pm) return null;
         const m = pickMetric(c.latest, c.pm.metric, c.pm.filter);
-        const prevM = c.prev ? pickMetric(c.prev, c.pm.metric, c.pm.filter) : null;
         if (!m) return null;
         let color: "default" | "green" | "red" | "yellow" = "default";
         const commit = shortCommit(c.latest);
         let detail = `n=${c.latest.n_samples}, ${c.latest.n_shot}-shot, ${commit}`;
-        if (prevM) {
-          const delta = m.value - prevM.value;
-          const sigma = Math.sqrt(m.stderr ** 2 + prevM.stderr ** 2);
-          const zish = sigma > 0 ? Math.abs(delta) / sigma : 0;
-          const dir = delta >= 0 ? "↑" : "↓";
-          const sign = delta >= 0 ? "+" : "";
-          detail = `${dir} ${sign}${(delta * 100).toFixed(2)}pp vs prev (${zish.toFixed(1)}σ)`;
-          if (m.higher_is_better) {
-            if (delta < 0 && zish > 2) color = "red";
-            else if (delta > 0 && zish > 2) color = "green";
-            else color = "yellow";
-          } else {
-            if (delta > 0 && zish > 2) color = "red";
-            else if (delta < 0 && zish > 2) color = "green";
-            else color = "yellow";
-          }
+        const cmp = compareToRollingBaseline(
+          { value: m.value, stderr: m.stderr },
+          c.priors
+        );
+        if (cmp) {
+          const dir = cmp.delta >= 0 ? "↑" : "↓";
+          const sign = cmp.delta >= 0 ? "+" : "";
+          detail = `${dir} ${sign}${(cmp.delta * 100).toFixed(2)}pp vs baseline (${cmp.sigma.toFixed(1)}σ)`;
+          const improved = m.higher_is_better ? cmp.delta > 0 : cmp.delta < 0;
+          if (cmp.flagged) color = improved ? "green" : "red";
+          else color = "yellow";
         }
         return (
           <StatCard
@@ -796,12 +815,17 @@ function LatestStatCards({
   );
 }
 
-function EvaluationOverview({ rows }: { rows: EvalRow[] }) {
+function EvaluationOverview({
+  rows,
+  taskCount,
+}: {
+  rows: EvalRow[];
+  taskCount?: number;
+}) {
   const overview = useMemo(() => {
     const sorted = [...rows].sort((a, b) => b.run_epoch - a.run_epoch);
     const latest = sorted[0] ?? null;
     const models = new Set(rows.map((row) => row.model).filter(Boolean));
-    const tasks = new Set(rows.map((row) => row.task).filter(Boolean));
     const groups = new Map<string, EvalRow[]>();
     for (const row of rows) {
       const key = `${row.model}|${row.task}`;
@@ -822,25 +846,27 @@ function EvaluationOverview({ rows }: { rows: EvalRow[] }) {
         (a, b) => b.run_epoch - a.run_epoch,
       );
       const current = group[0];
-      const previous = group[1];
       const metric = primaryMetric(group);
-      if (!current || !previous || !metric) continue;
+      if (!current || !metric) continue;
       const currentMetric = pickMetric(current, metric.metric, metric.filter);
-      const previousMetric = pickMetric(previous, metric.metric, metric.filter);
-      if (!currentMetric || !previousMetric) continue;
-      const delta = currentMetric.value - previousMetric.value;
-      const sigma = Math.sqrt(
-        currentMetric.stderr ** 2 + previousMetric.stderr ** 2,
+      if (!currentMetric) continue;
+      const priors = group
+        .slice(1)
+        .map((r) => pickMetric(r, metric.metric, metric.filter))
+        .filter((mm): mm is EvalMetric => mm !== null)
+        .map((mm) => ({ value: mm.value, stderr: mm.stderr }));
+      const cmp = compareToRollingBaseline(
+        { value: currentMetric.value, stderr: currentMetric.stderr },
+        priors,
       );
-      const significance = sigma > 0 ? Math.abs(delta) / sigma : 0;
-      if (significance < 2) continue;
-      const beneficialDelta = currentMetric.higher_is_better ? delta : -delta;
+      if (!cmp || !cmp.flagged) continue;
+      const beneficialDelta = currentMetric.higher_is_better ? cmp.delta : -cmp.delta;
       changes.push({
         key,
         model: current.model,
         task: current.task,
-        delta,
-        significance,
+        delta: cmp.delta,
+        significance: cmp.sigma,
         regression: beneficialDelta < 0,
       });
     }
@@ -849,7 +875,6 @@ function EvaluationOverview({ rows }: { rows: EvalRow[] }) {
     return {
       latest,
       modelCount: models.size,
-      taskCount: tasks.size,
       regressions: changes.filter((change) => change.regression).length,
       improvements: changes.filter((change) => !change.regression).length,
       changes: changes.slice(0, 5),
@@ -881,7 +906,7 @@ function EvaluationOverview({ rows }: { rows: EvalRow[] }) {
         />
         <StatCard
           label="Tasks"
-          value={overview.taskCount}
+          value={taskCount ?? new Set(rows.map((row) => row.task).filter(Boolean)).size}
           detail="Across current filters"
         />
         <StatCard
@@ -899,12 +924,12 @@ function EvaluationOverview({ rows }: { rows: EvalRow[] }) {
       <div className="rounded-xl border border-zinc-200/80 bg-white dark:border-zinc-800/80 dark:bg-zinc-950">
         <div className="border-b border-zinc-200 px-4 py-3 sm:px-5 dark:border-zinc-800">
           <h3 className="text-[13px] font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
-            Strongest changes vs previous run
+            Strongest changes vs rolling baseline
           </h3>
         </div>
         {overview.changes.length === 0 ? (
           <p className="px-4 py-5 text-sm text-zinc-500 sm:px-5 dark:text-zinc-400">
-            No changes exceeded the 2σ watch threshold.
+            No changes exceeded the baseline watch threshold.
           </p>
         ) : (
           <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
@@ -953,7 +978,7 @@ export default function EvalPage() {
   if (task) params.set("task", task);
   if (image) params.set("image", image);
 
-  const { data, isLoading } = useSWR<{ rows: EvalRow[] }>(
+  const { data, isLoading } = useSWR<{ rows: EvalRow[]; taskCount?: number }>(
     `/api/eval?${params.toString()}`,
     fetcher,
     { refreshInterval: 10 * 60 * 1000, keepPreviousData: true }
@@ -1015,7 +1040,7 @@ export default function EvalPage() {
 
       {!showInitialLoading && rows.length > 0 && (
         <>
-          {!model && <EvaluationOverview rows={rows} />}
+          {!model && <EvaluationOverview rows={rows} taskCount={data?.taskCount} />}
           {model && (
             <>
               <LatestStatCards rows={rows} />

--- a/src/lib/eval-data.test.ts
+++ b/src/lib/eval-data.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BASELINE_WINDOW,
+  DEDUPE_WINDOW_SECONDS,
+  compareToRollingBaseline,
+  dedupeEvalRows,
+  median,
+  type EvalRow,
+} from "./eval-data";
+
+function makeRow(overrides: Partial<EvalRow> = {}): EvalRow {
+  return {
+    ingest_ts: "2026-09-02T14:02:00Z",
+    run_date: "2026-09-02T14:02:00Z",
+    run_epoch: 1_788_358_920,
+    model: "openai/gpt-oss-120b",
+    task: "gsm8k",
+    n_shot: 0,
+    n_samples: 1319,
+    git_hash: null,
+    eval_seconds: 120,
+    metrics: [
+      {
+        name: "exact_match",
+        filter: "flexible-extract",
+        value: 0.8362,
+        stderr: 0.0102,
+        higher_is_better: true,
+      },
+    ],
+    image: "public.ecr.aws/q9t5s3a7/vllm-release-repo:33898f832c53c3e98999e0ec2c689f61ee92a9bc-x86_64",
+    buildkite_build_id: "123",
+    buildkite_build_number: "42",
+    buildkite_build_url: "https://buildkite.example/42",
+    buildkite_commit: null,
+    vllm_commit: "33898f832c53c3e98999e0ec2c689f61ee92a9bc",
+    workload: null,
+    duplicateCount: 1,
+    ...overrides,
+  };
+}
+
+test("dedupeEvalRows merges identical runs within the window, keeping the earliest", () => {
+  const base = makeRow();
+  const rows = [
+    makeRow({ run_epoch: base.run_epoch + 180, ingest_ts: "2026-09-02T14:05:00Z" }),
+    makeRow({ run_epoch: base.run_epoch, ingest_ts: "2026-09-02T14:02:00Z" }),
+    makeRow({ run_epoch: base.run_epoch + 60, ingest_ts: "2026-09-02T14:03:00Z" }),
+    makeRow({ run_epoch: base.run_epoch + 300, ingest_ts: "2026-09-02T14:07:00Z" }),
+  ];
+
+  const out = dedupeEvalRows(rows);
+
+  assert.equal(out.length, 1);
+  assert.equal(out[0].run_epoch, base.run_epoch);
+  assert.equal(out[0].duplicateCount, 4);
+});
+
+test("dedupeEvalRows keeps runs that differ in score, commit, image or samples", () => {
+  const base = makeRow();
+  const variants = [
+    makeRow(),
+    makeRow({
+      metrics: [{ ...base.metrics[0], value: 0.84 }],
+    }),
+    makeRow({
+      image: null,
+      vllm_commit: "0000000000000000000000000000000000000000",
+    }),
+    makeRow({ image: null }),
+    makeRow({ n_samples: 500 }),
+    makeRow({ task: "aime25" }),
+  ];
+
+  const out = dedupeEvalRows(variants);
+
+  assert.equal(out.length, variants.length);
+  assert.ok(out.every((r) => r.duplicateCount === 1));
+});
+
+test("dedupeEvalRows starts a new group after the 10-minute window", () => {
+  const rows = [
+    makeRow({ run_epoch: 1000 }),
+    makeRow({ run_epoch: 1000 + DEDUPE_WINDOW_SECONDS }),
+    makeRow({ run_epoch: 1000 + DEDUPE_WINDOW_SECONDS + 1 }),
+  ];
+
+  const out = dedupeEvalRows(rows);
+
+  assert.equal(out.length, 2);
+  const counts = out.map((r) => r.duplicateCount).sort();
+  assert.deepEqual(counts, [1, 2]);
+});
+
+test("dedupeEvalRows returns runs newest first", () => {
+  const rows = [
+    makeRow({ run_epoch: 1000 }),
+    makeRow({ run_epoch: 5000, task: "aime25" }),
+  ];
+
+  const out = dedupeEvalRows(rows);
+
+  assert.deepEqual(out.map((r) => r.run_epoch), [5000, 1000]);
+});
+
+test("median handles odd and even sample sizes", () => {
+  assert.equal(median([0.8]), 0.8);
+  assert.equal(median([0.7, 0.9, 0.8]), 0.8);
+  assert.equal(median([0.7, 0.9]), 0.8);
+  assert.equal(median([]), null);
+});
+
+test("compareToRollingBaseline returns null without prior runs", () => {
+  assert.equal(compareToRollingBaseline({ value: 0.8, stderr: 0.01 }, []), null);
+});
+
+test("compareToRollingBaseline uses the median of the last K runs", () => {
+  const prior = Array.from({ length: BASELINE_WINDOW + 2 }, (_, i) => ({
+    value: 0.8 + i * 0.1, // newest-first: 0.8, 0.9, 1.0, ... only first K count
+    stderr: 0.01,
+  }));
+  const cmp = compareToRollingBaseline({ value: 0.85, stderr: 0.01 }, prior);
+
+  assert.ok(cmp);
+  assert.equal(cmp.baselineCount, BASELINE_WINDOW);
+  // Median of the first BASELINE_WINDOW values (0.8, 0.9, 1.0, 1.1, 1.2).
+  assert.equal(cmp.baseline, 1.0);
+});
+
+test("compareToRollingBaseline flags changes beyond 2x stderr and 1pp", () => {
+  const prior = [{ value: 0.8, stderr: 0.01 }];
+
+  const small = compareToRollingBaseline({ value: 0.805, stderr: 0.01 }, prior);
+  assert.ok(small);
+  assert.equal(small.flagged, false); // 0.5pp < 2*stderr and < 1pp
+
+  const big = compareToRollingBaseline({ value: 0.83, stderr: 0.01 }, prior);
+  assert.ok(big);
+  assert.equal(big.flagged, true);
+  assert.ok(Math.abs(big.delta - 0.03) < 1e-9);
+  assert.ok(Math.abs(big.sigma - 0.03 / Math.SQRT2 / 0.01) < 1e-9);
+});
+
+test("compareToRollingBaseline never flags sub-1pp moves even with tiny stderr", () => {
+  const prior = [{ value: 0.8, stderr: 0.001 }];
+  const cmp = compareToRollingBaseline({ value: 0.809, stderr: 0.001 }, prior);
+
+  assert.ok(cmp);
+  assert.equal(cmp.flagged, false); // 0.9pp below the 1pp floor despite 9 sigma
+  assert.ok(cmp.sigma > 2);
+});

--- a/src/lib/eval-data.ts
+++ b/src/lib/eval-data.ts
@@ -1,4 +1,5 @@
 import { queryDatabricks } from "@/lib/databricks";
+import { commitFromImage } from "@/lib/commit-from-image";
 import {
   imageFromMessage,
   resolveEvalImage,
@@ -31,6 +32,7 @@ export interface EvalRow {
   buildkite_commit: string | null;
   vllm_commit: string | null;
   workload: string | null;
+  duplicateCount: number;
 }
 
 interface RawRow {
@@ -77,6 +79,19 @@ export interface EvalRowsQuery {
 
 function escapeSqlString(value: string): string {
   return value.replace(/'/g, "''");
+}
+
+function buildConditions(model?: string | null): string[] {
+  const conditions = [
+    "(message:results IS NOT NULL OR message:data:results IS NOT NULL)",
+  ];
+  if (model) {
+    const esc = escapeSqlString(model);
+    conditions.push(
+      `(message:config:model_args:model::STRING = '${esc}' OR message:data:config:model_args:model::STRING = '${esc}' OR message:config:model_args::STRING LIKE '%model=${esc}%' OR message:data:config:model_args::STRING LIKE '%model=${esc}%')`
+    );
+  }
+  return conditions;
 }
 
 export function parseEvalMetrics(
@@ -128,21 +143,97 @@ function extractModel(modelArgs: unknown): string | null {
   return null;
 }
 
+// CI often ingests the same lm-eval result more than once (retries, mirror
+// uploads). Runs are duplicates when every identifying field matches and they
+// land within this window of the first occurrence.
+export const DEDUPE_WINDOW_SECONDS = 10 * 60;
+
+// Number of prior runs (same model+task, newest first) that form the rolling
+// baseline a run is compared against.
+export const BASELINE_WINDOW = 5;
+
+// A change is only worth flagging when it exceeds both the statistical noise
+// (2 × stderr) and a floor of one percentage point.
+export const FLAG_FLOOR = 0.01;
+
+function dedupeKey(row: EvalRow): string {
+  const commit =
+    commitFromImage(row.image) ??
+    row.vllm_commit ??
+    row.buildkite_commit ??
+    row.git_hash ??
+    "";
+  const metrics = row.metrics
+    .map((m) => `${m.name},${m.filter}=${m.value}:${m.stderr}`)
+    .sort()
+    .join(";");
+  return [row.model, row.task, commit, row.image ?? "", metrics, row.n_samples].join("|");
+}
+
+// Collapse duplicate ingests: same model, task, commit, image, score, stderr
+// and sample count within DEDUPE_WINDOW_SECONDS keep only the earliest run,
+// which records how many rows were merged into it.
+export function dedupeEvalRows(rows: EvalRow[]): EvalRow[] {
+  const sorted = [...rows].sort((a, b) => a.run_epoch - b.run_epoch);
+  const open = new Map<string, { firstEpoch: number; kept: EvalRow }>();
+  const kept: EvalRow[] = [];
+  for (const row of sorted) {
+    const key = dedupeKey(row);
+    const group = open.get(key);
+    if (group && row.run_epoch - group.firstEpoch <= DEDUPE_WINDOW_SECONDS) {
+      group.kept.duplicateCount += 1;
+      continue;
+    }
+    const copy = { ...row, duplicateCount: 1 };
+    open.set(key, { firstEpoch: row.run_epoch, kept: copy });
+    kept.push(copy);
+  }
+  return kept.sort((a, b) => b.run_epoch - a.run_epoch);
+}
+
+export function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+export interface BaselineComparison {
+  baseline: number;
+  baselineCount: number;
+  delta: number;
+  sigma: number;
+  flagged: boolean;
+}
+
+// Compare a run against the rolling baseline: the median of the last
+// `window` prior runs for the same model+task. `prior` is newest-first.
+// Sigma combines the run's stderr with the median baseline stderr.
+export function compareToRollingBaseline(
+  current: { value: number; stderr: number },
+  prior: { value: number; stderr: number }[],
+  window: number = BASELINE_WINDOW
+): BaselineComparison | null {
+  const sample = prior.slice(0, Math.max(0, window));
+  const baseline = median(sample.map((p) => p.value));
+  if (baseline === null) return null;
+  const baseStderr = median(sample.map((p) => p.stderr)) ?? 0;
+  const delta = current.value - baseline;
+  const combined = Math.sqrt(current.stderr ** 2 + baseStderr ** 2);
+  const sigma = combined > 0 ? Math.abs(delta) / combined : 0;
+  const flagged = Math.abs(delta) > Math.max(2 * current.stderr, FLAG_FLOOR);
+  return { baseline, baselineCount: sample.length, delta, sigma, flagged };
+}
+
 export async function loadEvalRows({
   model,
   task,
   image,
   images,
 }: EvalRowsQuery = {}): Promise<EvalRow[]> {
-  const conditions = [
-    "(message:results IS NOT NULL OR message:data:results IS NOT NULL)",
-  ];
-  if (model) {
-    const esc = escapeSqlString(model);
-    conditions.push(
-      `(message:config:model_args:model::STRING = '${esc}' OR message:data:config:model_args:model::STRING = '${esc}' OR message:config:model_args::STRING LIKE '%model=${esc}%' OR message:data:config:model_args::STRING LIKE '%model=${esc}%')`
-    );
-  }
+  const conditions = buildConditions(model);
 
   const rawRows = await queryDatabricks<RawRow>(`
     SELECT
@@ -200,6 +291,7 @@ export async function loadEvalRows({
         buildkite_commit: raw.buildkite_commit ?? null,
         vllm_commit: raw.vllm_commit ?? null,
         workload,
+        duplicateCount: 1,
       };
 
       out.push(row);
@@ -214,8 +306,39 @@ export async function loadEvalRows({
   );
 
   const imageValues = [...(images ?? []), image ?? ""].filter(Boolean);
-  if (imageValues.length === 0) return out;
+  if (imageValues.length === 0) return dedupeEvalRows(out);
 
   const imageSet = new Set(imageValues);
-  return out.filter((row) => row.image !== null && imageSet.has(row.image));
+  return dedupeEvalRows(
+    out.filter((row) => row.image !== null && imageSet.has(row.image))
+  );
+}
+
+// Distinct task count over the full filtered dataset. The rows query is
+// truncated by Databricks INLINE limits, so client-side counting only sees
+// the first page. Selecting just the results map keeps the payload small
+// enough to count every task server-side. The image filter is resolved in
+// JS and cannot be pushed into SQL, so it is not applied here.
+export async function loadEvalTaskCount({
+  model,
+  task,
+}: Pick<EvalRowsQuery, "model" | "task"> = {}): Promise<number> {
+  const conditions = buildConditions(model);
+  const rows = await queryDatabricks<{ r: string | null }>(`
+    SELECT CAST(COALESCE(message:results, message:data:results) AS STRING) AS r
+    FROM vllm_data_warehouse.default.vllm_eval_data_ingest
+    WHERE ${conditions.join(" AND ")}
+  `);
+  const tasks = new Set<string>();
+  for (const row of rows) {
+    if (!row.r) continue;
+    try {
+      for (const key of Object.keys(JSON.parse(row.r))) {
+        if (!task || key === task) tasks.add(key);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return tasks.size;
 }


### PR DESCRIPTION
## What

- **Dedupe eval runs.** CI ingests the same lm-eval result multiple times, so `/eval` showed four identical rows for e.g. `openai/gpt-oss-120b` / `gsm8k` / commit `33898f8`. Runs with the same (model, task, commit, image, score, stderr, n_samples) within a 10-minute window are now collapsed into the earliest one; the run list shows a `×N` badge next to the time when N > 1.
- **Rolling baseline instead of previous-run diff.** Regression watch and the per-task stat cards compared only to the immediately previous run, which is noisy with duplicate ingests. Both now compare against the median of the last K=5 runs for the same model+task (excluding current). A change is flagged when `|current − baseline| > max(2 × stderr, 1 pp)`, and sigma is computed against the baseline (combined stderr of the run and the median baseline stderr). The math lives in `src/lib/eval-data.ts` (`compareToRollingBaseline`, `median`) with unit tests.
- **Fix Tasks stat.** The rows query is silently truncated by the Databricks INLINE result limit, so the unfiltered dataset only contained recent `gsm8k` rows — the Tasks stat showed 1 while the filter offers 12. `/api/eval` now also returns a `taskCount` computed from a lightweight query over the full filtered dataset (selects only the results map, not full message JSON), and the overview uses it.

## How verified

- `npm test`: 69 pass (10 new tests in `src/lib/eval-data.test.ts` covering dedupe window/keys, median, and baseline flagging).
- `npm run lint` and `npx tsc --noEmit`: clean.
- Ran the worktree dev server against the real data: unfiltered `/api/eval` went from 974 rows / taskCount 1 → 530 rows / taskCount 12; 66 duplicate groups merged (530 kept, 974 accounted for); `?task=gsm8k` returns taskCount 1 and the same 530 rows; `/eval` page renders 200.

## Notes

- `taskCount` respects model/task filters; the image filter is resolved in JS and cannot be pushed into SQL, so it is not reflected in the count (documented in code).
- Dedupe keeps the earliest run; its samples drawer links to that run's Buildkite build.