### PR TITLE
fix(alerting): report cascaded and timed-out jobs in full CI analysis

### DIFF
--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -455,6 +455,12 @@ def _build_summary(
             "new": len(_hard_failures(jobs) - set(cache.failed_tests)),
             "recurring": len(_hard_failures(jobs) & set(cache.failed_tests)),
             "scheduled": sum(1 for job in jobs if job.state == "scheduled"),
+            # Cascaded and unfinished-terminal jobs are not failures, but the
+            # old report gave them their own sections and the analyzer model
+            # cannot count the jobs array reliably.
+            "cascaded": sum(1 for job in jobs if job.state == "waiting_failed"),
+            "timed_out": sum(1 for job in jobs if job.state == "timed_out"),
+            "canceled": sum(1 for job in jobs if job.state == "canceled"),
             "has_previous_data": cache.build_number is not None,
             "total": len(jobs),
         },

--- a/alerting/assets/vllm-ci-failure-analyzer.md
+++ b/alerting/assets/vllm-ci-failure-analyzer.md
@@ -22,8 +22,12 @@ commits, open pull requests, post messages, or mutate Buildkite or GitHub.
    `previous_failures.failed_tests`.
 4. Recurring failures are hard-failure names present in that baseline.
 5. Fixed tests are baseline names now positively observed with `state ==
-   "passed"`. Missing, scheduled, canceled, timed-out, and soft-failed jobs are
-   not fixed.
+   "passed"`. Missing, scheduled, waiting-failed, canceled, timed-out, and
+   soft-failed jobs are not fixed.
+6. Jobs in state `waiting_failed`, `timed_out`, or `canceled` are neither hard
+   nor soft failures and never enter the baseline. `waiting_failed` means an
+   upstream step (usually an image build) failed and the job never ran — a
+   cascade, not a fault. Report them in their own sections (Phase C).
 
 ## Phase B — Investigate new failures
 
@@ -64,7 +68,21 @@ the `jobs` array yourself — it is too long to count reliably. The
 appears only when `stats.failed` > 0 and `stats.has_previous_data` is true;
 otherwise show just `Y failed`. If `stats.scheduled` > 0, append
 `, S scheduled` to the Stats line using `stats.scheduled`. Add sections for new, recurring, fixed,
-and soft failures when present. Investigation summaries must be concise. Show
+and soft failures when present. Also add these sections when their jobs exist:
+
+- If `stats.cascaded` > 0, after the fixed section add
+  `*:hourglass_flowing_sand: Cascaded, never ran (N):*` with N =
+  `stats.cascaded`, listing each `waiting_failed` job with a short reason.
+  These jobs have no log; identify the blocker from `nightly_full.json` (a
+  failed image-build step on the same queue) and write e.g.
+  `• Arm CPU Test Shard 1/2/3 — blocked by CPU arm64 image`, grouping shards
+  that share one blocker into a single bullet. N counts jobs, not bullets.
+- If `stats.timed_out` + `stats.canceled` > 0, add
+  `*:stopwatch: Timed out / cancelled (N):*` with N = `stats.timed_out` +
+  `stats.canceled`, listing each `timed_out` or `canceled` job with a short
+  reason when known (e.g. `— cancelled, never ran a test`).
+
+Investigation summaries must be concise. Show
 at most five bullets per section and link to the build for omitted entries.
 Keep the complete report at or below 2,800 characters without breaking Slack
 links or formatting. Write job names as plain text with their leading emoji

--- a/alerting/tests/test_analyzer.py
+++ b/alerting/tests/test_analyzer.py
@@ -638,6 +638,9 @@ def test_materialized_working_files_match_skill_contract(tmp_path: Path) -> None
         "new": 0,
         "recurring": 1,
         "scheduled": 0,
+        "cascaded": 0,
+        "timed_out": 0,
+        "canceled": 0,
         "has_previous_data": True,
         "total": 19,
     }
@@ -648,6 +651,46 @@ def test_materialized_working_files_match_skill_contract(tmp_path: Path) -> None
     assert "Phase A" in observed["agent"]
     assert "Phase D" in observed["agent"]
     assert "git push" not in observed["agent"]
+
+
+def test_summary_stats_count_cascaded_and_unfinished_jobs() -> None:
+    run1 = make_run(1, RUN1_AT)
+    run2 = make_run(2, RUN2_AT)
+    harness = Harness(
+        runs=[run1, run2],
+        builds={
+            2: build_json(
+                2,
+                mostly_passing_jobs(
+                    [
+                        ("Cascaded Job", "waiting_failed", False),
+                        ("Timed Out Job", "timed_out", False),
+                        ("Canceled Job", "canceled", False),
+                    ],
+                    # Unfinished jobs count against the 95% completeness gate.
+                    total=60,
+                ),
+                scheduled_at=RUN2_AT,
+            )
+        },
+    )
+    harness.seed_analysis(run1, failed_tests=())
+    observed: dict[str, Any] = {}
+
+    def capture(working_dir: Path) -> None:
+        logs = working_dir / ".logs"
+        observed["summary"] = json.loads((logs / "nightly_summary.json").read_text())
+        well_behaved(working_dir)
+
+    harness.runner.on_run(capture)
+    harness.analyze()
+
+    stats = observed["summary"]["stats"]
+    assert stats["cascaded"] == 1
+    assert stats["timed_out"] == 1
+    assert stats["canceled"] == 1
+    assert stats["failed"] == 0
+    assert stats["passed"] == 57
 
 
 def test_first_comparison_uses_imported_failure_cache_and_checkpoint() -> None:


### PR DESCRIPTION
## Problem

The new full CI analyzer (vLLM CI Bot) dropped the **Cascaded, never ran** and **Timed out / cancelled** sections that the legacy CI Notification Bot report had. The rewritten analyzer skill (`alerting/assets/vllm-ci-failure-analyzer.md`) only mandated new/recurring/fixed/soft sections; the legacy system got those sections from accumulated agent memory, which the new spec never carried over. `waiting_failed` / `timed_out` / `canceled` jobs were present in the input data but had no mandated section, so they were at best a one-line note.

## Fix

- `alerting/analyzer.py` — precompute `stats.cascaded` (`waiting_failed`), `stats.timed_out`, `stats.canceled` in the materialized summary. The spec forbids the model from counting the jobs array itself, so the counts must be deterministic.
- `alerting/assets/vllm-ci-failure-analyzer.md` — Phase A documents that these states are neither hard nor soft failures and never enter the baseline (`waiting_failed` = cascade from a failed upstream step, not a fault); Phase C mandates `:hourglass_flowing_sand: Cascaded, never ran (N):` and `:stopwatch: Timed out / cancelled (N):` sections matching the legacy report.
- `alerting/tests/test_analyzer.py` — updated exact stats assertion; added `test_summary_stats_count_cascaded_and_unfinished_jobs`.

## Tests

`uv run pytest alerting/tests/` — 212 passed.