### PR TITLE
fix(alerting): restore AMD full CI summary

### DIFF
--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -56,6 +56,9 @@ PACIFIC = ZoneInfo("America/Los_Angeles")
 NON_NVIDIA_JOB = re.compile(
     r"AMD|MI300|Neuron|HPU|Intel|Ascend|NPU|IBM|Torch Nightly", re.IGNORECASE
 )
+# Preserved from the legacy Slack step. MI355 job names carry the ``:amd:``
+# prefix, while older MI300 names are not required to do so.
+AMD_JOB = re.compile(r"AMD|MI300", re.IGNORECASE)
 
 MEMORY_DIR = Path(".claude/agent-memory/vllm-ci-failure-analyzer")
 REPORT_FILE = Path(".logs/ci_report.txt")
@@ -244,11 +247,11 @@ class AnalyzerStore(Protocol):
         self,
         *,
         analysis: CompletedAnalysis,
-        notification: NotificationIntent,
+        notifications: tuple[NotificationIntent, ...],
         now: datetime,
     ) -> None:
         """Atomically persist the analysis, its conditions, the checkpoint
-        reference, and the notification intent. Already-persisted analyses are
+        reference, and its notification intents. Already-persisted analyses are
         a no-op so retried commands cannot duplicate them."""
         ...
 
@@ -344,6 +347,43 @@ def _plain_bullet_names(report_text: str) -> str:
 
 def _hard_failures(jobs: list[FullCIJobOutcome]) -> set[str]:
     return {job.name for job in jobs if job.state == "failed" and not job.soft_failed}
+
+
+def _amd_failure_payload(
+    build: Mapping[str, Any], jobs: list[FullCIJobOutcome]
+) -> dict[str, Any] | None:
+    """Render the separate AMD failure message preserved from production."""
+    amd_jobs = [job for job in jobs if AMD_JOB.search(job.name) is not None]
+    failed = [job for job in amd_jobs if job.state == "failed"]
+    if not failed:
+        return None
+
+    failure_lines = "\n".join(f"• ✗ {job.name}" for job in failed)
+    passed = len(amd_jobs) - len(failed)
+    body = (
+        f"{failure_lines}\n\n"
+        f"*{passed} passed, {len(failed)} failed* — "
+        f"<{build['web_url']}|View build>"
+    )
+    return {
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": (
+                        "🔴 vLLM Full CI — AMD Failures "
+                        f"(Build #{build['number']})"
+                    ),
+                    "emoji": True,
+                },
+            },
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": body},
+            },
+        ]
+    }
 
 
 def _complete_enough(jobs: list[FullCIJobOutcome]) -> bool:
@@ -602,7 +642,7 @@ class FullCIAnalysisHandler:
         raw_jobs = build.get("jobs")
         if not isinstance(raw_jobs, list):
             raise AnalyzerError("Buildkite build JSON has no jobs list")
-        jobs = [
+        all_jobs = [
             FullCIJobOutcome(
                 name=str(job["name"]),
                 state=str(job.get("state") or ""),
@@ -610,8 +650,8 @@ class FullCIAnalysisHandler:
             )
             for job in cast(list[dict[str, Any]], raw_jobs)
             if job.get("name") is not None
-            and NON_NVIDIA_JOB.search(str(job["name"])) is None
         ]
+        jobs = [job for job in all_jobs if NON_NVIDIA_JOB.search(job.name) is None]
         if not _complete_enough(jobs):
             return False  # newer comparisons cannot overtake this baseline
 
@@ -667,6 +707,30 @@ class FullCIAnalysisHandler:
             )
             conditions = self._classify(context, jobs, cache, outputs)
             checkpoint = self._checkpoints.upload(_read_memory(workdir))
+            notifications = [
+                NotificationIntent(
+                    delivery_id=f"full-ci:{context.current.build_id}",
+                    alert_ref=f"full-ci-comparison:{context.current.build_id}",
+                    alert_path=AlertPath.FULL_CI,
+                    delivery_mode=self._delivery_mode,
+                    destination_mode=DestinationMode.BOT_TOKEN,
+                    destination=full_ci_slack_channel(),
+                    payload={"text": outputs.report_text},
+                )
+            ]
+            amd_payload = _amd_failure_payload(build, all_jobs)
+            if amd_payload is not None:
+                notifications.append(
+                    NotificationIntent(
+                        delivery_id=f"full-ci-amd:{context.current.build_id}",
+                        alert_ref=f"full-ci-comparison:{context.current.build_id}",
+                        alert_path=AlertPath.FULL_CI,
+                        delivery_mode=self._delivery_mode,
+                        destination_mode=DestinationMode.BOT_TOKEN,
+                        destination=full_ci_slack_channel(),
+                        payload=amd_payload,
+                    )
+                )
             self._store.commit_analysis(
                 analysis=CompletedAnalysis(
                     current_build_id=context.current.build_id,
@@ -678,15 +742,7 @@ class FullCIAnalysisHandler:
                     checkpoint=checkpoint,
                     commit_pull_request=commit_pull_request,
                 ),
-                notification=NotificationIntent(
-                    delivery_id=f"full-ci:{context.current.build_id}",
-                    alert_ref=f"full-ci-comparison:{context.current.build_id}",
-                    alert_path=AlertPath.FULL_CI,
-                    delivery_mode=self._delivery_mode,
-                    destination_mode=DestinationMode.BOT_TOKEN,
-                    destination=full_ci_slack_channel(),
-                    payload={"text": outputs.report_text},
-                ),
+                notifications=tuple(notifications),
                 now=self._clock.now(),
             )
         return True

--- a/alerting/docs/full-ci.md
+++ b/alerting/docs/full-ci.md
@@ -8,9 +8,10 @@ compares to its chronological predecessor. The ingest slice
 (`alerting/full_ci.py`) records every run, its job outcomes, and the
 comparison link. The analysis sidecar (`alerting/analyzer.py`) then runs a
 Kimi-driven agent over each pending comparison to classify every failing
-job (new / recurring / fixed; cause: infrastructure, flaky test, test,
-code, unknown), attribute culprit and fixing PRs, and post the rendered
-analysis report.
+NVIDIA-scope job (new / recurring / fixed; cause: infrastructure, flaky test,
+test, code, unknown), attribute culprit and fixing PRs, and post the rendered
+analysis report. AMD jobs remain outside that classification and are summarized
+in a separate failure-only Slack message.
 
 ## Where the code lives
 
@@ -45,12 +46,15 @@ analysis report.
 
 ## What it posts to Slack
 
-One message per analyzed comparison: the analyzer's report text, delivered
-through the outbox with delivery ID `full-ci:<build_id>` (idempotent per
-build). The reconciler itself posts nothing. Each analysis commits its
-report, classifications, checkpoint reference, and the notification intent
-in one Postgres transaction; a failure leaves the comparison pending for
-the next tick.
+The analyzer's NVIDIA-focused report is delivered through the outbox with
+delivery ID `full-ci:<build_id>` (idempotent per build). When the same build
+contains at least one failed AMD job, a second message lists only the failed
+AMD jobs and ends with the AMD passed/failed counts plus a Buildkite link. Its
+delivery ID is `full-ci-amd:<build_id>`, so it can retry independently without
+duplicating the main report. Both notification intents are committed in the
+same Postgres transaction as the report, classifications, and checkpoint
+reference. The reconciler itself posts nothing; a failure leaves the
+comparison pending for the next tick.
 
 ## Dashboard history
 

--- a/alerting/memory.py
+++ b/alerting/memory.py
@@ -808,7 +808,7 @@ class InMemoryAnalyzerStore:
         self,
         *,
         analysis: CompletedAnalysis,
-        notification: NotificationIntent,
+        notifications: tuple[NotificationIntent, ...],
         now: datetime,
     ) -> None:
         analyses_snapshot = dict(self._analyses)
@@ -827,7 +827,8 @@ class InMemoryAnalyzerStore:
                 analyzed_at=now,
             )
             self._checkpoints[analysis.current_build_id] = analysis.checkpoint
-            self._outbox.enqueue(notification, now=now)
+            for notification in notifications:
+                self._outbox.enqueue(notification, now=now)
             if self._fail_commit:
                 self._fail_commit = False
                 raise RuntimeError("Full CI analysis transaction failed")

--- a/alerting/postgres.py
+++ b/alerting/postgres.py
@@ -1652,7 +1652,7 @@ class PostgresAlertStore:
         self,
         *,
         analysis: CompletedAnalysis,
-        notification: NotificationIntent,
+        notifications: tuple[NotificationIntent, ...],
         now: datetime,
     ) -> None:
         with self._connection_factory() as connection:
@@ -1736,7 +1736,8 @@ class PostgresAlertStore:
                         now,
                     ),
                 )
-                self._enqueue(connection, notification, next_attempt_at=now)
+                for notification in notifications:
+                    self._enqueue(connection, notification, next_attempt_at=now)
 
 
 def _cache_payload(cache: FailureCache) -> dict[str, Any]:

--- a/alerting/tests/test_analyzer.py
+++ b/alerting/tests/test_analyzer.py
@@ -316,14 +316,16 @@ class Harness:
                 conditions=conditions,
                 checkpoint=checkpoint,
             ),
-            notification=NotificationIntent(
-                delivery_id=delivery_id,
-                alert_ref=f"full-ci-comparison:{run.build_id}",
-                alert_path=AlertPath.FULL_CI,
-                delivery_mode=DeliveryMode.LIVE,
-                destination_mode=DestinationMode.WEBHOOK,
-                destination="vllm-ci",
-                payload={"text": "seeded report"},
+            notifications=(
+                NotificationIntent(
+                    delivery_id=delivery_id,
+                    alert_ref=f"full-ci-comparison:{run.build_id}",
+                    alert_path=AlertPath.FULL_CI,
+                    delivery_mode=DeliveryMode.LIVE,
+                    destination_mode=DestinationMode.WEBHOOK,
+                    destination="vllm-ci",
+                    payload={"text": "seeded report"},
+                ),
             ),
             now=self.clock.now(),
         )
@@ -440,6 +442,86 @@ def test_analysis_persists_conditions_report_checkpoint_and_notification() -> No
     assert notification.destination_mode is DestinationMode.BOT_TOKEN
     assert notification.destination == "C0ABTNM9L5U"
     assert "Job B" in notification.payload["text"]
+
+
+def test_analysis_enqueues_separate_amd_failure_notification() -> None:
+    run1 = make_run(1, RUN1_AT)
+    run2 = make_run(2, RUN2_AT)
+    harness = Harness(
+        runs=[run1, run2],
+        builds={
+            2: build_json(
+                2,
+                mostly_passing_jobs(
+                    [
+                        (":amd: (MI355) LM Eval Spec Decode", "failed", False),
+                        (":amd: (MI300) V1 Sample + Logits", "failed", False),
+                        (":amd: (MI300) Passing Job", "passed", False),
+                    ]
+                ),
+                scheduled_at=RUN2_AT,
+            )
+        },
+    )
+
+    result = harness.analyze()
+
+    assert result.status is ProcessStatus.COMPLETED
+    notification = harness.outbox.get_outbox(f"full-ci-amd:{run2.build_id}")
+    assert notification is not None
+    assert notification.alert_ref == f"full-ci-comparison:{run2.build_id}"
+    assert notification.alert_path is AlertPath.FULL_CI
+    assert notification.destination_mode is DestinationMode.BOT_TOKEN
+    assert notification.destination == "C0ABTNM9L5U"
+    assert notification.payload == {
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "🔴 vLLM Full CI — AMD Failures (Build #2)",
+                    "emoji": True,
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        "• ✗ :amd: (MI355) LM Eval Spec Decode\n"
+                        "• ✗ :amd: (MI300) V1 Sample + Logits\n\n"
+                        "*1 passed, 2 failed* — "
+                        "<https://buildkite.com/vllm/ci/builds/2|View build>"
+                    ),
+                },
+            },
+        ]
+    }
+
+
+def test_analysis_does_not_enqueue_amd_notification_without_amd_failures() -> None:
+    run1 = make_run(1, RUN1_AT)
+    run2 = make_run(2, RUN2_AT)
+    harness = Harness(
+        runs=[run1, run2],
+        builds={
+            2: build_json(
+                2,
+                mostly_passing_jobs(
+                    [
+                        (":amd: (MI355) Passing Job", "passed", False),
+                        ("NVIDIA Job", "failed", False),
+                    ]
+                ),
+                scheduled_at=RUN2_AT,
+            )
+        },
+    )
+
+    result = harness.analyze()
+
+    assert result.status is ProcessStatus.COMPLETED
+    assert harness.outbox.get_outbox(f"full-ci-amd:{run2.build_id}") is None
 
 
 def test_wrapped_bullet_job_names_are_posted_plain_and_attributed() -> None:

--- a/alerting/tests/test_postgres_analyzer.py
+++ b/alerting/tests/test_postgres_analyzer.py
@@ -353,6 +353,7 @@ class FakeGitHub:
 def make_harness(
     connection: FakePostgresConnection,
     pull: PullRequestRef | None = None,
+    jobs: list[dict[str, Any]] | None = None,
 ) -> tuple[AlertingRuntime, FakeCheckpoints]:
     checkpoints = FakeCheckpoints()
     checkpoints.add("s3://test-checkpoints/seed.tar.gz", {"MEMORY.md": b"# seed\n"})
@@ -371,7 +372,9 @@ def make_harness(
         "scheduled_at": RUN2_AT.isoformat(),
         "started_at": RUN2_AT.isoformat(),
         "finished_at": (RUN2_AT + timedelta(hours=2)).isoformat(),
-        "jobs": [
+        "jobs": jobs
+        if jobs is not None
+        else [
             {"name": "Job A", "state": "failed", "soft_failed": False},
             {"name": "Job B", "state": "passed", "soft_failed": False},
         ],
@@ -434,6 +437,29 @@ def test_commit_analysis_persists_everything_in_one_transaction() -> None:
         ProcessStatus.SKIPPED_ALREADY_COMPLETED
     )
     assert list(connection.state["analyses"]) == ["build-101"]
+
+
+def test_commit_analysis_persists_main_and_amd_notifications() -> None:
+    connection = FakePostgresConnection()
+    runtime, _ = make_harness(
+        connection,
+        jobs=[
+            {"name": "Job A", "state": "passed", "soft_failed": False},
+            {
+                "name": ":amd: (MI355) LM Eval Spec Decode",
+                "state": "failed",
+                "soft_failed": False,
+            },
+        ],
+    )
+
+    result = runtime.process_command(analyze_command())
+
+    assert result.status is ProcessStatus.COMPLETED
+    assert set(connection.state["outbox"]) == {
+        "full-ci:build-101",
+        "full-ci-amd:build-101",
+    }
 
 
 def test_failed_commit_rolls_back_analysis_conditions_and_checkpoint() -> None:


### PR DESCRIPTION
## Summary
- restore the separate AMD failure-only Slack message from the legacy Full CI alert
- include failed AMD job names, passed/failed counts, and the Buildkite link
- persist the NVIDIA report and AMD summary as independent, idempotent outbox deliveries in one transaction
- document the AMD-specific behavior

## Testing
- alerting full suite: 205 passed
- Ruff: passed
- scoped mypy for changed Python modules/tests: passed