### PR TITLE
feat(gpu): sortable Host Summary columns + filter container plumbing mounts

### DIFF
--- a/scripts/gpu-reporter/gpu-reporter-k8s.py
+++ b/scripts/gpu-reporter/gpu-reporter-k8s.py
@@ -88,6 +88,24 @@ CADVISOR_FS_RE = re.compile(
     r'^container_fs_(usage|limit)_bytes\{([^}]*)\}\s+(\S+)'
 )
 
+# cAdvisor rows for container/pod plumbing are noise: overlay_* rows are
+# per-container views duplicating the root filesystem's usage (the real
+# underlying device is reported on its own row, which stays the base), and
+# tmpfs rows use their mount path as the device value, so every pod adds
+# "devices" like /run/containerd/.../shm and kubelet service-account volumes.
+# A busy node accumulates dozens of these (dgxb200-12 had ~20), all empty or
+# duplicates.
+PLUMBING_DEVICE_RE = re.compile(
+    r"^/(run/.+|var/lib/kubelet|sys/fs/cgroup)(/|$)"
+)
+
+
+def is_container_plumbing(device):
+    """True for cAdvisor device values that are container/pod plumbing."""
+    return device.startswith("overlay") or bool(
+        PLUMBING_DEVICE_RE.match(device)
+    )
+
 
 def kubectl(*args, timeout=KUBECTL_TIMEOUT):
     result = subprocess.run(
@@ -329,6 +347,11 @@ def build_disk_entries(node_name, fs_map, rootfs_capacity):
         # skip zero-capacity devices (e.g. unbacked /dev/loopN): nothing can
         # fill them, and the ingestion contract requires total_bytes >= 1.
         if device.startswith("/dev/loop"):
+            continue
+        # Container/pod plumbing: overlays duplicate the root filesystem
+        # (the underlying device is reported on its own row), per-pod tmpfs
+        # paths can never fill. A busy node accumulates dozens of these.
+        if is_container_plumbing(device):
             continue
         if not entry["total_bytes"]:
             continue

--- a/scripts/gpu-reporter/tests/test_gpu_reporter_k8s.py
+++ b/scripts/gpu-reporter/tests/test_gpu_reporter_k8s.py
@@ -193,6 +193,27 @@ def test_loop_devices_are_skipped(reporter_k8s):
     assert [d["device"] for d in disks] == ["/dev/md0"]
 
 
+def test_container_plumbing_devices_are_skipped(reporter_k8s):
+    # Busy nodes report one overlay row per container (duplicating the root
+    # fs usage of /dev/md0) and one tmpfs row per pod sandbox shm /
+    # service-account volume — dgxb200-12 had ~20 of these, all empty or
+    # duplicates. Real mounts (/dev/md0, /dev/shm, /run) stay the base.
+    fs_map = {
+        "/dev/md0": {"used_bytes": 1, "total_bytes": 1800000000000},
+        "overlay_0-569": {"used_bytes": 1, "total_bytes": 1800000000000},
+        "/dev/shm": {"used_bytes": 2, "total_bytes": 1082331758592},
+        "/run": {"used_bytes": 3, "total_bytes": 216466350080},
+        "/run/lock": {"used_bytes": 4, "total_bytes": 5242880},
+        "/run/containerd/io.containerd.grpc.v1.cri/sandboxes/abc123/shm":
+            {"used_bytes": 5, "total_bytes": 67108864},
+        "/var/lib/kubelet/pods/0102f2e2/volumes/"
+        "kubernetes.io~projected/kube-api-access-gjhj7":
+            {"used_bytes": 6, "total_bytes": 2164663500800},
+    }
+    disks = reporter_k8s.build_disk_entries("dgxb200-12", fs_map, 1800000000000)
+    assert [d["device"] for d in disks] == ["/dev/md0", "/dev/shm", "/run"]
+
+
 def test_disk_scrape_cadence(reporter_k8s, monkeypatch):
     calls = []
 

--- a/src/components/gpu-host-table.test.ts
+++ b/src/components/gpu-host-table.test.ts
@@ -289,3 +289,39 @@ test("an empty roster keeps the deployment hint", () => {
 
   assert.match(markup, /No GPU data found/);
 });
+
+test("the drill-down hides container plumbing mounts and says how many", () => {
+  const markup = render(
+    [hostRow()],
+    [
+      hostLatest({
+        disks: [
+          disk({ mount_point: "/" }),
+          disk({ mount_point: "/data", device: "/dev/md127", role: "data" }),
+          disk({ device: "overlay_0-569", mount_point: null, role: "other" }),
+          disk({
+            mount_point:
+              "/run/containerd/io.containerd.grpc.v1.cri/sandboxes/abc123/shm",
+            device: "shm",
+            fstype: "tmpfs",
+            role: "other",
+          }),
+          disk({
+            mount_point:
+              "/var/lib/kubelet/pods/0102f2e2/volumes/kubernetes.io~projected/kube-api-access-gjhj7",
+            device: "tmpfs",
+            fstype: "tmpfs",
+            role: "other",
+          }),
+        ],
+      }),
+    ],
+    "h200-ci-1",
+  );
+
+  assert.match(markup, /\/data/);
+  assert.doesNotMatch(markup, /overlay_0-569/);
+  assert.doesNotMatch(markup, /sandboxes/);
+  assert.doesNotMatch(markup, /kube-api-access/);
+  assert.match(markup, /3 container\/pod mounts hidden/);
+});

--- a/src/components/gpu-host-table.tsx
+++ b/src/components/gpu-host-table.tsx
@@ -7,15 +7,32 @@ import type {
   NormalizedNodeConditions,
 } from "@/lib/gpu-report";
 import {
+  DESCENDING_FIRST_SORT_KEYS,
   hostReportStatus,
   indexHostsByName,
+  isContainerPlumbingMount,
   isRamBackedMount,
+  sortHostRows,
   worstAlertableDisk,
   type HostReportStatus,
   type HostRow,
+  type HostSortKey,
+  type SortDirection,
 } from "@/lib/gpu-host-view";
 
 const COLUMN_COUNT = 9;
+
+const SORTABLE_COLUMNS: { key: HostSortKey; label: string }[] = [
+  { key: "host", label: "Host" },
+  { key: "gpuType", label: "GPU Type" },
+  { key: "gpuUtil", label: "GPU Utilization" },
+  { key: "gpuTemp", label: "GPU Temp" },
+  { key: "gpuMemory", label: "Per-GPU Memory" },
+  { key: "cpu", label: "CPU" },
+  { key: "ram", label: "RAM" },
+  { key: "disk", label: "Disk (worst)" },
+  { key: "lastSeen", label: "Last Seen" },
+];
 
 function formatMemory(mb: number): string {
   if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
@@ -165,14 +182,16 @@ function NodeConditionChips({
 }
 
 function DiskDetail({ disks }: { disks: NormalizedDiskMetric[] | null }) {
-  if (!disks || disks.length === 0) {
+  const visible = disks?.filter((disk) => !isContainerPlumbingMount(disk)) ?? [];
+  const hiddenCount = (disks?.length ?? 0) - visible.length;
+  if (visible.length === 0) {
     return (
       <p className="mt-1 text-xs text-zinc-400">No disk metrics reported.</p>
     );
   }
   return (
     <div className="mt-1 space-y-1.5">
-      {disks.map((disk, index) => {
+      {visible.map((disk, index) => {
         const usedPct =
           disk.used_bytes != null &&
           disk.total_bytes != null &&
@@ -217,6 +236,11 @@ function DiskDetail({ disks }: { disks: NormalizedDiskMetric[] | null }) {
           </div>
         );
       })}
+      {hiddenCount > 0 && (
+        <p className="text-xs text-zinc-400">
+          {hiddenCount} container/pod {hiddenCount === 1 ? "mount" : "mounts"} hidden
+        </p>
+      )}
     </div>
   );
 }
@@ -340,7 +364,23 @@ export function GpuHostTable({
   defaultExpanded = null,
 }: GpuHostTableProps) {
   const [expanded, setExpanded] = useState<string | null>(defaultExpanded);
+  const [sort, setSort] = useState<{ key: HostSortKey; direction: SortDirection }>({
+    key: "host",
+    direction: "asc",
+  });
   const hostsByName = useMemo(() => indexHostsByName(hosts), [hosts]);
+  const sortedRows = useMemo(
+    () => sortHostRows(hostRows, hostsByName, sort.key, sort.direction),
+    [hostRows, hostsByName, sort],
+  );
+
+  function toggleSort(key: HostSortKey) {
+    setSort((current) =>
+      current.key === key
+        ? { key, direction: current.direction === "asc" ? "desc" : "asc" }
+        : { key, direction: DESCENDING_FIRST_SORT_KEYS.has(key) ? "desc" : "asc" },
+    );
+  }
 
   return (
     <div className="min-w-0 overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-none">
@@ -354,19 +394,41 @@ export function GpuHostTable({
         <table className="w-full min-w-[1200px] text-sm">
           <thead>
             <tr className="border-b border-zinc-200 text-left text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
-              <th className="px-5 py-3 font-medium sm:px-6">Host</th>
-              <th className="px-5 py-3 font-medium sm:px-6">GPU Type</th>
-              <th className="px-5 py-3 font-medium sm:px-6">GPU Utilization</th>
-              <th className="px-5 py-3 font-medium sm:px-6">GPU Temp</th>
-              <th className="px-5 py-3 font-medium sm:px-6">Per-GPU Memory</th>
-              <th className="px-5 py-3 font-medium sm:px-6">CPU</th>
-              <th className="px-5 py-3 font-medium sm:px-6">RAM</th>
-              <th className="px-5 py-3 font-medium sm:px-6">Disk (worst)</th>
-              <th className="px-5 py-3 font-medium sm:px-6">Last Seen</th>
+              {SORTABLE_COLUMNS.map((column) => {
+                const active = sort.key === column.key;
+                return (
+                  <th
+                    key={column.key}
+                    aria-sort={
+                      active
+                        ? sort.direction === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : "none"
+                    }
+                    className="px-5 py-3 font-medium sm:px-6"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => toggleSort(column.key)}
+                      className="dashboard-control -mx-2 -my-1 inline-flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+                      title={`Sort by ${column.label}`}
+                    >
+                      {column.label}
+                      <span
+                        aria-hidden="true"
+                        className={`text-xs ${active ? "text-zinc-900 dark:text-zinc-100" : "text-zinc-400 dark:text-zinc-500"}`}
+                      >
+                        {active ? (sort.direction === "asc" ? "▲" : "▼") : "⇅"}
+                      </span>
+                    </button>
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody>
-            {hostRows.map((h) => {
+            {sortedRows.map((h) => {
               const host = hostsByName.get(h.hostname);
               const agent = agents?.get(h.hostname);
               const gpuUtil =

--- a/src/lib/gpu-host-view.test.ts
+++ b/src/lib/gpu-host-view.test.ts
@@ -7,7 +7,9 @@ import {
   diskUsedPct,
   hostReportStatus,
   indexHostsByName,
+  isContainerPlumbingMount,
   isRamBackedMount,
+  sortHostRows,
   worstAlertableDisk,
 } from "./gpu-host-view";
 import type { GpuLatest, HostLatest } from "./gpu-types";
@@ -168,6 +170,33 @@ test("isRamBackedMount flags tmpfs and ramfs only", () => {
   assert.equal(isRamBackedMount(disk({ fstype: "overlay" })), false);
 });
 
+test("isContainerPlumbingMount hides pod plumbing but keeps real mounts", () => {
+  // Overlay snapshots duplicate the underlying disk.
+  assert.equal(
+    isContainerPlumbingMount(disk({ device: "overlay_0-569", mount_point: null })),
+    true,
+  );
+  // Per-container shm and kubelet service-account volumes multiply per pod.
+  assert.equal(
+    isContainerPlumbingMount(
+      disk({ mount_point: "/run/containerd/io.containerd.grpc.v1.cri/sandboxes/abc/shm" }),
+    ),
+    true,
+  );
+  assert.equal(
+    isContainerPlumbingMount(
+      disk({ mount_point: "/var/lib/kubelet/pods/0102f2e2/volumes/kubernetes.io~projected/kube-api-access-gjhj7" }),
+    ),
+    true,
+  );
+  assert.equal(isContainerPlumbingMount(disk({ mount_point: "/run/lock" })), true);
+  // Real host mounts stay visible.
+  assert.equal(isContainerPlumbingMount(disk({ mount_point: "/" })), false);
+  assert.equal(isContainerPlumbingMount(disk({ mount_point: "/data" })), false);
+  assert.equal(isContainerPlumbingMount(disk({ mount_point: "/dev/shm" })), false);
+  assert.equal(isContainerPlumbingMount(disk({ mount_point: "/run" })), false);
+});
+
 function hostLatest(overrides: Partial<HostLatest> = {}): HostLatest {
   return {
     hostname: "h200-ci-1",
@@ -194,4 +223,72 @@ test("indexHostsByName keeps one row per host, the newest one", () => {
   assert.equal(map.size, 2);
   assert.equal(map.get("h200-ci-1")?.cpu_util, 55);
   assert.equal(map.get("h200-ci-2")?.cpu_util, 42);
+});
+
+function sortableFixture(): { rows: ReturnType<typeof buildHostRows>; hosts: Map<string, HostLatest> } {
+  const rows = buildHostRows(
+    [
+      gpu({ hostname: "h200-ci-1", gpu_util: 20, temperature_c: 61, mem_used_mb: 1000 }),
+      gpu({ hostname: "h200-ci-2", gpu_util: 90, temperature_c: null, mem_used_mb: 2000 }),
+      gpu({ hostname: "dgxb200-01", gpu_util: 50, temperature_c: 75, mem_used_mb: 500 }),
+    ],
+    gpuType,
+  );
+  const hosts = indexHostsByName([
+    hostLatest({ hostname: "h200-ci-1", cpu_util: 42 }),
+    hostLatest({
+      hostname: "h200-ci-2",
+      cpu_util: 10,
+      disks: [disk({ mount_point: "/data", role: "data", used_bytes: 90, total_bytes: 100 })],
+    }),
+  ]);
+  return { rows, hosts };
+}
+
+test("sortHostRows orders by average GPU utilization in both directions", () => {
+  const { rows, hosts } = sortableFixture();
+  assert.deepEqual(
+    sortHostRows(rows, hosts, "gpuUtil", "desc").map((r) => r.hostname),
+    ["h200-ci-2", "dgxb200-01", "h200-ci-1"],
+  );
+  assert.deepEqual(
+    sortHostRows(rows, hosts, "gpuUtil", "asc").map((r) => r.hostname),
+    ["h200-ci-1", "dgxb200-01", "h200-ci-2"],
+  );
+});
+
+test("sortHostRows keeps rows with no value last in both directions", () => {
+  const { rows, hosts } = sortableFixture();
+  assert.deepEqual(
+    sortHostRows(rows, hosts, "gpuTemp", "desc").map((r) => r.hostname),
+    ["dgxb200-01", "h200-ci-1", "h200-ci-2"],
+  );
+  assert.deepEqual(
+    sortHostRows(rows, hosts, "gpuTemp", "asc").map((r) => r.hostname),
+    ["h200-ci-1", "dgxb200-01", "h200-ci-2"],
+  );
+});
+
+test("sortHostRows reads host-level metrics from the joined host row", () => {
+  const { rows, hosts } = sortableFixture();
+  // dgxb200-01 has no host row at all, so it sorts last on cpu; on disk both
+  // h200-ci-1 (no disks reported) and dgxb200-01 are null and tie-break by name.
+  assert.deepEqual(
+    sortHostRows(rows, hosts, "cpu", "desc").map((r) => r.hostname),
+    ["h200-ci-1", "h200-ci-2", "dgxb200-01"],
+  );
+  assert.deepEqual(
+    sortHostRows(rows, hosts, "disk", "desc").map((r) => r.hostname),
+    ["h200-ci-2", "dgxb200-01", "h200-ci-1"],
+  );
+});
+
+test("sortHostRows sorts hostnames alphabetically and never mutates the input", () => {
+  const { rows, hosts } = sortableFixture();
+  const before = rows.map((r) => r.hostname);
+  assert.deepEqual(
+    sortHostRows(rows, hosts, "host", "desc").map((r) => r.hostname),
+    ["h200-ci-2", "h200-ci-1", "dgxb200-01"],
+  );
+  assert.deepEqual(rows.map((r) => r.hostname), before);
 });

--- a/src/lib/gpu-host-view.ts
+++ b/src/lib/gpu-host-view.ts
@@ -107,7 +107,8 @@ export function buildHostRows(
 /**
  * Disk roles that can fill up a job and therefore drive alerting and the
  * summary Disk cell. "other" mounts (cgroup, tmpfs snapshots, container
- * plumbing) are shown in the drill-down but never drive the cell.
+ * plumbing) never drive the cell, and the container-plumbing ones are hidden
+ * from the drill-down entirely — see isContainerPlumbingMount.
  */
 export const ALERTABLE_DISK_ROLES: readonly DiskRole[] = [
   "workspace",
@@ -115,6 +116,21 @@ export const ALERTABLE_DISK_ROLES: readonly DiskRole[] = [
   "data",
   "system",
 ];
+
+/**
+ * Mounts that are container or pod plumbing rather than real host storage:
+ * overlay snapshots of the root filesystem, per-container shm mounts, kubelet
+ * projected service-account volumes. They duplicate a real mount (an overlay
+ * shows the same usage as the underlying disk) or can never fill up, and a
+ * busy node accumulates dozens of them, so the drill-down filters them out.
+ */
+export function isContainerPlumbingMount(
+  disk: Pick<NormalizedDiskMetric, "mount_point" | "device">,
+): boolean {
+  if (disk.device?.startsWith("overlay")) return true;
+  const mount = disk.mount_point ?? "";
+  return /^\/(run\/.+|var\/lib\/kubelet|sys\/fs\/cgroup)(\/|$)/.test(mount);
+}
 
 /** RAM-backed filesystems consume memory, not disk; the UI labels them. */
 export function isRamBackedMount(disk: Pick<NormalizedDiskMetric, "fstype">): boolean {
@@ -168,4 +184,86 @@ export function indexHostsByName(hosts: HostLatest[]): Map<string, HostLatest> {
     }
   }
   return map;
+}
+
+export type HostSortKey =
+  | "host"
+  | "gpuType"
+  | "gpuUtil"
+  | "gpuTemp"
+  | "gpuMemory"
+  | "cpu"
+  | "ram"
+  | "disk"
+  | "lastSeen";
+
+export type SortDirection = "asc" | "desc";
+
+/** Sort keys whose useful first click is highest-first; the rest sort A→Z. */
+export const DESCENDING_FIRST_SORT_KEYS: ReadonlySet<HostSortKey> = new Set([
+  "gpuUtil",
+  "gpuTemp",
+  "gpuMemory",
+  "cpu",
+  "ram",
+  "disk",
+  "lastSeen",
+]);
+
+function hostSortValue(
+  row: HostRow,
+  host: HostLatest | undefined,
+  key: HostSortKey,
+): string | number | null {
+  switch (key) {
+    case "host":
+      return row.hostname;
+    case "gpuType":
+      return row.gpuType;
+    case "gpuUtil":
+      return row.gpuCount > 0 ? row.gpuUtil / row.gpuCount : null;
+    case "gpuTemp":
+      return row.maxTemperatureC;
+    case "gpuMemory":
+      return row.memTotalMb > 0 ? (row.memUsedMb / row.memTotalMb) * 100 : null;
+    case "cpu":
+      return host?.cpu_util ?? null;
+    case "ram":
+      return host?.ram_used_bytes != null &&
+        host.ram_total_bytes != null &&
+        host.ram_total_bytes > 0
+        ? (host.ram_used_bytes / host.ram_total_bytes) * 100
+        : null;
+    case "disk":
+      return worstAlertableDisk(host?.disks ?? null)?.usedPct ?? null;
+    case "lastSeen":
+      return Date.parse(row.lastSeen);
+  }
+}
+
+/**
+ * Returns a new array of rows sorted by the given column. Rows with no value
+ * for the column (unreported CPU/RAM/disk, no temperature) always sort last,
+ * regardless of direction, so missing data never masquerades as "best".
+ */
+export function sortHostRows(
+  rows: HostRow[],
+  hostsByName: Map<string, HostLatest>,
+  key: HostSortKey,
+  direction: SortDirection,
+): HostRow[] {
+  const sign = direction === "asc" ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const aValue = hostSortValue(a, hostsByName.get(a.hostname), key);
+    const bValue = hostSortValue(b, hostsByName.get(b.hostname), key);
+    if (aValue == null && bValue == null) return 0;
+    if (aValue == null) return 1;
+    if (bValue == null) return -1;
+    const compared =
+      typeof aValue === "string" && typeof bValue === "string"
+        ? aValue.localeCompare(bValue)
+        : Number(aValue) - Number(bValue);
+    if (compared !== 0) return compared * sign;
+    return a.hostname.localeCompare(b.hostname);
+  });
 }


### PR DESCRIPTION
## What

**/gpu Host Summary table is now sortable.** Every column (Host, GPU Type, GPU Utilization, GPU Temp, Per-GPU Memory, CPU, RAM, Disk (worst), Last Seen) is clickable: first click sorts (highest-first for metric columns, A→Z for text), clicking again toggles direction. Headers show an always-visible `⇅` so it's clear they're sortable, switching to ▲/▼ when active, with `aria-sort` for screen readers. Rows missing a value (unreported CPU/RAM/disk, no temperature) always sort last in both directions.

**Container plumbing mounts are filtered out of disk reporting.** Busy k8s nodes accumulated dozens of noise mounts — `dgxb200-12` showed ~24, mostly 0% per-pod `shm`, kubelet service-account volumes, and `overlay_*` views duplicating the root filesystem. Two layers:

- **Collection** (`gpu-reporter-k8s.py`): `build_disk_entries` now skips overlay devices and paths under `/run/*`, `/var/lib/kubelet`, `/sys/fs/cgroup`. The underlying real device (e.g. `/dev/md0`) remains the single source for that filesystem — no duplicate mounts.
- **Display** (`DiskDetail`): same predicate filters already-stored rows, with a "N container/pod mounts hidden" note.

Already rolled out to both reporter hosts (`h100-cp` for the H100 cluster, `dgxb200-01` for the DGX cluster); `dgxb200-12` now reports exactly `/dev/md0`, `/dev/md127`, `/dev/shm`, `/run`.

## Test plan

- `npm test` (173 passing): new lib tests for `sortHostRows` (both directions, nulls-last, host-metric join, no input mutation) and `isContainerPlumbingMount`; component test that the drill-down hides plumbing mounts and reports the count.
- `pytest scripts/gpu-reporter/tests` (30 passing): `test_container_plumbing_devices_are_skipped` with a fixture modeled on dgxb200-12's cAdvisor output.
- `tsc --noEmit` and `eslint` clean.
- Verified live on both k8s clusters via systemd journal + reporter state file.