### PR TITLE
alerting: strike resolved alerts line-by-line, drop our '(edited)' suffix

### DIFF
--- a/alerting/docs/infra.md
+++ b/alerting/docs/infra.md
@@ -25,8 +25,8 @@ RAM, load, and network are display-only and never alert. Every episode
 opens only after the breach sustains across `consecutive_scans` and
 resolves on the first healthy observation. One Slack message per episode:
 the resolve edits the bot's own open alert in place (chat.update) into a
-✅-prefixed, struck-through copy ending in `(edited)`; if the original
-message is gone it posts fresh.
+✅-prefixed copy with each line struck through (Slack adds its own
+`(edited)` marker); if the original message is gone it posts fresh.
 
 ## Where the code lives
 

--- a/alerting/runtime.py
+++ b/alerting/runtime.py
@@ -140,9 +140,10 @@ class AlertingRuntime:
 
         Infra notifications pair as `<base>:open` / `<base>:resolve`; when the
         open record was delivered via bot token we chat.update that message to
-        a ✅-prefixed, struck-through copy of the original alert instead of
-        posting a second message. Falls back to a fresh post when the original
-        is gone (deleted message, shadow-era open, webhook destination).
+        a ✅-prefixed, line-by-line struck-through copy of the original alert
+        instead of posting a second message. Falls back to a fresh post when
+        the original is gone (deleted message, shadow-era open, webhook
+        destination).
         """
         if (
             record.delivery_id.endswith(":resolve")
@@ -157,13 +158,18 @@ class AlertingRuntime:
                 and open_record.slack_ts
             ):
                 original = str(open_record.payload.get("text") or "")
+                # Slack mrkdwn strikethrough does not span line breaks, so
+                # strike each line individually. Slack appends its own
+                # "(edited)" marker to updated messages; don't add another.
+                struck = "\n".join(
+                    f"~{line}~" if line.strip() else line
+                    for line in original.split("\n")
+                )
                 try:
                     self._slack.update_message(
                         channel=open_record.destination,
                         ts=open_record.slack_ts,
-                        payload={
-                            "text": f":white_check_mark: ~{original}~ (edited)"
-                        },
+                        payload={"text": f":white_check_mark: {struck}"},
                     )
                 except SlackPermanentError:
                     # Original message deleted or channel gone: fresh post.

--- a/alerting/tests/test_infra.py
+++ b/alerting/tests/test_infra.py
@@ -218,7 +218,7 @@ def test_first_fresh_report_resolves_episode_by_editing_the_open_message() -> No
     update_text = slack.updates[0]["payload"]["text"]
     assert update_text.startswith(":white_check_mark: ~")
     assert "stopped reporting" in update_text
-    assert update_text.endswith("~ (edited)")
+    assert update_text.endswith("~") and "(edited)" not in update_text
 
 
 def test_reopened_episode_after_resolution_sends_a_new_pair() -> None:
@@ -285,7 +285,7 @@ def test_absent_and_silent_host_is_auto_retired_after_seven_days() -> None:
     assert outbox.count() == 2
     assert len(slack.deliveries) == 1
     assert len(slack.updates) == 1
-    assert slack.updates[0]["payload"]["text"].endswith("~ (edited)")
+    assert slack.updates[0]["payload"]["text"].endswith("~")
 
     # Retired hosts stop alerting even while they stay absent and silent.
     scan(runtime, retire_scan + timedelta(minutes=5))
@@ -418,7 +418,7 @@ def test_shared_nfs_volume_pages_once_regardless_of_mounting_host_count() -> Non
     runtime.dispatch_due_notifications()
     assert [episode.status for episode in store.episodes()] == ["resolved"]
     assert outbox.count() == 2
-    assert slack.updates[0]["payload"]["text"].endswith("~ (edited)")
+    assert slack.updates[0]["payload"]["text"].endswith("~")
 
 
 def test_other_role_and_errored_mounts_never_alert() -> None:
@@ -515,7 +515,7 @@ def test_gpu_temperature_requires_sustained_breach_across_scans() -> None:
 
     assert [episode.status for episode in store.episodes()] == ["resolved"]
     assert outbox.count() == 2
-    assert slack.updates[0]["payload"]["text"].endswith("~ (edited)")
+    assert slack.updates[0]["payload"]["text"].endswith("~")
 
 
 class _FakeCompletedProcess:

--- a/alerting/tests/test_outbox.py
+++ b/alerting/tests/test_outbox.py
@@ -403,6 +403,11 @@ def test_resolve_record_updates_the_paired_open_message_in_place() -> None:
     clock = FixedClock(START)
     runtime = make_runtime(outbox, slack, clock)
     _infra_pair(outbox, clock)
+    # The open alert spans multiple lines; Slack strikethrough must wrap
+    # each line individually to render.
+    open_record = outbox.get_outbox("infra:unreporting:abc123:100:open")
+    assert open_record is not None
+    open_record.payload["text"] = "Infra alert — host stopped reporting\nNo report for over 10 minutes"
     assert runtime.dispatch_due_notifications().delivered == 1
 
     outbox.enqueue(
@@ -416,6 +421,7 @@ def test_resolve_record_updates_the_paired_open_message_in_place() -> None:
     assert runtime.dispatch_due_notifications().delivered == 1
 
     # No new message: the bot struck through its own open alert instead.
+    # Slack appends its own "(edited)" marker; the payload must not add one.
     assert [r.delivery_id for r in slack.deliveries] == [
         "infra:unreporting:abc123:100:open"
     ]
@@ -424,7 +430,7 @@ def test_resolve_record_updates_the_paired_open_message_in_place() -> None:
             "channel": "C0ANHBE642Y",
             "ts": "1724900000.001",
             "payload": {
-                "text": ":white_check_mark: ~8 jobs failed within 30s~ (edited)"
+                "text": ":white_check_mark: ~Infra alert — host stopped reporting~\n~No report for over 10 minutes~"
             },
         }
     ]


### PR DESCRIPTION
## What changes

Two rendering bugs found in the live test of #141:

1. **No strikethrough rendered** — Slack mrkdwn `~…~` does not span line breaks, so a multi-line alert showed literal tildes. Now each line is wrapped individually.
2. **Duplicate `(edited)`** — Slack appends its own `(edited)` marker to updated messages; ours was redundant. Dropped.

Resulting edit: `:white_check_mark: ` + the original alert with each line struck through — Slack adds `(edited)` itself.

## Tests

- The pairing test now uses a **multi-line** alert text and asserts the exact per-line struck-through payload (this is the regression guard for bug 1)
- Episode tests assert the ✅/~…~ shape and the absence of our own `(edited)` suffix
- `pytest alerting` 202 passed, ruff clean

## Deploy

Worker picks this up on the next `install.sh` from `main`.

Signed-off-by: Thang Nguyen <thang.nguyen@inferact.ai>
