### PR TITLE
alerting: strike through resolved infra alerts instead of appending a banner

### DIFF
--- a/alerting/docs/infra.md
+++ b/alerting/docs/infra.md
@@ -24,8 +24,9 @@ Three fleet-health signals, reconciled by one five-minute scan
 RAM, load, and network are display-only and never alert. Every episode
 opens only after the breach sustains across `consecutive_scans` and
 resolves on the first healthy observation. One Slack message per episode:
-the resolve edits the bot's own open alert in place (chat.update), appending
-the resolution banner; if the original message is gone it posts fresh.
+the resolve edits the bot's own open alert in place (chat.update) into a
+✅-prefixed, struck-through copy ending in `(edited)`; if the original
+message is gone it posts fresh.
 
 ## Where the code lives
 

--- a/alerting/runtime.py
+++ b/alerting/runtime.py
@@ -139,10 +139,10 @@ class AlertingRuntime:
         """A resolve record edits its paired open message in place when possible.
 
         Infra notifications pair as `<base>:open` / `<base>:resolve`; when the
-        open record was delivered via bot token we chat.update that message
-        with the original alert plus the resolution banner instead of posting
-        a second message. Falls back to a fresh post when the original is
-        gone (deleted message, shadow-era open, webhook destination).
+        open record was delivered via bot token we chat.update that message to
+        a ✅-prefixed, struck-through copy of the original alert instead of
+        posting a second message. Falls back to a fresh post when the original
+        is gone (deleted message, shadow-era open, webhook destination).
         """
         if (
             record.delivery_id.endswith(":resolve")
@@ -157,12 +157,13 @@ class AlertingRuntime:
                 and open_record.slack_ts
             ):
                 original = str(open_record.payload.get("text") or "")
-                banner = str(record.payload.get("text") or "")
                 try:
                     self._slack.update_message(
                         channel=open_record.destination,
                         ts=open_record.slack_ts,
-                        payload={"text": f"{original}\n\n{banner}"},
+                        payload={
+                            "text": f":white_check_mark: ~{original}~ (edited)"
+                        },
                     )
                 except SlackPermanentError:
                     # Original message deleted or channel gone: fresh post.

--- a/alerting/tests/test_infra.py
+++ b/alerting/tests/test_infra.py
@@ -211,13 +211,14 @@ def test_first_fresh_report_resolves_episode_by_editing_the_open_message() -> No
 
     assert [episode.status for episode in store.episodes()] == ["resolved"]
     assert outbox.count() == 2
-    # The resolve edits the bot's open alert in place instead of posting again.
+    # The resolve strikes through the bot's open alert instead of posting.
     assert len(slack.deliveries) == 1
     assert "stopped reporting" in slack.deliveries[0].payload["text"]
     assert len(slack.updates) == 1
     update_text = slack.updates[0]["payload"]["text"]
+    assert update_text.startswith(":white_check_mark: ~")
     assert "stopped reporting" in update_text
-    assert "reporting again" in update_text
+    assert update_text.endswith("~ (edited)")
 
 
 def test_reopened_episode_after_resolution_sends_a_new_pair() -> None:
@@ -284,7 +285,7 @@ def test_absent_and_silent_host_is_auto_retired_after_seven_days() -> None:
     assert outbox.count() == 2
     assert len(slack.deliveries) == 1
     assert len(slack.updates) == 1
-    assert "auto-retired" in slack.updates[0]["payload"]["text"]
+    assert slack.updates[0]["payload"]["text"].endswith("~ (edited)")
 
     # Retired hosts stop alerting even while they stay absent and silent.
     scan(runtime, retire_scan + timedelta(minutes=5))
@@ -417,7 +418,7 @@ def test_shared_nfs_volume_pages_once_regardless_of_mounting_host_count() -> Non
     runtime.dispatch_due_notifications()
     assert [episode.status for episode in store.episodes()] == ["resolved"]
     assert outbox.count() == 2
-    assert "back below" in slack.updates[0]["payload"]["text"]
+    assert slack.updates[0]["payload"]["text"].endswith("~ (edited)")
 
 
 def test_other_role_and_errored_mounts_never_alert() -> None:
@@ -514,7 +515,7 @@ def test_gpu_temperature_requires_sustained_breach_across_scans() -> None:
 
     assert [episode.status for episode in store.episodes()] == ["resolved"]
     assert outbox.count() == 2
-    assert "back below" in slack.updates[0]["payload"]["text"]
+    assert slack.updates[0]["payload"]["text"].endswith("~ (edited)")
 
 
 class _FakeCompletedProcess:

--- a/alerting/tests/test_outbox.py
+++ b/alerting/tests/test_outbox.py
@@ -412,14 +412,10 @@ def test_resolve_record_updates_the_paired_open_message_in_place() -> None:
         ),
         now=clock.now(),
     )
-    # Resolve payload carries the resolution banner text.
-    record = outbox.get_outbox("infra:unreporting:abc123:100:resolve")
-    assert record is not None
-    record.payload["text"] = "host is reporting again"
 
     assert runtime.dispatch_due_notifications().delivered == 1
 
-    # No new message: the bot edited its own open alert instead.
+    # No new message: the bot struck through its own open alert instead.
     assert [r.delivery_id for r in slack.deliveries] == [
         "infra:unreporting:abc123:100:open"
     ]
@@ -428,7 +424,7 @@ def test_resolve_record_updates_the_paired_open_message_in_place() -> None:
             "channel": "C0ANHBE642Y",
             "ts": "1724900000.001",
             "payload": {
-                "text": "8 jobs failed within 30s\n\nhost is reporting again"
+                "text": ":white_check_mark: ~8 jobs failed within 30s~ (edited)"
             },
         }
     ]


### PR DESCRIPTION
## What changes

Follow-up to #140 with the resolved-message look we want: when an infra episode resolves, the bot's open alert is edited into:

> ✅ ~🚨 Infra alert — host `h200-ci-1` stopped reporting …~ (edited)

— original text struck through, ✅ prefix, `(edited)` suffix. The previous composition (original + appended resolve banner) is gone; that also removes the confusing case where the banner quoted the episode's opening threshold rather than the current one.

## Tests

- `test_outbox.py`: pairing asserts the exact struck-through payload
- `test_infra.py`: resolve assertions now check the ✅/~…~/`(edited)` shape
- `pytest alerting` 202 passed, ruff clean

## Deploy

Worker picks this up on the next `install.sh` from `main`. Only affects how resolves render.

Signed-off-by: Thang Nguyen <thang.nguyen@inferact.ai>
