### PR TITLE
alerting: resolve infra alerts by editing the open Slack message in place

### DIFF
--- a/alerting/docs/infra.md
+++ b/alerting/docs/infra.md
@@ -23,8 +23,9 @@ Three fleet-health signals, reconciled by one five-minute scan
 
 RAM, load, and network are display-only and never alert. Every episode
 opens only after the breach sustains across `consecutive_scans` and
-resolves on the first healthy observation — exactly two Slack messages per
-episode.
+resolves on the first healthy observation. One Slack message per episode:
+the resolve edits the bot's own open alert in place (chat.update), appending
+the resolution banner; if the original message is gone it posts fresh.
 
 ## Where the code lives
 

--- a/alerting/memory.py
+++ b/alerting/memory.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import copy
 from dataclasses import replace
 from datetime import datetime, timedelta
+from typing import Any, Mapping
 
 from alerting.analyzer import (
     CheckpointRef,
@@ -852,6 +853,7 @@ class RecordingSlackPort:
     def __init__(self, ts: str = "0.0") -> None:
         self.ts = ts
         self.deliveries: list[NotificationIntentRecord] = []
+        self.updates: list[dict[str, Any]] = []
         self._failures: dict[str, list[Exception]] = {}
 
     def fail_next(self, delivery_id: str, error: Exception) -> None:
@@ -863,3 +865,10 @@ class RecordingSlackPort:
             raise queued.pop(0)
         self.deliveries.append(record)
         return self.ts
+
+    def update_message(
+        self, *, channel: str, ts: str, payload: Mapping[str, Any]
+    ) -> None:
+        self.updates.append(
+            {"channel": channel, "ts": ts, "payload": dict(payload)}
+        )

--- a/alerting/ports.py
+++ b/alerting/ports.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, StrEnum
-from typing import Any, Protocol
+from typing import Any, Mapping, Protocol
 
 from alerting.commands import ScheduledCommand
 
@@ -191,3 +191,9 @@ class SlackPort(Protocol):
     """Delivers one outbox record; returns the Slack message timestamp if any."""
 
     def deliver(self, record: NotificationIntentRecord) -> str | None: ...
+
+    def update_message(
+        self, *, channel: str, ts: str, payload: Mapping[str, Any]
+    ) -> None:
+        """Edit a previously posted message in place (chat.update)."""
+        ...

--- a/alerting/runtime.py
+++ b/alerting/runtime.py
@@ -16,6 +16,9 @@ from alerting.ports import (
     ClaimOutcome,
     Clock,
     AutomationExecutionStore,
+    DestinationMode,
+    NotificationIntentRecord,
+    OutboxStatus,
     OutboxStore,
     SlackPermanentError,
     SlackPort,
@@ -132,6 +135,42 @@ class AlertingRuntime:
             self._executions.complete(key, now=self._clock.now())
         return ProcessResult(key, ProcessStatus.COMPLETED)
 
+    def _deliver_or_update(self, record: NotificationIntentRecord) -> str | None:
+        """A resolve record edits its paired open message in place when possible.
+
+        Infra notifications pair as `<base>:open` / `<base>:resolve`; when the
+        open record was delivered via bot token we chat.update that message
+        with the original alert plus the resolution banner instead of posting
+        a second message. Falls back to a fresh post when the original is
+        gone (deleted message, shadow-era open, webhook destination).
+        """
+        if (
+            record.delivery_id.endswith(":resolve")
+            and record.destination_mode is DestinationMode.BOT_TOKEN
+        ):
+            open_record = self._outbox.get_outbox(
+                record.delivery_id[: -len(":resolve")] + ":open"
+            )
+            if (
+                open_record is not None
+                and open_record.status is OutboxStatus.DELIVERED
+                and open_record.slack_ts
+            ):
+                original = str(open_record.payload.get("text") or "")
+                banner = str(record.payload.get("text") or "")
+                try:
+                    self._slack.update_message(
+                        channel=open_record.destination,
+                        ts=open_record.slack_ts,
+                        payload={"text": f"{original}\n\n{banner}"},
+                    )
+                except SlackPermanentError:
+                    # Original message deleted or channel gone: fresh post.
+                    pass
+                else:
+                    return open_record.slack_ts
+        return self._slack.deliver(record)
+
     def dispatch_due_notifications(self, *, limit: int = 50) -> DispatchResult:
         now = self._clock.now()
         if self._stale_notifications is not None:
@@ -145,7 +184,7 @@ class AlertingRuntime:
         delivered = retried = dead_lettered = 0
         for record in records:
             try:
-                slack_ts = self._slack.deliver(record)
+                slack_ts = self._deliver_or_update(record)
             except SlackPermanentError as exc:
                 self._outbox.mark_dead_letter(
                     record.delivery_id, error=str(exc), now=self._clock.now()

--- a/alerting/slack.py
+++ b/alerting/slack.py
@@ -16,6 +16,7 @@ from alerting.ports import (
 )
 
 CHAT_POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage"
+CHAT_UPDATE_URL = "https://slack.com/api/chat.update"
 _TRANSIENT_API_ERRORS = {
     "fatal_error",
     "internal_error",
@@ -144,6 +145,37 @@ class SlackDeliveryPort:
             raise SlackPermanentError(f"Slack rejected message: {error}")
         slack_ts = result.get("ts")
         return slack_ts if isinstance(slack_ts, str) else None
+
+    def update_message(
+        self, *, channel: str, ts: str, payload: Mapping[str, Any]
+    ) -> None:
+        """Edit a message the bot posted earlier (chat.update)."""
+        if not self._bot_token:
+            raise SlackPermanentError("Slack bot token is not configured")
+
+        response = self._http.post(
+            CHAT_UPDATE_URL,
+            headers={
+                "Authorization": f"Bearer {self._bot_token}",
+                "Content-Type": "application/json; charset=utf-8",
+            },
+            payload={"channel": channel, "ts": ts, **payload},
+        )
+        _raise_for_http_failure(response)
+        try:
+            result = json.loads(response.body)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise SlackTransientError("Slack returned an invalid response") from exc
+        if not isinstance(result, dict):
+            raise SlackTransientError("Slack returned an invalid response")
+        if result.get("ok") is not True:
+            error = str(result.get("error", "unknown_error"))
+            if error in _TRANSIENT_API_ERRORS:
+                raise SlackTransientError(
+                    f"Slack could not update message: {error}",
+                    retry_after=_retry_after(response.headers),
+                )
+            raise SlackPermanentError(f"Slack rejected update: {error}")
 
 
 def _raise_for_http_failure(response: HttpResponse) -> None:

--- a/alerting/tests/test_fast_ci.py
+++ b/alerting/tests/test_fast_ci.py
@@ -2,7 +2,7 @@
 
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Mapping
 
 from alerting.commands import ScheduledCommand
 from alerting.fast_ci import (
@@ -49,6 +49,11 @@ class RecordingDatabricks:
 
 class UnavailableSlackPort:
     def deliver(self, _record: NotificationIntentRecord) -> str | None:
+        raise RuntimeError("slack unavailable")
+
+    def update_message(
+        self, *, channel: str, ts: str, payload: Mapping[str, Any]
+    ) -> None:
         raise RuntimeError("slack unavailable")
 
 

--- a/alerting/tests/test_infra.py
+++ b/alerting/tests/test_infra.py
@@ -193,7 +193,7 @@ def test_episode_opens_on_second_consecutive_silent_scan_not_the_first() -> None
     assert "down" not in text.lower()
 
 
-def test_first_fresh_report_resolves_episode_with_exactly_two_messages() -> None:
+def test_first_fresh_report_resolves_episode_by_editing_the_open_message() -> None:
     hosts = FixtureHosts({"gpu-h100-01"})
     snapshots = FixtureSnapshots()
     runtime, store, outbox, slack, clock = runtime_for(hosts, snapshots)
@@ -211,9 +211,13 @@ def test_first_fresh_report_resolves_episode_with_exactly_two_messages() -> None
 
     assert [episode.status for episode in store.episodes()] == ["resolved"]
     assert outbox.count() == 2
-    assert len(slack.deliveries) == 2
+    # The resolve edits the bot's open alert in place instead of posting again.
+    assert len(slack.deliveries) == 1
     assert "stopped reporting" in slack.deliveries[0].payload["text"]
-    assert "reporting again" in slack.deliveries[1].payload["text"]
+    assert len(slack.updates) == 1
+    update_text = slack.updates[0]["payload"]["text"]
+    assert "stopped reporting" in update_text
+    assert "reporting again" in update_text
 
 
 def test_reopened_episode_after_resolution_sends_a_new_pair() -> None:
@@ -238,8 +242,9 @@ def test_reopened_episode_after_resolution_sends_a_new_pair() -> None:
     runtime.dispatch_due_notifications()
 
     assert [episode.status for episode in store.episodes()] == ["resolved", "open"]
-    assert len(slack.deliveries) == 3
-    assert "stopped reporting" in slack.deliveries[2].payload["text"]
+    # The first resolve edited open #1 in place, so the reopen is delivery #2.
+    assert len(slack.deliveries) == 2
+    assert "stopped reporting" in slack.deliveries[1].payload["text"]
 
 
 def test_absent_and_silent_host_is_auto_retired_after_seven_days() -> None:
@@ -277,8 +282,9 @@ def test_absent_and_silent_host_is_auto_retired_after_seven_days() -> None:
 
     assert [episode.status for episode in store.episodes()] == ["resolved"]
     assert outbox.count() == 2
-    assert len(slack.deliveries) == 2
-    assert "auto-retired" in slack.deliveries[1].payload["text"]
+    assert len(slack.deliveries) == 1
+    assert len(slack.updates) == 1
+    assert "auto-retired" in slack.updates[0]["payload"]["text"]
 
     # Retired hosts stop alerting even while they stay absent and silent.
     scan(runtime, retire_scan + timedelta(minutes=5))
@@ -411,7 +417,7 @@ def test_shared_nfs_volume_pages_once_regardless_of_mounting_host_count() -> Non
     runtime.dispatch_due_notifications()
     assert [episode.status for episode in store.episodes()] == ["resolved"]
     assert outbox.count() == 2
-    assert "back below" in slack.deliveries[1].payload["text"]
+    assert "back below" in slack.updates[0]["payload"]["text"]
 
 
 def test_other_role_and_errored_mounts_never_alert() -> None:
@@ -508,7 +514,7 @@ def test_gpu_temperature_requires_sustained_breach_across_scans() -> None:
 
     assert [episode.status for episode in store.episodes()] == ["resolved"]
     assert outbox.count() == 2
-    assert "back below" in slack.deliveries[1].payload["text"]
+    assert "back below" in slack.updates[0]["payload"]["text"]
 
 
 class _FakeCompletedProcess:

--- a/alerting/tests/test_outbox.py
+++ b/alerting/tests/test_outbox.py
@@ -5,6 +5,7 @@ not retry internals.
 """
 
 from datetime import datetime, timezone
+from typing import Any, Mapping
 
 import pytest
 
@@ -40,6 +41,9 @@ class AcceptThenCrashSlackPort:
 
     def deliver(self, record: NotificationIntentRecord) -> str | None:
         self.accepted_delivery_ids.append(record.delivery_id)
+        raise SimulatedWorkerCrash
+
+    def update_message(self, **_kwargs: object) -> None:
         raise SimulatedWorkerCrash
 
 
@@ -374,3 +378,108 @@ def test_replacement_worker_recovers_expired_lease_with_stable_delivery_id() -> 
     assert [item.delivery_id for item in replacement_slack.deliveries] == [
         record.delivery_id
     ]
+
+
+class _RejectingUpdateSlackPort(RecordingSlackPort):
+    def update_message(
+        self, *, channel: str, ts: str, payload: Mapping[str, Any]
+    ) -> None:
+        raise SlackPermanentError("message_not_found")
+
+
+def _infra_pair(outbox: InMemoryOutboxStore, clock: FixedClock) -> None:
+    outbox.enqueue(
+        make_message(
+            "infra:unreporting:abc123:100:open",
+            alert_path=AlertPath.INFRA,
+        ),
+        now=clock.now(),
+    )
+
+
+def test_resolve_record_updates_the_paired_open_message_in_place() -> None:
+    outbox = InMemoryOutboxStore()
+    slack = RecordingSlackPort(ts="1724900000.001")
+    clock = FixedClock(START)
+    runtime = make_runtime(outbox, slack, clock)
+    _infra_pair(outbox, clock)
+    assert runtime.dispatch_due_notifications().delivered == 1
+
+    outbox.enqueue(
+        make_message(
+            "infra:unreporting:abc123:100:resolve",
+            alert_path=AlertPath.INFRA,
+        ),
+        now=clock.now(),
+    )
+    # Resolve payload carries the resolution banner text.
+    record = outbox.get_outbox("infra:unreporting:abc123:100:resolve")
+    assert record is not None
+    record.payload["text"] = "host is reporting again"
+
+    assert runtime.dispatch_due_notifications().delivered == 1
+
+    # No new message: the bot edited its own open alert instead.
+    assert [r.delivery_id for r in slack.deliveries] == [
+        "infra:unreporting:abc123:100:open"
+    ]
+    assert slack.updates == [
+        {
+            "channel": "C0ANHBE642Y",
+            "ts": "1724900000.001",
+            "payload": {
+                "text": "8 jobs failed within 30s\n\nhost is reporting again"
+            },
+        }
+    ]
+    resolved = outbox.get_outbox("infra:unreporting:abc123:100:resolve")
+    assert resolved is not None
+    assert resolved.status is OutboxStatus.DELIVERED
+    assert resolved.slack_ts == "1724900000.001"
+
+
+def test_resolve_without_delivered_open_posts_a_new_message() -> None:
+    outbox = InMemoryOutboxStore()
+    slack = RecordingSlackPort(ts="1724900000.009")
+    clock = FixedClock(START)
+    runtime = make_runtime(outbox, slack, clock)
+    outbox.enqueue(
+        make_message(
+            "infra:unreporting:abc123:100:resolve",
+            alert_path=AlertPath.INFRA,
+        ),
+        now=clock.now(),
+    )
+
+    assert runtime.dispatch_due_notifications().delivered == 1
+
+    assert slack.updates == []
+    assert [r.delivery_id for r in slack.deliveries] == [
+        "infra:unreporting:abc123:100:resolve"
+    ]
+
+
+def test_resolve_falls_back_to_post_when_the_open_message_is_gone() -> None:
+    outbox = InMemoryOutboxStore()
+    slack = _RejectingUpdateSlackPort(ts="1724900000.001")
+    clock = FixedClock(START)
+    runtime = make_runtime(outbox, slack, clock)
+    _infra_pair(outbox, clock)
+    assert runtime.dispatch_due_notifications().delivered == 1
+
+    outbox.enqueue(
+        make_message(
+            "infra:unreporting:abc123:100:resolve",
+            alert_path=AlertPath.INFRA,
+        ),
+        now=clock.now(),
+    )
+    assert runtime.dispatch_due_notifications().delivered == 1
+
+    assert [r.delivery_id for r in slack.deliveries] == [
+        "infra:unreporting:abc123:100:open",
+        "infra:unreporting:abc123:100:resolve",
+    ]
+    resolved = outbox.get_outbox("infra:unreporting:abc123:100:resolve")
+    assert resolved is not None
+    assert resolved.status is OutboxStatus.DELIVERED

--- a/alerting/tests/test_slack.py
+++ b/alerting/tests/test_slack.py
@@ -183,3 +183,39 @@ def test_invalid_slack_payload_is_permanent(
 
     with pytest.raises(SlackPermanentError, match=expected_error):
         slack.deliver(make_record(mode=mode, destination=destination))
+
+
+def test_update_message_posts_to_chat_update_with_channel_and_ts() -> None:
+    http = StubHttpTransport(
+        HttpResponse(status=200, headers={}, body=b'{"ok":true}')
+    )
+    slack = SlackDeliveryPort(bot_token="xoxb-secret", webhook_urls={}, http=http)
+
+    slack.update_message(
+        channel="C0ANHBE642Y",
+        ts="1724900000.001",
+        payload={"text": "alert\n\nresolved"},
+    )
+
+    url, headers, payload = http.requests[0]
+    assert url == "https://slack.com/api/chat.update"
+    assert headers["Authorization"] == "Bearer xoxb-secret"
+    assert payload == {
+        "channel": "C0ANHBE642Y",
+        "ts": "1724900000.001",
+        "text": "alert\n\nresolved",
+    }
+
+
+def test_update_message_rejection_is_permanent() -> None:
+    http = StubHttpTransport(
+        HttpResponse(
+            status=200, headers={}, body=b'{"ok":false,"error":"message_not_found"}'
+        )
+    )
+    slack = SlackDeliveryPort(bot_token="xoxb-secret", webhook_urls={}, http=http)
+
+    with pytest.raises(SlackPermanentError, match="message_not_found"):
+        slack.update_message(
+            channel="C0ANHBE642Y", ts="1724900000.001", payload={"text": "x"}
+        )


### PR DESCRIPTION
## What changes

An infra episode used to produce **two** Slack messages: the 🚨 alert, then a separate ✅ resolve. Now the bot **edits its own open alert** when the episode resolves — the message keeps the original alert text and gains the resolution banner appended below it, so the channel never has stale-looking open alerts.

## How

- Infra notifications already pair as `<base>:open` / `<base>:resolve` and the outbox already stores each message's `slack_ts`.
- New `SlackDeliveryPort.update_message` → Slack `chat.update`, with the same transient/permanent error classification as `chat.postMessage`.
- The dispatch path (`runtime.py`) pairs a `…:resolve` record with its delivered `…:open` record and edits it; the resolve row is marked delivered against the original ts.
- **Fallbacks**: no delivered paired open (shadow-era open, webhook destinations) or a permanent update failure (e.g. someone deleted the message) → posts a fresh message like today. Transient update failures ride the existing outbox retry/backoff.

## Tests

- `test_outbox.py`: pairing edits in place (no second post), missing open → fresh post, permanent update failure → fresh-post fallback
- `test_slack.py`: `chat.update` URL/payload contract, `message_not_found` classified permanent
- `test_infra.py`: episode tests updated for the new one-message behavior
- `pytest alerting` 202 passed, ruff clean, mypy clean except the known local-venv boto3/stub quirks (identical without this change)

## Deploy

Takes effect on the worker after the next `install.sh` from `main`. No schema or config changes.

Signed-off-by: Thang Nguyen <thang.nguyen@inferact.ai>
