### PR TITLE
fix(alerting): exclude torch nightly from main CI alerts

### DIFF
--- a/alerting/CONTEXT.md
+++ b/alerting/CONTEXT.md
@@ -39,6 +39,8 @@ _Avoid_: Incident, alert lifecycle
 **Main CI Job Observation**:
 A hard terminal command-job outcome on the main branch, keyed by configured
 step identity plus rendered job name so matrix cells remain independent.
+Torch-nightly builds are excluded: their failures cannot open or refresh an
+episode, and their passes cannot resolve a standard Main CI failure.
 _Avoid_: Test failure, diagnosis
 
 **Main CI Job Alert**:

--- a/alerting/README.md
+++ b/alerting/README.md
@@ -58,7 +58,10 @@ Queue-wait alerting is owned by the dashboard context:
   job-outcome records, and chronological reconciliation handler. Analyzer
   invocation remains outside this ingest-only slice.
 - `main_ci.py` — the two-minute Buildkite main-branch poller and exact-job
-  lifecycle. It ignores soft/non-command/non-terminal jobs, protects newer
+  lifecycle. It excludes builds with `TORCH_NIGHTLY=1` or the scheduled message
+  `Full CI run torch nightly` from both polling and backstop reconciliation,
+  including passing outcomes. Other nightly/full CI builds remain eligible.
+  It ignores soft/non-command/non-terminal jobs, protects newer
   outcomes from older builds finishing late, and resolves only on a positive
   pass. Retried executions are fetched alongside originals (`include_retried_jobs`),
   retried-out executions that lack a step key inherit it from the same-named

--- a/alerting/main_ci.py
+++ b/alerting/main_ci.py
@@ -1,6 +1,7 @@
 """Main-branch CI job alert lifecycle reconciliation.
 
-Every hard terminal failure opens (or refreshes) one alert keyed by the
+Torch-nightly builds are excluded from both failure and recovery observations.
+Every other hard terminal failure opens (or refreshes) one alert keyed by the
 Buildkite step key. Only a positively observed pass of that same logical job
 in the same or a newer main build resolves it. Older builds that finish late
 cannot overwrite a newer outcome.
@@ -125,6 +126,14 @@ def build_job_observations(build: dict[str, Any]) -> list[MainCIJobObservation]:
     name → step-key map, and same-named executions missing the key inherit
     it, so every execution of a step shares the alert's job key.
     """
+    env = build.get("env") or {}
+    if isinstance(env, dict) and str(env.get("TORCH_NIGHTLY", "")) == "1":
+        return []
+    # The scheduled build label also identifies older API payloads without env.
+    message = str(build.get("message") or "").strip().lower()
+    if message == "full ci run torch nightly":
+        return []
+
     jobs = build.get("jobs")
     if not isinstance(jobs, list):
         return []

--- a/alerting/tests/test_main_ci.py
+++ b/alerting/tests/test_main_ci.py
@@ -3,6 +3,8 @@
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+import pytest
+
 from alerting.commands import ScheduledCommand
 from alerting.full_ci import BuildkiteRestClient
 from alerting.main_ci import (
@@ -367,6 +369,59 @@ def source_runtime_for(
     return runtime, store, clock
 
 
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"env": {"TORCH_NIGHTLY": "1"}, "message": "Manual nightly validation"},
+        {"message": "Full CI run torch nightly"},
+    ],
+)
+def test_torch_nightly_cannot_open_or_resolve_main_alerts(
+    metadata: dict[str, Any],
+) -> None:
+    buildkite = RecordingBuildkite([])
+    runtime, store, _ = source_runtime_for(buildkite)
+    nightly = buildkite_build(
+        300,
+        [buildkite_job(job_id="nightly-fail", state="failed", finished_at=START)],
+    )
+    nightly.update(metadata)
+    buildkite.builds = [nightly]
+    reconcile(runtime, START)
+    assert store.alerts() == []
+
+    standard = buildkite_build(
+        301,
+        [buildkite_job(job_id="main-fail", state="failed", finished_at=START)],
+    )
+    buildkite.builds = [standard]
+    reconcile(runtime, START + timedelta(minutes=2))
+    nightly = buildkite_build(
+        302,
+        [buildkite_job(job_id="nightly-pass", state="passed", finished_at=START)],
+    )
+    nightly.update(metadata)
+    buildkite.builds = [nightly]
+    reconcile(runtime, START + timedelta(minutes=4))
+    assert [(a.status, a.last_failure.job_id) for a in store.alerts()] == [
+        ("open", "main-fail")
+    ]
+
+
+@pytest.mark.parametrize("env", [{}, {"TORCH_NIGHTLY": "0"}, {"NIGHTLY": "1"}])
+def test_standard_full_ci_still_opens_main_alerts(env: dict[str, str]) -> None:
+    build = buildkite_build(
+        300,
+        [buildkite_job(job_id="main-fail", state="failed", finished_at=START)],
+    )
+    build.update(env=env, message="Full CI run")
+    runtime, store, _ = source_runtime_for(RecordingBuildkite([build]))
+    reconcile(runtime, START)
+    assert [(a.status, a.last_failure.job_id) for a in store.alerts()] == [
+        ("open", "main-fail")
+    ]
+
+
 def test_retry_pass_inside_window_resolves_original_failure() -> None:
     failure = buildkite_job(
         job_id="orig", state="failed", finished_at=START - timedelta(hours=3)
@@ -564,6 +619,33 @@ def open_alert(runtime: AlertingRuntime, source: FixtureSource) -> None:
         )
     ]
     reconcile(runtime, START - timedelta(hours=2, minutes=55))
+
+
+def test_backstop_excludes_nightly_from_sweep_and_targeted_recheck() -> None:
+    source = FixtureSource()
+    nightly = buildkite_build(
+        300,
+        [
+            buildkite_job(job_id="nightly-pass", state="passed", finished_at=START),
+            buildkite_job(
+                job_id="nightly-fail",
+                state="failed",
+                finished_at=START,
+                name="Other job",
+                step_key="other",
+            ),
+        ],
+    )
+    nightly["env"] = {"TORCH_NIGHTLY": "1"}
+    builds = FixtureBuilds({300: nightly})
+    builds.sweep_builds = [nightly]
+    runtime, store, _ = combined_runtime_for(source, builds)
+    open_alert(runtime, source)
+    backstop(runtime, START)
+    assert builds.calls == [(300, True)]
+    assert [(a.status, a.last_failure.job_id) for a in store.alerts()] == [
+        ("open", "orig")
+    ]
 
 
 def test_backstop_resolves_open_alert_whose_retried_job_now_passes() -> None:


### PR DESCRIPTION
Torch-nightly build #87673 refreshed or opened 64 Main CI alerts even though it runs a different PyTorch environment. Exclude builds with `TORCH_NIGHTLY=1` (and the scheduled `Full CI run torch nightly` label) at the shared observation mapper used by polling, backstop sweeps, and targeted build rechecks. Nightly passes are excluded too, so they cannot resolve standard-main failures. Regular full/nightly CI remains tracked.

No open dashboard PR addressing this exclusion was found. AI assistance was used to implement and test this change.

Validation: `.venv/bin/python -m pytest alerting/tests -q` — **211 passed**. The three nightly exclusion regression cases fail against the original implementation and pass with the fix. `.venv/bin/python -m ruff check alerting/main_ci.py alerting/tests/test_main_ci.py` and `git diff --check` passed. No model or serving behavior changes.

Operational follow-up: the 64 alerts whose latest failure was from #87673 were manually resolved at the operator's request, preserving their history with `resolution_kind=manual`. Deploy this worker change before the next torch-nightly run to prevent recurrence. This PR does not alter Full CI reporting.
