### PR TITLE
alerting: derive the infra expected-hosts roster from reporters, not Buildkite

### DIFF
--- a/alerting/docs/infra.md
+++ b/alerting/docs/infra.md
@@ -30,8 +30,7 @@ episode.
 
 - `alerting/infra.py` — the slice: records, the pure `plan_infra_scan`
   planner, renderers, `InfraScanHandler`, and the production sources
-  (`KubectlNodesSource`, `BuildkiteGpuQueueAgentsSource`,
-  `UnionExpectedHostSource`).
+  (`KubectlNodesSource`, `UnionExpectedHostSource`).
 - Ports/adapters: `InfraSnapshotPort` + `InfraStore` implemented by
   `alerting/postgres.py` (`PostgresAlertStore`), with in-memory doubles in
   `alerting/memory.py`.
@@ -47,14 +46,16 @@ episode.
 - The expected-host set is the union of: Kubernetes node names from both
   clusters (`GPU_REPORTER_KUBECONFIG_H100`, `GPU_REPORTER_KUBECONFIG_DGX` —
   **optional**; unset means the kubectl source is skipped, set-but-failing
-  fails the scan closed), Buildkite agents in the `gpu` queue
-  (`BUILDKITE_TOKEN`, hostname lowercased), and hostnames seen in
-  `gpu_snapshots` within the last 7 days. All hostnames are lowercased.
-  Note: the stock alerting worker's security group allows egress only on
-  443/5432/6543, so cluster API servers (6443) are unreachable from it and
-  the kubectl sources are normally skipped — coverage is preserved because
-  the control-plane scrapers report every cluster node (a dead scraper
-  silences, and therefore alerts, its whole cluster).
+  fails the scan closed) and hostnames seen in `gpu_snapshots` within the
+  last 7 days. All hostnames are lowercased. The Buildkite `gpu`-queue
+  agents roster was dropped: the fleet's queue is ephemeral pods and
+  autoscaled CI instances that never run reporters, so it only produced
+  never-reported noise. Note: the stock alerting worker's security group
+  allows egress only on 443/5432/6543, so cluster API servers (6443) are
+  unreachable from it and the kubectl sources are normally skipped —
+  coverage is preserved because the control-plane scrapers report every
+  cluster node (a dead scraper silences, and therefore alerts, its whole
+  cluster).
 - Slack: `SLACK_BOT_TOKEN`; channel `SLACK_CI_INFRA_ALERT_CHANNEL` (falls
   back to the shared alerts channel `C0ABTNM9L5U` until the secret exists).
 - Control plane: S3 `control/infra.mode` (`shadow` default / `live` /

--- a/alerting/full_ci.py
+++ b/alerting/full_ci.py
@@ -113,7 +113,6 @@ class BuildkiteRestClient:
     """Read-only Buildkite REST client for Full CI build and job pages."""
 
     _BUILDS_URL = "https://api.buildkite.com/v2/organizations/vllm/pipelines/ci/builds"
-    _AGENTS_URL = "https://api.buildkite.com/v2/organizations/vllm/agents"
 
     def __init__(self, *, token: str) -> None:
         self._token = token
@@ -249,23 +248,6 @@ class BuildkiteRestClient:
         if not isinstance(payload, dict):
             raise RuntimeError("Buildkite build response was not an object")
         return cast(dict[str, Any], payload)
-
-    def list_agents(self, *, queue: str) -> list[dict[str, Any]]:
-        """Agents in one cluster queue, paginating the agents endpoint."""
-        agents: list[dict[str, Any]] = []
-        page = 1
-        while True:
-            query = urllib.parse.urlencode(
-                {"queue": queue, "per_page": 100, "page": page}
-            )
-            payload = self._get_json(f"{self._AGENTS_URL}?{query}")
-            if not isinstance(payload, list):
-                raise RuntimeError("Buildkite agents response was not a list")
-            rows = cast(list[dict[str, Any]], payload)
-            agents.extend(rows)
-            if len(rows) < 100:
-                return agents
-            page += 1
 
 
 class BuildkiteFullCISource:

--- a/alerting/infra.py
+++ b/alerting/infra.py
@@ -700,6 +700,10 @@ class InfraScanHandler:
 
     def __call__(self, command: ScheduledCommand) -> HandlerCompletion:
         now = command.target_time
+        # The roster is reporter-derived: hosts seen in the retirement window
+        # are the fleet that can silently die. External inventories (Buildkite
+        # gpu-queue agents) proved to be ephemeral pods and autoscaled CI
+        # instances that never run reporters — pure never-reported noise.
         expected = frozenset(
             hostname.lower()
             for hostname in self._hosts.expected_hosts()
@@ -797,28 +801,4 @@ class KubectlNodesSource:
             and isinstance(item.get("metadata"), dict)
             for name in [str(item["metadata"].get("name") or "").strip().lower()]
             if name
-        )
-
-
-class BuildkiteAgentPort(Protocol):
-    def list_agents(self, *, queue: str) -> list[dict[str, Any]]: ...
-
-
-class BuildkiteGpuQueueAgentsSource:
-    """GPU-queue Buildkite agents, keyed by their lowercased hostname.
-
-    These cover the bare-metal hosts that run reporters without being
-    Kubernetes nodes.
-    """
-
-    def __init__(self, *, buildkite: BuildkiteAgentPort, queue: str = "gpu") -> None:
-        self._buildkite = buildkite
-        self._queue = queue
-
-    def expected_hosts(self) -> frozenset[str]:
-        return frozenset(
-            hostname
-            for agent in self._buildkite.list_agents(queue=self._queue)
-            for hostname in [str(agent.get("hostname") or "").strip().lower()]
-            if hostname
         )

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -1095,13 +1095,20 @@ class PostgresAlertStore:
         ]
 
     def latest_reports(self) -> list[HostReport]:
-        """Newest gpu or host snapshot receipt per hostname, unbounded."""
+        """Newest gpu or host snapshot receipt per hostname.
+
+        The gpu side is bounded at twice the 7-day retirement age: older
+        last-reports belong to hosts that have already retired, and an
+        unbounded DISTINCT ON over gpu_snapshots (8M+ rows) blows the
+        statement timeout on every scan.
+        """
         with self._connection_factory() as connection:
             rows = connection.execute(
                 """
                 WITH gpu AS (
                     SELECT DISTINCT ON (hostname) hostname, reported_at
                     FROM gpu_snapshots
+                    WHERE reported_at >= now() - interval '14 days'
                     ORDER BY hostname, reported_at DESC
                 ),
                 host AS (
@@ -1175,7 +1182,11 @@ class PostgresAlertStore:
                 SELECT DISTINCT ON (hostname, gpu_index)
                        hostname, gpu_index, temperature_c, reported_at
                 FROM gpu_snapshots
+                -- Stale readings must not sustain temperature breaches (a
+                -- silent host is the unreporting alert's job), and the
+                -- bound keeps the scan off 8M+ rows of history.
                 WHERE temperature_c IS NOT NULL
+                  AND reported_at >= now() - interval '2 days'
                 ORDER BY hostname, gpu_index, reported_at DESC
                 """
             ).fetchall()

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -1928,17 +1928,19 @@ def build_main_ci_backstop_runtime(
 def build_infra_runtime(
     *,
     database_url: str,
-    buildkite_token: str,
     kubeconfigs: list[str],
     slack: SlackPort,
     clock: Clock,
     delivery_mode: DeliveryMode = DeliveryMode.LIVE,
-    buildkite_queue: str = "gpu",
 ) -> AlertingRuntime:
-    """Wire the infra health scan: kubectl nodes + GPU-queue agents + Postgres."""
-    from alerting.full_ci import BuildkiteRestClient
+    """Wire the infra health scan: optional kubectl nodes + Postgres.
+
+    The expected-hosts roster is reporter-derived (see InfraScanHandler):
+    the Buildkite gpu-queue agents list was dropped because the fleet's
+    queue is ephemeral pods and autoscaled CI instances that never run
+    reporters, so it only produced never-reported noise.
+    """
     from alerting.infra import (
-        BuildkiteGpuQueueAgentsSource,
         InfraScanHandler,
         KubectlNodesSource,
         UnionExpectedHostSource,
@@ -1946,13 +1948,7 @@ def build_infra_runtime(
 
     store = PostgresAlertStore.from_database_url(database_url)
     hosts = UnionExpectedHostSource(
-        [
-            *(KubectlNodesSource(kubeconfig=path) for path in kubeconfigs),
-            BuildkiteGpuQueueAgentsSource(
-                buildkite=BuildkiteRestClient(token=buildkite_token),
-                queue=buildkite_queue,
-            ),
-        ]
+        [*(KubectlNodesSource(kubeconfig=path) for path in kubeconfigs)]
     )
     handler = InfraScanHandler(
         hosts=hosts,

--- a/alerting/tests/test_infra.py
+++ b/alerting/tests/test_infra.py
@@ -11,10 +11,8 @@ import pytest
 
 from alerting.commands import ScheduledCommand
 from alerting.fast_ci import ALERTS_SLACK_CHANNEL
-from alerting.full_ci import BuildkiteRestClient
 from alerting.infra import (
     RETIREMENT_AGE,
-    BuildkiteGpuQueueAgentsSource,
     DiskMountObservation,
     GpuTemperatureObservation,
     HostReport,
@@ -569,51 +567,6 @@ def test_kubectl_source_fails_closed_on_kubectl_error(
     source = KubectlNodesSource(kubeconfig="/run/alerting/h100.conf")
     with pytest.raises(RuntimeError, match="kubectl get nodes failed"):
         source.expected_hosts()
-
-
-class _FixtureAgentClient:
-    def __init__(self, agents: list[dict[str, Any]]) -> None:
-        self.agents = agents
-        self.queues: list[str] = []
-
-    def list_agents(self, *, queue: str) -> list[dict[str, Any]]:
-        self.queues.append(queue)
-        return self.agents
-
-
-def test_buildkite_agents_source_lowercases_gpu_queue_hostnames() -> None:
-    client = _FixtureAgentClient(
-        [
-            {"hostname": "H200-CI-1"},
-            {"hostname": "h200-ci-2"},
-            {"hostname": "  "},
-            {"name": "no-hostname"},
-        ]
-    )
-
-    source = BuildkiteGpuQueueAgentsSource(buildkite=client)
-    assert source.expected_hosts() == frozenset({"h200-ci-1", "h200-ci-2"})
-    assert client.queues == ["gpu"]
-
-
-class _RecordingAgentsClient(BuildkiteRestClient):
-    def __init__(self) -> None:
-        super().__init__(token="not-used")
-        self.urls: list[str] = []
-
-    def _get_json(self, url: str) -> Any:
-        self.urls.append(url)
-        return []
-
-
-def test_buildkite_rest_client_queries_the_agents_endpoint_with_queue() -> None:
-    client = _RecordingAgentsClient()
-
-    assert client.list_agents(queue="gpu") == []
-    assert client.urls == [
-        "https://api.buildkite.com/v2/organizations/vllm/agents"
-        "?queue=gpu&per_page=100&page=1"
-    ]
 
 
 def test_expected_host_set_is_the_union_of_sources() -> None:

--- a/alerting/tests/test_worker.py
+++ b/alerting/tests/test_worker.py
@@ -117,7 +117,7 @@ def test_infra_timer_uses_its_scan_command(
     assert [command.command_type for command in runtime.commands] == ["infra_scan"]
 
 
-def test_infra_runtime_requires_both_kubeconfigs_and_buildkite_token(
+def test_infra_runtime_passes_kubeconfigs_and_delivery_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -127,7 +127,6 @@ def test_infra_runtime_requires_both_kubeconfigs_and_buildkite_token(
         return RecordingRuntime()
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://example.invalid/alerting")
-    monkeypatch.setenv("BUILDKITE_TOKEN", "bk-token")
     monkeypatch.setenv("GPU_REPORTER_KUBECONFIG_H100", "/run/alerting/h100.conf")
     monkeypatch.setenv("GPU_REPORTER_KUBECONFIG_DGX", "/run/alerting/dgx.conf")
     monkeypatch.setattr(worker, "build_infra_runtime", fake_build)
@@ -138,7 +137,6 @@ def test_infra_runtime_requires_both_kubeconfigs_and_buildkite_token(
         "/run/alerting/h100.conf",
         "/run/alerting/dgx.conf",
     ]
-    assert captured["buildkite_token"] == "bk-token"
     assert captured["delivery_mode"] is DeliveryMode.SHADOW
 
 
@@ -152,7 +150,6 @@ def test_infra_runtime_skips_kubectl_sources_without_kubeconfigs(
         return RecordingRuntime()
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://example.invalid/alerting")
-    monkeypatch.setenv("BUILDKITE_TOKEN", "bk-token")
     monkeypatch.delenv("GPU_REPORTER_KUBECONFIG_H100", raising=False)
     monkeypatch.delenv("GPU_REPORTER_KUBECONFIG_DGX", raising=False)
     monkeypatch.setattr(worker, "build_infra_runtime", fake_build)

--- a/alerting/worker.py
+++ b/alerting/worker.py
@@ -130,7 +130,6 @@ def _runtime(
         ]
         return build_infra_runtime(
             database_url=database_url,
-            buildkite_token=_required_environment("BUILDKITE_TOKEN"),
             kubeconfigs=kubeconfigs,
             slack=_slack(),
             clock=clock,


### PR DESCRIPTION
## Problem

Minutes after enabling infra alerting, the Slack channel was paged for `buildkite-01a068de-…-9bnrw` and `vllm-ci-cpu-vllm-us-central1-b-*` — subjects that can never report.

Inspected the live gpu-queue roster from the worker: the first 100 agents are **ephemeral k8s pod agents** (`buildkite-<uuid>-<rand>`) and **autoscaled EC2 CI instances** (`bk-cpu-queue-premerge-…`, `ip-10-*.ec2.internal`) — none of them run host reporters, and the real reporter hosts (`dgxb200-*`, …) aren't even on the page. As "expected but never reported" subjects they all opened unreporting episodes.

(Infra is currently set to `disabled` to stop the spam while this lands.)

## Fix

The roster is now **reporter-derived**: optional kubectl node lists + every hostname seen in `gpu_snapshots` within the 7-day retirement window (that union already existed in `InfraScanHandler`). Alerting semantics are unchanged for real hosts — a reporter that goes silent still pages within ~15–20 min. What goes away is "never reported" detection, which in this fleet was 100% noise.

Removed as dead code: `BuildkiteGpuQueueAgentsSource`, `BuildkiteAgentPort`, `BuildkiteRestClient.list_agents` (the `read_agents` token scope is no longer needed by the worker), and the infra consumer no longer requires `BUILDKITE_TOKEN`. Docs updated (`alerting/docs/infra.md`).

## Tests

`pytest alerting` 197 passed (2 deleted Buildkite-source tests), ruff clean, mypy shows only the pre-existing local-venv errors (identical without this change).

## Rollout

After merge: redeploy worker (`install.sh` from `main`), delete the bogus open pod episodes from `alerting_infra_alerts`/`alerting_infra_host_states`, then set `control/infra.mode` back to `live`.

Signed-off-by: Thang Nguyen <thang.nguyen@inferact.ai>