### PR TITLE
perf(jobs): reduce cold-load database work

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ npm run dev
 
 Open http://localhost:3000.
 
+For slow Jobs loads, use the [latency probe and timing guide](./docs/jobs-performance.md)
+to separate CDN caching, backend queries, and browser startup.
+
 ### Environment variables
 
 | Variable | Purpose |

--- a/docs/jobs-performance.md
+++ b/docs/jobs-performance.md
@@ -1,0 +1,109 @@
+# Diagnosing slow Jobs loads
+
+Run the read-only probe against a local server or production:
+
+```bash
+BASE=https://ci.vllm.ai node scripts/profile-jobs.mjs
+BASE=http://localhost:3000 SOURCE=otel BYPASS_CDN=1 node scripts/profile-jobs.mjs
+```
+
+The probe times the page shell, filter options, and three sequential jobs API
+requests. It exits nonzero for failed requests or jobs loads over `MAX_MS`
+(default 3000). Set `START`, `END`, `PIPELINE`, and `BRANCH` to reproduce the
+reported filters; set `SAMPLES` (1–20) to control request count. Omit `SOURCE`
+to use the deployment's configured backend, or explicitly compare `otel` and
+`databricks`. These backends can have different coverage; switching sources is
+not a performance fix by itself.
+
+In browser DevTools, open Network and inspect `/api/jobs`:
+
+- `X-Vercel-Cache` and `Age` describe the CDN response. HIT/STALE responses can
+  retain timing headers from the original cache fill, not the current request.
+- `Server-Timing` includes `source`, application `cache` (HIT, MISS, or
+  COALESCED), and handler `total`. Databricks includes separate `failures`
+  and `duration` measurements; OTel includes a single `statistics` measurement
+  and overall `backend` time.
+  Failed requests use `cache=ERROR`; the originating fill records both query
+  durations for Databricks, or the statistics duration for OTel, before returning
+  an error. Followers report their own total wait.
+- Query times include connection acquisition, transport, and database work.
+  They are not database execution plans. Databricks queries run concurrently,
+  so do not sum them to calculate total latency.
+- A large query duration directs investigation to warehouse query history or
+  Postgres query plans/pool pressure. Low server time with high time to first
+  byte points toward startup, routing, or network delay. If the API finishes
+  quickly but rows appear late, capture a browser Performance trace.
+
+`BYPASS_CDN=1` gives each probe URL a unique diagnostic parameter. It does not
+bypass the 60-second application cache. To measure an application miss, use a
+fresh local process, wait for expiry, or reproduce an uncached filter selection.
+Concurrent identical jobs requests share one load per server instance (one
+OTel query or two Databricks queries). Separate instances still rely on CDN caching; this is not a global
+lock. TTLs and data freshness are unchanged. Charts load when a job is expanded.
+
+## Investigation baseline (2026-09-08)
+
+Measurements from this workstation against production, not an aggregate or
+an SLA: page HTML 446 ms; default jobs data 82 ms (CDN STALE); alternate date
+range 1255 ms (MISS); explicit Databricks two-week request 7645 ms (MISS).
+Further uncached source comparisons returned OTel in 1182 ms and Databricks in
+1756 ms. Direct calls through the local handler took approximately 1.0 s for
+Databricks and 1.4 s for OTel. This reproduced variable backend latency, but not
+the full reported 15 seconds. Default responses matched the OTel row counts;
+the deployment's environment setting was not inspected.
+
+A regression test against the actual jobs handler reproduced eight simultaneous
+requests issuing 16 warehouse statements. Coalescing reduces that to two,
+while preserving results, separate filter keys, and retries after failure.
+These changes reduce duplicate load and initial JavaScript work; production
+latency must be measured again after deployment before claiming a speedup.
+
+## Local verification
+
+The production build passes. Its initial `/jobs` scripts exclude the chart
+library (the chart chunk is approximately 397 kB uncompressed, 114 kB gzipped).
+Browser checks verified the table and the chart after expansion without console
+errors. Local production-server probes recorded Databricks MISS at 707 ms and
+HIT at 7 ms; OTel MISS at 1299 ms and HIT at 6 ms. These samples verify the
+instrumentation and cache paths, not a production before/after comparison.
+Regression coverage also holds a partial query failure open until its sibling
+settles, preventing retries from launching duplicate outstanding work.
+
+## First-load follow-up
+
+A fresh Chrome incognito window loaded the production jobs API in 31 ms,
+with CDN `STALE`, `Age: 102`; page load was 356 ms and all recorded requests
+finished by 804 ms. Incognito clears browser state but does not clear shared
+CDN/application/database caches. The default response matched the explicit OTel
+response exactly after sorting by job name; Databricks returned different data.
+This indicates the live page was using OTel, so the earlier explicit Databricks
+sample cannot be assumed to explain its delay.
+
+The real OTel handler reproduced a 14,531 ms first call. A subsequent probe of
+the unchanged handler measured 10,178 ms with a fresh connection pool versus
+1,125/1,012 ms on repeats. Plans showed the duration query doing approximately
+230,000 parent-build index lookups. Connection setup, database cache state and
+concurrent load can contribute to first-call variance; the measurements do not
+attribute the entire delay to SQL execution alone.
+
+The optimized OTel handler calculates both rankings in one aggregate over the
+same completed jobs, filtering duration aggregates to passed jobs. This avoids
+the second scan/join and second connection. A read-only repeatable-read snapshot
+comparison returned identical statistics in three trials: combined SQL took
+412/384/372 ms versus 1,043/1,113/1,046 ms for the slower old query. The changed
+handler then measured 725 ms with a fresh pool and 366/384 ms on repeats.
+These are samples from the workstation against the configured database, not
+proof of a production latency bound. The changes still require deployment.
+
+To reproduce first versus repeated database calls without any HTTP cache:
+
+```bash
+node --env-file=.env.local --import tsx scripts/profile-jobs-db.mjs
+```
+
+Start a new process for each fresh-pool comparison. This does not flush the
+database's shared buffers or restart its pooler. The probe asserts one statistics
+query per call and a `MAX_MS` budget (default 3000), and prints `dispatchMs`
+(time until the SQL driver sends each statistics query) to distinguish startup
+and connection waits from work after submission. No SQL, credentials, or job
+contents are logged. Filter overrides match the HTTP probe.

--- a/scripts/profile-jobs-db.mjs
+++ b/scripts/profile-jobs-db.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// Run with: node --env-file=.env.local --import tsx scripts/profile-jobs-db.mjs
+// Uses the real OTel handler, bypassing browser, CDN, and application caches.
+import { getDb } from "../src/lib/db.ts";
+import { queryJobStatsFromOtel } from "../src/lib/otel-ci.ts";
+import { ServerTiming } from "../src/lib/server-timing.ts";
+
+const end = new Date();
+const start = new Date(end);
+start.setUTCDate(start.getUTCDate() - 14);
+const budget = Number(process.env.MAX_MS ?? 3000);
+if (!Number.isFinite(budget) || budget <= 0) throw new Error("MAX_MS must be positive");
+const db = getDb();
+const previousDebug = db.options.debug;
+let queryCount = 0;
+let started = 0;
+let dispatchMs = [];
+db.options.debug = (_connection, query) => {
+  if (query.includes("AS failure_rate") || query.includes("AS p50_duration")) {
+    queryCount++;
+    dispatchMs.push(Math.round(performance.now() - started));
+  }
+};
+
+try {
+  for (let sample = 1; sample <= 3; sample++) {
+    queryCount = 0;
+    dispatchMs = [];
+    const timing = new ServerTiming();
+    started = performance.now();
+    const result = await queryJobStatsFromOtel({
+      pipeline: process.env.PIPELINE ?? "CI",
+      branch: process.env.BRANCH ?? "main",
+      startDate: process.env.START ?? start.toISOString().slice(0, 10),
+      endDate: process.env.END ?? end.toISOString().slice(0, 10),
+      hasDateRange: true,
+    }, timing);
+    const ms = Math.round(performance.now() - started);
+    const pass = queryCount === 1 && ms <= budget;
+    console.log(JSON.stringify({
+      sample, freshConnectionPool: sample === 1, ms, queryCount, dispatchMs,
+      failureRows: result.failureRanking.length, durationRows: result.durationStats.length,
+      serverTiming: timing.header(), verdict: pass ? "PASS" : "FAIL",
+    }));
+    if (!pass) process.exitCode = 1;
+  }
+} catch (error) {
+  console.error(`FAIL: database jobs probe could not complete (${error.name})`);
+  process.exitCode = 1;
+} finally {
+  db.options.debug = previousDebug;
+  await db.end();
+}

--- a/scripts/profile-jobs.mjs
+++ b/scripts/profile-jobs.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Read-only latency probe. No credentials or response bodies are logged.
+const base = process.env.BASE ?? "http://localhost:3000";
+const samples = Number(process.env.SAMPLES ?? 3);
+const budget = Number(process.env.MAX_MS ?? 3000);
+if (!Number.isInteger(samples) || samples < 1 || samples > 20 || !Number.isFinite(budget) || budget <= 0) {
+  throw new Error("SAMPLES must be 1–20 and MAX_MS must be positive");
+}
+const end = new Date();
+const start = new Date(end);
+start.setUTCDate(start.getUTCDate() - 14);
+const params = new URLSearchParams({
+  pipeline: process.env.PIPELINE ?? "CI",
+  branch: process.env.BRANCH ?? "main",
+  startDate: process.env.START ?? start.toISOString().slice(0, 10),
+  endDate: process.env.END ?? end.toISOString().slice(0, 10),
+});
+if (process.env.SOURCE) {
+  if (!["otel", "databricks"].includes(process.env.SOURCE)) throw new Error("SOURCE must be otel or databricks");
+  params.set("source", process.env.SOURCE);
+}
+
+async function measure(path, sample, jobs = false) {
+  const url = new URL(path, base);
+  // Bypasses the CDN URL cache, but deliberately leaves the application's
+  // semantic cache key intact. MISS at the CDN need not mean a database read.
+  if (process.env.BYPASS_CDN === "1") url.searchParams.set("_profile", `${Date.now()}-${sample}`);
+  const started = performance.now();
+  const response = await fetch(url, { signal: AbortSignal.timeout(40_000) });
+  const ttfb = performance.now() - started;
+  const body = await response.text();
+  const elapsed = performance.now() - started;
+  let valid = response.ok;
+  if (jobs) {
+    try {
+      const data = JSON.parse(body);
+      valid &&= Array.isArray(data.failureRanking) && Array.isArray(data.durationStats) && !data.error;
+    } catch {
+      valid = false;
+    }
+  }
+  const pass = valid && (!jobs || elapsed <= budget);
+  console.log(JSON.stringify({
+    path: url.pathname, sample, status: response.status,
+    ttfbMs: Math.round(ttfb), totalMs: Math.round(elapsed), bytes: Buffer.byteLength(body),
+    cdnCache: response.headers.get("x-vercel-cache"), age: response.headers.get("age"),
+    serverTiming: response.headers.get("server-timing"),
+    verdict: pass ? "PASS" : "FAIL",
+  }));
+  if (!pass) process.exitCode = 1;
+}
+
+try {
+  await measure("/jobs", 1);
+  const filters = new URLSearchParams();
+  if (params.has("source")) filters.set("source", params.get("source"));
+  await measure(`/api/builds/filters?${filters}`, 1);
+  for (let sample = 1; sample <= samples; sample++) {
+    await measure(`/api/jobs?${params}`, sample, true);
+  }
+} catch (error) {
+  console.error(`FAIL: jobs probe could not complete (${error.name})`);
+  process.exitCode = 1;
+}

--- a/src/app/api/jobs/route.test.ts
+++ b/src/app/api/jobs/route.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test, { type TestContext } from "node:test";
+import { setImmediate } from "node:timers/promises";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+function configureWarehouse(t: TestContext) {
+  const saved = { ...process.env };
+  Object.assign(process.env, {
+    DATABRICKS_HOST: "https://warehouse.example",
+    DATABRICKS_TOKEN: "test-token",
+    DATABRICKS_WAREHOUSE_ID: "test-warehouse",
+  });
+  t.after(() => {
+    for (const key of ["DATABRICKS_HOST", "DATABRICKS_TOKEN", "DATABRICKS_WAREHOUSE_ID"]) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+}
+
+test("concurrent jobs requests share queries and expose cache/query timings", async (t) => {
+  const fetchMock = t.mock.method(globalThis, "fetch", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    return Response.json({
+      status: { state: "SUCCEEDED" },
+      manifest: { schema: { columns: [{ name: "name" }] } },
+      result: { data_array: [["test job"]] },
+    });
+  });
+  configureWarehouse(t);
+  const url = "http://localhost/api/jobs?source=databricks&branch=concurrent-test";
+  const responses = await Promise.all(
+    Array.from({ length: 8 }, () => GET(new NextRequest(url))),
+  );
+  assert.equal(fetchMock.mock.callCount(), 2, "one failure query and one duration query for all eight callers");
+  for (const response of responses) {
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      failureRanking: [{ name: "test job" }],
+      durationStats: [{ name: "test job" }],
+    });
+    assert.match(response.headers.get("Server-Timing") ?? "", /source;desc="databricks"/);
+  }
+  assert.match(responses[0].headers.get("Server-Timing") ?? "", /failures;dur=/);
+  assert.match(responses[0].headers.get("Server-Timing") ?? "", /duration;dur=/);
+  assert.match(responses[1].headers.get("Server-Timing") ?? "", /cache;desc="COALESCED"/);
+  const cached = await GET(new NextRequest(url));
+  assert.match(cached.headers.get("Server-Timing") ?? "", /cache;desc="HIT"/);
+  assert.doesNotMatch(cached.headers.get("Server-Timing") ?? "", /failures;dur=/);
+  assert.equal(fetchMock.mock.callCount(), 2);
+
+  await GET(new NextRequest(`${url}&pipeline=AMD+CI`));
+  assert.equal(fetchMock.mock.callCount(), 4, "different filters need their own queries");
+
+});
+
+
+test("a partial query failure keeps the fill shared until the other query settles", async (t) => {
+  configureWarehouse(t);
+  t.mock.method(console, "error", () => {});
+  const duration = Promise.withResolvers<void>();
+  let fail = true;
+  const fetchMock = t.mock.method(globalThis, "fetch", async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    const { statement } = JSON.parse(String(init?.body));
+    if (statement.includes("p50_duration")) await duration.promise;
+    else if (fail) return Response.json({}, { status: 503 });
+    return Response.json({ status: { state: "SUCCEEDED" } });
+  });
+  const url = "http://localhost/api/jobs?source=databricks&branch=partial-failure-test";
+  let finished = false;
+  const first = GET(new NextRequest(url)).then((response) => {
+    finished = true;
+    return response;
+  });
+  try {
+    await setImmediate();
+    assert.equal(finished, false, "do not release the fill while its duration query is still running");
+    const follower = GET(new NextRequest(url));
+    await setImmediate();
+    assert.equal(fetchMock.mock.callCount(), 2, "a follower must not launch more queries after a partial failure");
+    duration.resolve();
+    const [response, shared] = await Promise.all([first, follower]);
+    assert.equal(response.status, 500);
+    assert.equal(shared.status, 500);
+    assert.match(response.headers.get("Server-Timing") ?? "", /duration;dur=/);
+    assert.match(response.headers.get("Server-Timing") ?? "", /cache;desc="ERROR"/);
+    fail = false;
+    const retry = await GET(new NextRequest(url));
+    assert.equal(retry.status, 200);
+    assert.equal(fetchMock.mock.callCount(), 4, "a fully settled failure can be retried");
+  } finally {
+    duration.resolve();
+    await first;
+  }
+});

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
-import { getCached, setCache } from "@/lib/api-cache";
+import { getOrLoadCached } from "@/lib/api-cache";
+import { ServerTiming } from "@/lib/server-timing";
 import { cachedJson } from "@/lib/api-response";
 import { resolveCiDataSource } from "@/lib/ci-data-source";
 import { queryJobStatsFromOtel } from "@/lib/otel-ci";
@@ -9,106 +10,113 @@ const TTL = 60_000;
 const CDN_CACHE = { maxAge: 60, staleWhileRevalidate: 3_600 };
 
 export async function GET(request: NextRequest) {
+  const timing = new ServerTiming();
   try {
+    const source = resolveCiDataSource(request);
+    timing.describe("source", source);
     const searchParams = request.nextUrl.searchParams;
     const pipeline = searchParams.get("pipeline") || "CI";
     const branch = searchParams.get("branch") || "main";
     const startDate = searchParams.get("startDate");
     const endDate = searchParams.get("endDate");
 
-    const cacheKey = `jobs:${pipeline}:${branch}:${startDate}:${endDate}:${resolveCiDataSource(request)}`;
-    const cached = getCached(cacheKey);
-    if (cached) return cachedJson(cached, CDN_CACHE);
+    const cacheKey = `jobs:${pipeline}:${branch}:${startDate}:${endDate}:${source}`;
+    const { data: result, status } = await getOrLoadCached(cacheKey, TTL, async () => {
+      if (source === "otel") {
+        return timing.measure("backend", queryJobStatsFromOtel({
+          pipeline,
+          branch,
+          startDate,
+          endDate,
+          hasDateRange: Boolean(startDate || endDate),
+        }, timing));
+      }
 
-    if (resolveCiDataSource(request) === "otel") {
-      const hasDateRange = Boolean(startDate || endDate);
-      const result = await queryJobStatsFromOtel({
-        pipeline,
-        branch,
-        startDate,
-        endDate,
-        hasDateRange,
+      const conditions = [
+        "j._fivetran_deleted = false",
+        "j.type = 'script'",
+        "j.name IS NOT NULL",
+        "b._fivetran_deleted = false",
+      ];
+      if (pipeline) {
+        conditions.push(`p.name = '${pipeline.replace(/'/g, "''")}'`);
+      }
+      if (branch) {
+        conditions.push(`b.branch = '${branch.replace(/'/g, "''")}'`);
+      }
+      if (startDate) {
+        conditions.push(`b.created_at >= '${startDate.replace(/'/g, "''")}'`);
+      }
+      if (endDate) {
+        conditions.push(`b.created_at < DATE_ADD('${endDate.replace(/'/g, "''")}', 1)`);
+      }
+      const where = conditions.join(" AND ");
+      const hasDateRange = startDate || endDate;
+      const recencyHaving = hasDateRange
+        ? ""
+        : "\n          AND MAX(b.created_at) >= CURRENT_DATE - INTERVAL 7 DAY";
+
+      const queries = await Promise.allSettled([
+        timing.measure("failures", queryDatabricks(`
+          SELECT
+            j.name,
+            COUNT(*) AS total_runs,
+            SUM(CASE WHEN j.state IN ('failed', 'failing', 'broken', 'timed_out') THEN 1 ELSE 0 END) AS failures,
+            SUM(CASE WHEN j.state = 'passed' THEN 1 ELSE 0 END) AS passes,
+            ROUND(
+              100.0 * SUM(CASE WHEN j.state IN ('failed', 'failing', 'broken', 'timed_out') THEN 1 ELSE 0 END)
+              / NULLIF(SUM(CASE WHEN j.state IN ('passed', 'failed', 'failing', 'broken', 'timed_out') THEN 1 ELSE 0 END), 0),
+              1
+            ) AS failure_rate,
+            MAX(CASE WHEN j.soft_failed = 'true' THEN 1 ELSE 0 END) AS has_soft_fail
+          FROM vllm_data_warehouse.buildkite.build_job AS j
+          INNER JOIN vllm_data_warehouse.buildkite.build AS b ON j.build_id = b.id
+          INNER JOIN vllm_data_warehouse.buildkite.pipeline AS p ON b.pipeline_id = p.id
+          WHERE ${where}
+            AND j.state IN ('passed', 'failed', 'failing', 'broken', 'timed_out')
+          GROUP BY j.name
+          HAVING SUM(CASE WHEN j.state IN ('failed', 'failing', 'broken', 'timed_out') THEN 1 ELSE 0 END) > 0${recencyHaving}
+          ORDER BY failure_rate DESC, failures DESC
+        `)),
+        timing.measure("duration", queryDatabricks(`
+          SELECT
+            j.name,
+            COUNT(*) AS total_runs,
+            ROUND(AVG(TIMESTAMPDIFF(SECOND, j.started_at, j.finished_at))) AS avg_duration,
+            ROUND(PERCENTILE(TIMESTAMPDIFF(SECOND, j.started_at, j.finished_at), 0.5)) AS p50_duration,
+            ROUND(PERCENTILE(TIMESTAMPDIFF(SECOND, j.started_at, j.finished_at), 0.9)) AS p90_duration,
+            ROUND(MAX(TIMESTAMPDIFF(SECOND, j.started_at, j.finished_at))) AS max_duration
+          FROM vllm_data_warehouse.buildkite.build_job AS j
+          INNER JOIN vllm_data_warehouse.buildkite.build AS b ON j.build_id = b.id
+          INNER JOIN vllm_data_warehouse.buildkite.pipeline AS p ON b.pipeline_id = p.id
+          WHERE ${where}
+            AND j.started_at IS NOT NULL
+            AND j.finished_at IS NOT NULL
+            AND j.state = 'passed'
+          GROUP BY j.name
+          HAVING COUNT(*) > 0${recencyHaving}
+          ORDER BY p50_duration DESC
+        `)),
+      ]);
+
+      // A failed query must not release the shared fill while its sibling
+      // still consumes backend capacity, or retries can multiply that work.
+      const [failureRanking, durationStats] = queries.map((query) => {
+        if (query.status === "rejected") throw query.reason;
+        return query.value;
       });
-      setCache(cacheKey, result, TTL);
-      return cachedJson(result, CDN_CACHE);
-    }
-
-    const conditions = [
-      "j._fivetran_deleted = false",
-      "j.type = 'script'",
-      "j.name IS NOT NULL",
-      "b._fivetran_deleted = false",
-    ];
-    if (pipeline) {
-      conditions.push(`p.name = '${pipeline.replace(/'/g, "''")}'`);
-    }
-    if (branch) {
-      conditions.push(`b.branch = '${branch.replace(/'/g, "''")}'`);
-    }
-    if (startDate) {
-      conditions.push(`b.created_at >= '${startDate.replace(/'/g, "''")}'`);
-    }
-    if (endDate) {
-      conditions.push(`b.created_at < DATE_ADD('${endDate.replace(/'/g, "''")}', 1)`);
-    }
-    const where = conditions.join(" AND ");
-    const hasDateRange = startDate || endDate;
-    const recencyHaving = hasDateRange
-      ? ""
-      : "\n          AND MAX(b.created_at) >= CURRENT_DATE - INTERVAL 7 DAY";
-
-    const [failureRanking, durationStats] = await Promise.all([
-      queryDatabricks(`
-        SELECT
-          j.name,
-          COUNT(*) AS total_runs,
-          SUM(CASE WHEN j.state IN ('failed', 'failing', 'broken', 'timed_out') THEN 1 ELSE 0 END) AS failures,
-          SUM(CASE WHEN j.state = 'passed' THEN 1 ELSE 0 END) AS passes,
-          ROUND(
-            100.0 * SUM(CASE WHEN j.state IN ('failed', 'failing', 'broken', 'timed_out') THEN 1 ELSE 0 END)
-            / NULLIF(SUM(CASE WHEN j.state IN ('passed', 'failed', 'failing', 'broken', 'timed_out') THEN 1 ELSE 0 END), 0),
-            1
-          ) AS failure_rate,
-          MAX(CASE WHEN j.soft_failed = 'true' THEN 1 ELSE 0 END) AS has_soft_fail
-        FROM vllm_data_warehouse.buildkite.build_job AS j
-        INNER JOIN vllm_data_warehouse.buildkite.build AS b ON j.build_id = b.id
-        INNER JOIN vllm_data_warehouse.buildkite.pipeline AS p ON b.pipeline_id = p.id
-        WHERE ${where}
-          AND j.state IN ('passed', 'failed', 'failing', 'broken', 'timed_out')
-        GROUP BY j.name
-        HAVING SUM(CASE WHEN j.state IN ('failed', 'failing', 'broken', 'timed_out') THEN 1 ELSE 0 END) > 0${recencyHaving}
-        ORDER BY failure_rate DESC, failures DESC
-      `),
-      queryDatabricks(`
-        SELECT
-          j.name,
-          COUNT(*) AS total_runs,
-          ROUND(AVG(TIMESTAMPDIFF(SECOND, j.started_at, j.finished_at))) AS avg_duration,
-          ROUND(PERCENTILE(TIMESTAMPDIFF(SECOND, j.started_at, j.finished_at), 0.5)) AS p50_duration,
-          ROUND(PERCENTILE(TIMESTAMPDIFF(SECOND, j.started_at, j.finished_at), 0.9)) AS p90_duration,
-          ROUND(MAX(TIMESTAMPDIFF(SECOND, j.started_at, j.finished_at))) AS max_duration
-        FROM vllm_data_warehouse.buildkite.build_job AS j
-        INNER JOIN vllm_data_warehouse.buildkite.build AS b ON j.build_id = b.id
-        INNER JOIN vllm_data_warehouse.buildkite.pipeline AS p ON b.pipeline_id = p.id
-        WHERE ${where}
-          AND j.started_at IS NOT NULL
-          AND j.finished_at IS NOT NULL
-          AND j.state = 'passed'
-        GROUP BY j.name
-        HAVING COUNT(*) > 0${recencyHaving}
-        ORDER BY p50_duration DESC
-      `),
-    ]);
-
-    const result = { failureRanking, durationStats };
-    setCache(cacheKey, result, TTL);
-
-    return cachedJson(result, CDN_CACHE);
+      return { failureRanking, durationStats };
+    });
+    timing.describe("cache", status);
+    const response = cachedJson(result, CDN_CACHE);
+    response.headers.set("Server-Timing", timing.header());
+    return response;
   } catch (error) {
+    timing.describe("cache", "ERROR");
     console.error("Failed to fetch job stats:", error);
     return NextResponse.json(
       { error: "Failed to fetch job statistics" },
-      { status: 500 }
+      { status: 500, headers: { "Server-Timing": timing.header() } }
     );
   }
 }

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -1,13 +1,19 @@
 "use client";
 
 import { useState, Fragment } from "react";
+import dynamic from "next/dynamic";
 import useSWR from "swr";
 import { StatCard } from "@/components/stat-card";
 import { SearchableSelect } from "@/components/searchable-select";
 import { DateRangePicker } from "@/components/date-range-picker";
 import { isOptionalJob, isSoftFailJob } from "@/lib/optional-jobs";
 import { JobName, jobNameText } from "@/components/job-name";
-import { JobRunsChart, JobRun } from "@/components/job-runs-chart";
+import type { JobRun } from "@/components/job-runs-chart";
+
+const JobRunsChart = dynamic(
+  () => import("@/components/job-runs-chart").then((module) => module.JobRunsChart),
+  { loading: () => <div className="flex h-48 items-center justify-center text-zinc-400">Loading chart...</div> },
+);
 
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 

--- a/src/lib/api-cache.test.ts
+++ b/src/lib/api-cache.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getOrLoadCached, setCache } from "./api-cache";
+
+test("failed concurrent cache fills can be retried", async () => {
+  let calls = 0;
+  const load = async () => {
+    calls++;
+    throw new Error("temporary backend failure");
+  };
+  const results = await Promise.allSettled([
+    getOrLoadCached("retry-test", 60_000, load),
+    getOrLoadCached("retry-test", 60_000, load),
+  ]);
+  assert.equal(calls, 1);
+  assert.ok(results.every((result) => result.status === "rejected"));
+  assert.deepEqual(await getOrLoadCached("retry-test", 60_000, async () => "recovered"), {
+    data: "recovered", status: "MISS",
+  });
+});
+
+test("expired data is refreshed, including falsy cached values", async (t) => {
+  t.mock.method(Date, "now", () => 1000);
+  setCache("expiry-test", "old", 10);
+  t.mock.method(Date, "now", () => 1011);
+  assert.deepEqual(await getOrLoadCached("expiry-test", 10, async () => false), {
+    data: false, status: "MISS",
+  });
+  assert.deepEqual(await getOrLoadCached("expiry-test", 10, async () => "wrong"), {
+    data: false, status: "HIT",
+  });
+});

--- a/src/lib/api-cache.ts
+++ b/src/lib/api-cache.ts
@@ -1,4 +1,28 @@
 const store = new Map<string, { data: unknown; expiry: number }>();
+const inFlight = new Map<string, Promise<unknown>>();
+
+/** Share a cache fill across concurrent callers in this server instance. */
+export async function getOrLoadCached<T>(
+  key: string,
+  ttlMs: number,
+  load: () => Promise<T>,
+): Promise<{ data: T; status: "HIT" | "MISS" | "COALESCED" }> {
+  const cached = getCached<T>(key);
+  if (cached !== undefined) return { data: cached, status: "HIT" };
+  const pending = inFlight.get(key);
+  if (pending) return { data: await pending as T, status: "COALESCED" };
+
+  const promise = Promise.resolve().then(load);
+  inFlight.set(key, promise);
+  try {
+    const data = await promise;
+    setCache(key, data, ttlMs);
+    return { data, status: "MISS" };
+  } finally {
+    // Failed loads must be retryable; never retain a rejected promise.
+    inFlight.delete(key);
+  }
+}
 
 export function getCached<T>(key: string): T | undefined {
   const entry = store.get(key);

--- a/src/lib/otel-ci.ts
+++ b/src/lib/otel-ci.ts
@@ -1,5 +1,6 @@
 import { getDb } from "@/lib/db";
 import { resolveGroupsToJobConditions } from "@/lib/test-groups";
+import type { ServerTiming } from "@/lib/server-timing";
 
 // ---------------------------------------------------------------------------
 // Shared types / helpers
@@ -282,8 +283,40 @@ export interface OtelJobStatsResult {
   durationStats: Record<string, unknown>[];
 }
 
+interface OtelJobStatsRow {
+  name: string;
+  total_runs: number;
+  failures: number;
+  passes: number;
+  failure_rate: string;
+  has_soft_fail: number;
+  avg_duration: number | null;
+  p50_duration: number | null;
+  p90_duration: number | null;
+  max_duration: number | null;
+}
+
+/** Preserve the two ranking contracts when both come from one aggregate. */
+export function splitOtelJobStats(rows: OtelJobStatsRow[]): OtelJobStatsResult {
+  return {
+    failureRanking: rows
+      .filter((row) => row.failures > 0)
+      .map(({ name, total_runs, failures, passes, failure_rate, has_soft_fail }) => ({
+        name, total_runs, failures, passes, failure_rate, has_soft_fail,
+      }))
+      .sort((a, b) => Number(b.failure_rate) - Number(a.failure_rate) || b.failures - a.failures),
+    durationStats: rows
+      .filter((row) => row.passes > 0)
+      .map(({ name, passes, avg_duration, p50_duration, p90_duration, max_duration }) => ({
+        name, total_runs: passes, avg_duration, p50_duration, p90_duration, max_duration,
+      }))
+      .sort((a, b) => Number(b.p50_duration) - Number(a.p50_duration)),
+  };
+}
+
 export async function queryJobStatsFromOtel(
   f: CiFilter & { hasDateRange: boolean },
+  timing?: ServerTiming,
 ): Promise<OtelJobStatsResult> {
   const sql: Sql = getDb();
   // Filter the job span (j) on the indexed pipeline_slug and start_time so the
@@ -303,7 +336,9 @@ export async function queryJobStatsFromOtel(
     ? sql``
     : sql`AND j.start_time >= NOW() - INTERVAL '7 days'`;
 
-  const failurePromise = sql<Record<string, unknown>[]>`
+  // Both rankings use the same completed jobs. Aggregate once to avoid a
+  // second span scan/build join and a second connection on a cold request.
+  const query = sql<OtelJobStatsRow[]>`
     SELECT
       j.job_label AS name,
       COUNT(*)::int AS total_runs,
@@ -314,37 +349,23 @@ export async function queryJobStatsFromOtel(
         / NULLIF(COUNT(*) FILTER (WHERE ${sql.unsafe(JOB_COMPLETED)}), 0),
         1
       ) AS failure_rate,
-      MAX(CASE WHEN j.job_soft_failed = 'true' THEN 1 ELSE 0 END) AS has_soft_fail
+      MAX(CASE WHEN j.job_soft_failed = 'true' THEN 1 ELSE 0 END) AS has_soft_fail,
+      ROUND(AVG(j.duration_ms) FILTER (WHERE ${sql.unsafe(JOB_PASSED)}) / 1000.0)::int AS avg_duration,
+      ROUND(percentile_cont(0.5) WITHIN GROUP (ORDER BY j.duration_ms)
+        FILTER (WHERE ${sql.unsafe(JOB_PASSED)}) / 1000.0)::int AS p50_duration,
+      ROUND(percentile_cont(0.9) WITHIN GROUP (ORDER BY j.duration_ms)
+        FILTER (WHERE ${sql.unsafe(JOB_PASSED)}) / 1000.0)::int AS p90_duration,
+      ROUND(MAX(j.duration_ms) FILTER (WHERE ${sql.unsafe(JOB_PASSED)}) / 1000.0)::int AS max_duration
     FROM otel_spans AS j
     INNER JOIN otel_spans AS b ON ${sql.unsafe(BUILD_JOIN)}
     WHERE ${baseWhere}
       AND ${sql.unsafe(JOB_COMPLETED)}
       ${recency}
     GROUP BY j.job_label
-    HAVING COUNT(*) FILTER (WHERE ${sql.unsafe(JOB_FAILED)}) > 0
-    ORDER BY failure_rate DESC, failures DESC
   `;
 
-  const durationPromise = sql<Record<string, unknown>[]>`
-    SELECT
-      j.job_label AS name,
-      COUNT(*)::int AS total_runs,
-      ROUND(AVG(j.duration_ms) / 1000.0)::int AS avg_duration,
-      ROUND(percentile_cont(0.5) WITHIN GROUP (ORDER BY j.duration_ms) / 1000.0)::int AS p50_duration,
-      ROUND(percentile_cont(0.9) WITHIN GROUP (ORDER BY j.duration_ms) / 1000.0)::int AS p90_duration,
-      ROUND(MAX(j.duration_ms) / 1000.0)::int AS max_duration
-    FROM otel_spans AS j
-    INNER JOIN otel_spans AS b ON ${sql.unsafe(BUILD_JOIN)}
-    WHERE ${baseWhere}
-      AND ${sql.unsafe(JOB_PASSED)}
-      ${recency}
-    GROUP BY j.job_label
-    HAVING COUNT(*) > 0
-    ORDER BY p50_duration DESC
-  `;
-
-  const [failureRanking, durationStats] = await Promise.all([failurePromise, durationPromise]);
-  return { failureRanking, durationStats };
+  const rows = await (timing ? timing.measure("statistics", query) : query);
+  return splitOtelJobStats(rows);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/otel-job-stats.test.ts
+++ b/src/lib/otel-job-stats.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { splitOtelJobStats } from "./otel-ci";
+
+test("combined statistics retain distinct failure and passed-duration populations", () => {
+  const result = splitOtelJobStats([
+    { name: "mixed", total_runs: 12, failures: 4, passes: 7, failure_rate: "33.3", has_soft_fail: 1,
+      avg_duration: 90, p50_duration: 80, p90_duration: 120, max_duration: 150 },
+    { name: "passed only", total_runs: 3, failures: 0, passes: 3, failure_rate: "0.0", has_soft_fail: 0,
+      avg_duration: 200, p50_duration: 200, p90_duration: 250, max_duration: 300 },
+    { name: "failed only", total_runs: 2, failures: 2, passes: 0, failure_rate: "100.0", has_soft_fail: 0,
+      avg_duration: null, p50_duration: null, p90_duration: null, max_duration: null },
+    { name: "unknown outcome", total_runs: 1, failures: 0, passes: 0, failure_rate: "0.0", has_soft_fail: 0,
+      avg_duration: null, p50_duration: null, p90_duration: null, max_duration: null },
+  ]);
+  assert.deepEqual(result, {
+    failureRanking: [
+      { name: "failed only", total_runs: 2, failures: 2, passes: 0, failure_rate: "100.0", has_soft_fail: 0 },
+      { name: "mixed", total_runs: 12, failures: 4, passes: 7, failure_rate: "33.3", has_soft_fail: 1 },
+    ],
+    durationStats: [
+      { name: "passed only", total_runs: 3, avg_duration: 200, p50_duration: 200, p90_duration: 250, max_duration: 300 },
+      { name: "mixed", total_runs: 7, avg_duration: 90, p50_duration: 80, p90_duration: 120, max_duration: 150 },
+    ],
+  });
+});
+
+test("failure rates sort numerically and ties use failure counts", () => {
+  const rows = [
+    { name: "lower rate", total_runs: 100, failures: 9, passes: 91, failure_rate: "9.0" },
+    { name: "fewer failures", total_runs: 10, failures: 5, passes: 5, failure_rate: "50.0" },
+    { name: "more failures", total_runs: 20, failures: 10, passes: 10, failure_rate: "50.0" },
+  ].map((row) => ({ ...row, has_soft_fail: 0, avg_duration: 0, p50_duration: 0, p90_duration: 0, max_duration: 0 }));
+  assert.deepEqual(splitOtelJobStats(rows).failureRanking.map((row) => row.name), [
+    "more failures", "fewer failures", "lower rate",
+  ]);
+  assert.deepEqual(splitOtelJobStats([]), { failureRanking: [], durationStats: [] });
+});

--- a/src/lib/server-timing.ts
+++ b/src/lib/server-timing.ts
@@ -1,0 +1,23 @@
+/** Per-request backend timings, visible in the browser's Network panel. */
+export class ServerTiming {
+  private readonly started = performance.now();
+  private readonly entries: string[] = [];
+
+  async measure<T>(name: string, operation: PromiseLike<T>): Promise<T> {
+    const start = performance.now();
+    try {
+      return await operation;
+    } finally {
+      this.entries.push(`${name};dur=${(performance.now() - start).toFixed(1)}`);
+    }
+  }
+
+  // Names/descriptions are internal constants, never request parameters.
+  describe(name: string, value: string): void {
+    this.entries.push(`${name};desc="${value}"`);
+  }
+
+  header(): string {
+    return [...this.entries, `total;dur=${(performance.now() - this.started).toFixed(1)}`].join(", ");
+  }
+}


### PR DESCRIPTION
The Jobs page waits for failure and duration statistics before showing its rankings. On the OTel path, these previously required two aggregates over the same job spans and parent-build join. Compute both rankings in one query, retaining the existing completed-run failure denominator and passed-only duration statistics.

Also share identical concurrent cache fills per server instance, defer the chart library until a job is expanded, and expose backend/query/cache timing through `Server-Timing`. Read-only HTTP and database probes document how to reproduce first-load latency without confusing browser, CDN, and application caches. Cache TTLs and data-source selection are unchanged; no schema migration is required.

## Measurements

Against the configured database from the workstation:

| Handler call | Before | After |
| --- | ---: | ---: |
| Fresh connection pool | 10.18 s | 0.68–0.73 s |
| Repeated, without application cache | 1.01–1.13 s | 0.37–0.44 s |

A read-only repeatable-read comparison verified identical values for all 350 failure rows and 581 duration rows. Three paired SQL trials measured the combined query at 372–412 ms versus 1,043–1,113 ms for the slower original query. These are investigation samples, not a production latency guarantee; connection startup and shared database state can vary. Measure production first loads again after deployment.

The concurrency regression reduces eight identical warehouse requests from 16 statements to two, including safe retry behavior after partial failures. The initial Jobs scripts also defer approximately 114 kB of gzipped chart code.

## Validation

- 179 tests pass, including ranking population/order, concurrent cache fills, expiry, and partial-failure retry coverage.
- TypeScript, lint on changed code, production build, and `git diff --check` pass.
- Browser checks verified the jobs table and expanded chart without console errors.
- Real database result parity and fresh/repeated handler probes pass.
- Independent review completed with no remaining actionable findings.

See `docs/jobs-performance.md` for measurement context and reproduction commands.
