### PR TITLE
feat(alerting): grant worker SSM access by default and document in-place deploys

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -20,10 +20,12 @@ must be JSON objects whose keys are environment-variable names.
 
 The role can read only these two named secrets and can list, read, and write
 only the stack's checkpoint bucket. The instance has no SSH ingress and needs
-no interactive credential setup. Each service fetches credentials through its
-instance role, writes them briefly under `/run/alerting`, removes the file
-before starting Python, and suppresses worker stdout and stderr so credentials,
-CI logs, model output, and Slack payloads do not enter the journal.
+no interactive credential setup; day-to-day access is through SSM Session
+Manager / Run Command via the role's `AmazonSSMManagedInstanceCore` managed
+policy. Each service fetches credentials through its instance role, writes
+them briefly under `/run/alerting`, removes the file before starting Python,
+and suppresses worker stdout and stderr so credentials, CI logs, model output,
+and Slack payloads do not enter the journal.
 
 The Full CI analyzer calls the Kimi API using `KIMI_API_KEY` from
 `WorkerSecretArn`, with a bundled read-only analyzer definition and the stack
@@ -64,6 +66,10 @@ the instance **without** re-running provisioning — cloud-init runs UserData
 only once per instance, so `/etc/alerting/worker.env` is not rewritten. Any
 parameter or environment change requires a real instance replacement (see
 [disaster-recovery.md](disaster-recovery.md)).
+
+A merged code change does **not** need a stack update at all: pull the repo on
+the worker and re-run `install.sh` over SSM Run Command — see
+[disaster-recovery.md](disaster-recovery.md#in-place-code-updates-ssm).
 
 ## Shadow, cutover, and rollback
 

--- a/deploy/aws/alerting-worker.yaml
+++ b/deploy/aws/alerting-worker.yaml
@@ -71,6 +71,11 @@ Resources:
             Principal:
               Service: ec2.amazonaws.com
             Action: sts:AssumeRole
+      # SSM Session Manager / Run Command access for in-place ops (code
+      # updates, health checks). The security group already allows the 443
+      # egress the agent needs; the instance stays without SSH ingress.
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Policies:
         - PolicyName: AlertingWorkerCheckpointAccess
           PolicyDocument:

--- a/deploy/aws/disaster-recovery.md
+++ b/deploy/aws/disaster-recovery.md
@@ -4,6 +4,36 @@ The alerting worker is disposable. All durable state lives in Postgres (runs,
 comparisons, analyses, scan cursors, outbox, execution records) and the S3
 checkpoint bucket (analyzer memory, delivery modes), both outside the instance.
 
+## In-place code updates (SSM)
+
+The worker role includes `AmazonSSMManagedInstanceCore`, so the instance is
+SSM-managed (the security group's 443 egress is all the agent needs; there is
+still no SSH ingress). A merged code change deploys without replacing the
+instance — pull the repo on the box and re-run `install.sh` via Run Command:
+
+```bash
+aws ssm send-command \
+  --instance-ids <instance-id> \
+  --document-name AWS-RunShellScript \
+  --timeout-seconds 600 \
+  --parameters '{"commands":[
+    "cd /opt/alerting/source && git fetch origin main && git reset --hard origin/main",
+    "/opt/alerting/source/deploy/aws/install.sh <checkpoint-bucket> <worker-secret-arn> <github-secret-arn> <kimi-effort> <kimi-main-ci-effort>"
+  ]}'
+```
+
+Take the `install.sh` arguments from the live stack
+(`aws cloudformation describe-stacks --stack-name <stack-name>` — the secret
+ARNs and Kimi efforts are parameters, the bucket name is an output).
+`install.sh` is idempotent for this purpose: it rebuilds the venv package,
+reinstalls the same units and env file, and re-enables the timers. The workers
+are timer-triggered oneshots, so the next tick picks up the new code; verify
+with `systemctl list-timers 'alerting-*' --no-pager`.
+
+Because SSM access is in the template, instance replacement and stack
+recreation both keep this channel — it is not an out-of-band role edit that a
+redeploy would silently drop.
+
 ## Instance replacement (crash, termination, rebuild)
 
 Redeploy the stack with the same parameters; CloudFormation recreates the

--- a/deploy/aws/tests/test_alerting_worker_infrastructure.py
+++ b/deploy/aws/tests/test_alerting_worker_infrastructure.py
@@ -41,6 +41,13 @@ def test_instance_role_is_scoped_to_checkpoint_bucket_and_named_secrets() -> Non
     assert "Resource: '*'" not in template
 
 
+def test_instance_role_is_ssm_managed_for_in_place_ops() -> None:
+    template = read("alerting-worker.yaml")
+
+    assert "ManagedPolicyArns" in template
+    assert "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" in template
+
+
 def test_full_ci_timer_uses_pacific_wall_clock_and_recovers_after_downtime() -> None:
     timer = read("systemd/alerting-full-ci.timer")
 


### PR DESCRIPTION
## Problem

The live worker (`i-0957b1b607f75f304`) is SSM-managed and we just used Run Command to deploy #149 in place, but the template's `WorkerRole` never granted SSM — it must have been attached out-of-band. A stack redeploy or instance replacement would silently drop the channel and strand the box (no SSH ingress, no key pair).

## Changes

- `deploy/aws/alerting-worker.yaml` — attach `AmazonSSMManagedInstanceCore` to `WorkerRole`. The security group's existing 443 egress is all the agent needs; no ingress added. Role-only change: deploys in place, no instance replacement.
- `deploy/aws/disaster-recovery.md` — new "In-place code updates (SSM)" section documenting the `git fetch + install.sh` Run Command deploy path, where to get the `install.sh` args from the live stack, and why the channel now survives redeploys.
- `deploy/aws/README.md` — access note in Secrets section + pointer from Deploy.
- `deploy/aws/tests/test_alerting_worker_infrastructure.py` — assert the managed policy stays attached.

## Validation

- `aws cloudformation validate-template` — OK
- `pytest deploy/aws/tests/` — 25 passed

After merge, apply with a parameter-identical `aws cloudformation deploy` (role updates in place; the instance is untouched).