### PR TITLE
alerting: bound infra scan queries so they fit the statement timeout

### DIFF
--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -1095,13 +1095,20 @@ class PostgresAlertStore:
         ]
 
     def latest_reports(self) -> list[HostReport]:
-        """Newest gpu or host snapshot receipt per hostname, unbounded."""
+        """Newest gpu or host snapshot receipt per hostname.
+
+        The gpu side is bounded at twice the 7-day retirement age: older
+        last-reports belong to hosts that have already retired, and an
+        unbounded DISTINCT ON over gpu_snapshots (8M+ rows) blows the
+        statement timeout on every scan.
+        """
         with self._connection_factory() as connection:
             rows = connection.execute(
                 """
                 WITH gpu AS (
                     SELECT DISTINCT ON (hostname) hostname, reported_at
                     FROM gpu_snapshots
+                    WHERE reported_at >= now() - interval '14 days'
                     ORDER BY hostname, reported_at DESC
                 ),
                 host AS (
@@ -1175,7 +1182,11 @@ class PostgresAlertStore:
                 SELECT DISTINCT ON (hostname, gpu_index)
                        hostname, gpu_index, temperature_c, reported_at
                 FROM gpu_snapshots
+                -- Stale readings must not sustain temperature breaches (a
+                -- silent host is the unreporting alert's job), and the
+                -- bound keeps the scan off 8M+ rows of history.
                 WHERE temperature_c IS NOT NULL
+                  AND reported_at >= now() - interval '2 days'
                 ORDER BY hostname, gpu_index, reported_at DESC
                 """
             ).fetchall()


### PR DESCRIPTION
## Problem

The infra scan (restored today) has never completed a run: after fixing the Buildkite `read_agents` scope, every scan fails with `canceling statement due to statement timeout`.

Measured on the worker against production data:

| query | result |
|---|---|
| `gpu_snapshots` size | 8,532,264 rows |
| `statement_timeout` | 2min |
| `latest_reports` | 12.3s (passes, but unbounded) |
| `gpu_temperatures` | **times out at 120s** |

Root cause: unbounded `DISTINCT ON` over all of `gpu_snapshots` history.

## Fix

- `gpu_temperatures`: only readings from the last **2 days** count. This is also semantically right — `_plan_gpu_temperature` has no staleness check, so a dead host's last hot reading would otherwise sustain a temperature breach forever; a silent host is the unreporting alert's job.
- `latest_reports` (gpu CTE): bounded at **14 days** = 2× the 7-day `RETIREMENT_AGE`, so retirement aging still sees every last-report it needs while skipping the rest of history.

## Tests

`pytest alerting` 199 passed, ruff clean, mypy shows only the pre-existing local-venv boto3 stub errors (identical without this change). The fake-connection infra tests match on the queries' `SELECT DISTINCT ON` prefix, which is unchanged.

## Deploy

Worker picks this up on the next `install.sh` from `main`; after that the 5-minute infra scan should go green and we can flip `control/infra.mode` to `live`.

Signed-off-by: Thang Nguyen <thang.nguyen@inferact.ai>