### PR TITLE
fix(alerting): validate full secret ARNs before worker deployment

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -18,6 +18,18 @@ must be JSON objects whose keys are environment-variable names.
   limited to read-only metadata and contents for required repositories. The
   worker must have no repository write permission.
 
+Pass the **full ARN**, including the six-character suffix, for both parameters:
+
+```bash
+aws secretsmanager describe-secret --secret-id vllm-alerting-github-read \
+  --query ARN --output text
+```
+
+Secrets Manager accepts a partial ARN for lookups, but the template also uses
+these values as exact IAM policy resources. A partial ARN there denies secret
+access and prevents every worker from starting. The parameter validation rejects
+the missing-suffix form; always use the ARN returned by `describe-secret`.
+
 The role can read only these two named secrets and can list, read, and write
 only the stack's checkpoint bucket. The instance has no SSH ingress and needs
 no interactive credential setup; day-to-day access is through SSM Session

--- a/deploy/aws/alerting-worker.yaml
+++ b/deploy/aws/alerting-worker.yaml
@@ -20,10 +20,14 @@ Parameters:
     Default: main
   WorkerSecretArn:
     Type: String
-    Description: ARN of a JSON secret containing runtime environment variables
+    Description: Full ARN of a JSON secret containing runtime environment variables
+    AllowedPattern: 'arn:aws[a-z-]*:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[A-Za-z0-9/_+=.@-]+-[A-Za-z0-9]{6}'
+    ConstraintDescription: Must be a full Secrets Manager ARN including its six-character suffix; use describe-secret --query ARN.
   GitHubReadOnlySecretArn:
     Type: String
-    Description: ARN of a JSON secret containing a read-only GITHUB_TOKEN
+    Description: Full ARN of a JSON secret containing a read-only GITHUB_TOKEN
+    AllowedPattern: 'arn:aws[a-z-]*:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[A-Za-z0-9/_+=.@-]+-[A-Za-z0-9]{6}'
+    ConstraintDescription: Must be a full Secrets Manager ARN including its six-character suffix; use describe-secret --query ARN.
   KimiReasoningEffort:
     Type: String
     Description: Thinking effort for the Full CI Kimi analyzer

--- a/deploy/aws/tests/test_alerting_worker_infrastructure.py
+++ b/deploy/aws/tests/test_alerting_worker_infrastructure.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from pathlib import Path
+import re
 
 import pytest
 
@@ -46,6 +47,22 @@ def test_instance_role_is_ssm_managed_for_in_place_ops() -> None:
 
     assert "ManagedPolicyArns" in template
     assert "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" in template
+
+
+@pytest.mark.parametrize("parameter", ["WorkerSecretArn", "GitHubReadOnlySecretArn"])
+def test_secret_parameters_reject_partial_arns_used_as_iam_resources(parameter: str) -> None:
+    block = read("alerting-worker.yaml").split(f"  {parameter}:\n", 1)[1]
+    block = re.split(r"\n  \S", block, maxsplit=1)[0]
+    pattern = block.split("AllowedPattern: '", 1)[1].split("'", 1)[0]
+    partial = "arn:aws:secretsmanager:us-east-1:123456789012:secret:github-read"
+
+    assert re.fullmatch(pattern, partial) is None
+    assert re.fullmatch(pattern, "github-read") is None
+    assert re.fullmatch(pattern, partial + "-Ab12Cd") is not None
+    assert re.fullmatch(
+        pattern,
+        "arn:aws-us-gov:secretsmanager:us-gov-west-1:123456789012:secret:ci/token-Ab12Cd",
+    ) is not None
 
 
 def test_full_ci_timer_uses_pacific_wall_clock_and_recovers_after_downtime() -> None:


### PR DESCRIPTION
The alerting worker stopped ingesting CI results after a CloudFormation update reapplied an IAM policy whose `GitHubReadOnlySecretArn` omitted the Secrets Manager suffix. Secrets Manager accepts partial ARNs for lookups, but the same parameter is used verbatim as an IAM resource and therefore did not grant access to the actual secret. Every consumer failed in `load-secrets` before recording an execution, leaving the dashboard stale.

Add full-ARN format constraints to both secret parameters and document obtaining the canonical ARN with `describe-secret`. Tests cover the observed partial ARN, plain names, full ARNs, and GovCloud ARNs. No broader IAM permissions are introduced.

The live stack parameter has separately been corrected to the canonical secret ARN. Secret loading now succeeds and the Main CI cursor has advanced beyond the outage cutoff.

Validation:
- `.venv/bin/python -m pytest deploy/aws/tests/ -q`: 27 passed.
- `.venv/bin/ruff check deploy/aws/tests/test_alerting_worker_infrastructure.py`: passed.
- `aws cloudformation validate-template --template-body file://deploy/aws/alerting-worker.yaml`: passed.
- `git diff --check`: passed.

No matching open secret-ARN validation PR was found. AI assistance was used for the investigation, repair, implementation, and validation.
