### PR TITLE
alerting: retry pending Full CI analyses hourly between scheduled ticks

### DIFF
--- a/alerting/control.py
+++ b/alerting/control.py
@@ -35,7 +35,12 @@ class UnitControl(Protocol):
 
 _UNITS = {
     AlertPath.FAST_CI: (("alerting-fast-ci.timer", "alerting-fast-ci.service"),),
-    AlertPath.FULL_CI: (("alerting-full-ci.timer", "alerting-full-ci.service"),),
+    AlertPath.FULL_CI: (
+        ("alerting-full-ci.timer", "alerting-full-ci.service"),
+        # The hourly retry sidecar follows the Full CI control: disabling the
+        # path also stops retries of failed or pending analyses.
+        ("alerting-full-ci-retry.timer", "alerting-full-ci-retry.service"),
+    ),
     # The analysis sidecar follows the Main CI control: disabling the path
     # stops both its lifecycle reconciliation and its AI analysis. The hourly
     # backstop sweep follows the same control.

--- a/alerting/docs/full-ci.md
+++ b/alerting/docs/full-ci.md
@@ -22,6 +22,10 @@ analysis report.
 - Deployment: `deploy/aws/systemd/alerting-full-ci.timer` fires at 05:00
   and 19:00 `America/Los_Angeles`; `alerting-full-ci.service` runs
   `run-worker full-ci` and then `run-worker full-ci-analyze` in one tick.
+  `alerting-full-ci-retry.timer` additionally fires the analyzer hourly
+  (`*:43` UTC) so a failed or still-pending analysis is retried within an
+  hour instead of waiting for the next twice-daily tick; it skips while the
+  scheduled run is active.
 
 ## Configuration
 

--- a/alerting/tests/test_control.py
+++ b/alerting/tests/test_control.py
@@ -69,6 +69,7 @@ def test_reconcile_controls_defaults_missing_path_to_shadow_and_disables_one_pat
     assert units.enabled == ["alerting-fast-ci.timer"]
     assert units.disabled == [
         "alerting-full-ci.timer",
+        "alerting-full-ci-retry.timer",
         "alerting-main-ci.timer",
         "alerting-main-ci-analysis.timer",
         "alerting-main-ci-backstop.timer",
@@ -76,6 +77,7 @@ def test_reconcile_controls_defaults_missing_path_to_shadow_and_disables_one_pat
     ]
     assert units.stopped == [
         "alerting-full-ci.service",
+        "alerting-full-ci-retry.service",
         "alerting-main-ci.service",
         "alerting-main-ci-analysis.service",
         "alerting-main-ci-backstop.service",
@@ -97,7 +99,10 @@ def test_live_control_enables_only_selected_path(tmp_path: Path) -> None:
     reconcile_controls(controls=controls, units=units, mode_dir=tmp_path)
 
     assert (tmp_path / "full-ci.mode").read_text() == ("ALERTING_DELIVERY_MODE=live\n")
-    assert units.enabled == ["alerting-full-ci.timer"]
+    assert units.enabled == [
+        "alerting-full-ci.timer",
+        "alerting-full-ci-retry.timer",
+    ]
 
 
 def test_main_ci_live_control_enables_its_independent_timers(tmp_path: Path) -> None:

--- a/deploy/aws/systemd/alerting-full-ci-retry.service
+++ b/deploy/aws/systemd/alerting-full-ci-retry.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Retry pending Full CI analyses between scheduled ticks
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=alerting
+Group=alerting
+# Skip while the scheduled twice-daily run is active: its analyze phase
+# already drains pending comparisons, and concurrent runs duplicate LLM work.
+ExecStartPre=/bin/bash -c '! systemctl is-active --quiet alerting-full-ci.service'
+ExecStart=/opt/alerting/bin/run-worker full-ci-analyze
+StandardOutput=null
+StandardError=null
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+TimeoutStartSec=infinity

--- a/deploy/aws/systemd/alerting-full-ci-retry.timer
+++ b/deploy/aws/systemd/alerting-full-ci-retry.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Retry pending Full CI analyses hourly between scheduled ticks
+
+[Timer]
+OnBootSec=5min
+OnCalendar=*-*-* *:43:00 UTC
+Persistent=true
+AccuracySec=1min
+RandomizedDelaySec=0
+Unit=alerting-full-ci-retry.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/aws/tests/test_alerting_worker_infrastructure.py
+++ b/deploy/aws/tests/test_alerting_worker_infrastructure.py
@@ -58,6 +58,26 @@ def test_fast_ci_timer_uses_pacific_wall_clock_every_fifteen_minutes() -> None:
     assert "Persistent=true" in timer
 
 
+def test_full_ci_retry_timer_retries_analyses_hourly_without_overlapping() -> None:
+    timer = read("systemd/alerting-full-ci-retry.timer")
+    service = read("systemd/alerting-full-ci-retry.service")
+
+    assert "OnCalendar=*-*-* *:43:00 UTC" in timer
+    assert "OnBootSec=" in timer
+    assert "Persistent=true" in timer
+    assert "Unit=alerting-full-ci-retry.service" in timer
+    # Analyze-only: reconciliation stays on the twice-daily Pacific schedule.
+    assert "run-worker full-ci-analyze" in service
+    assert "run-worker full-ci\n" not in service
+    # Skip while the scheduled run is active so retries never duplicate an
+    # in-progress analysis.
+    assert "systemctl is-active --quiet alerting-full-ci.service" in service
+    assert "StandardOutput=null" in service
+    assert "StandardError=null" in service
+    for sensitive_name in ("DATABASE_URL", "TOKEN", "PASSWORD"):
+        assert sensitive_name not in service + timer
+
+
 def test_main_ci_timer_polls_every_two_minutes_and_recovers_after_downtime() -> None:
     timer = read("systemd/alerting-main-ci.timer")
 


### PR DESCRIPTION
## Problem

A failed Full CI analysis only retried at the next twice-daily tick (05:00 / 19:00 PT), so one failure could delay a report by up to 12 hours and go unnoticed — this happened today with the #87024 nightly report.

## Change

- **`alerting-full-ci-retry.timer`** fires hourly at `*:43` UTC and runs `run-worker full-ci-analyze` only — reconciliation stays on the Pacific schedule. The analyzer already drains pending comparisons oldest-first and is idempotent (`commit_analysis` upserts with `ON CONFLICT DO NOTHING`), so more frequent invocation is safe.
- The retry service **skips while the scheduled `alerting-full-ci.service` is active** (`ExecStartPre` guard) so a retry never duplicates an in-progress analysis.
- The control service registers the retry units under the `full_ci` path, so setting the mode to `disabled` stops retries too.
- Docs updated (`alerting/docs/full-ci.md`).

## Tests

- New infra test pins the retry timer schedule, analyze-only service, overlap guard, and no-secrets properties.
- Control tests updated: retry timer/service follow the `full_ci` mode (enabled when live/shadow, disabled+stopped when disabled).
- `pytest alerting` 199 passed, `deploy/aws` 24 passed, ruff clean, mypy shows only the pre-existing local-venv boto3/stub errors (identical without this change).

## Deploy

Takes effect on the worker after the next `install.sh` run from `main` (ops handbook §9); the control service enables the new timer within a minute of the unit files landing.

Signed-off-by: Thang Nguyen <thang.nguyen@inferact.ai>