### PR TITLE
perf(builds): cache settled job rosters to fix slow main page cold loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ page (Builds) loads, see the [Builds latency guide](./docs/builds-performance.md
 | `SLACK_BOT_TOKEN` | Slack bot for queue-depth alerts (`chat:write`, `reactions:write`) |
 | `SLACK_CI_NOTIFICATIONS_CHANNEL`, `SLACK_CI_FAST_FAILURE_ALERT_CHANNEL`, `SLACK_CI_INFRA_ALERT_CHANNEL` | Per-path Slack channels for Full CI, Fast CI, and infra/queue alerts; `SLACK_CHANNEL_ID` is the legacy shared fallback when a per-path channel is unset |
 | `CRON_SECRET` | Optional shared secret required by Vercel cron handlers |
+| `WARM_JOBS_BASE_URL` | Optional base URL the `/api/cron/warm-jobs` cache warmer requests; defaults to `https://ci.vllm.ai` |
 
 The dashboard assumes a warehouse schema with tables under `vllm_data_warehouse.buildkite.*` (builds, jobs, agent query rules) and `vllm_data_warehouse.default.vllm_perf_data_ingest` for benchmarks. Adapt the queries in `src/app/api/**/route.ts` if your schema differs.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ npm run dev
 Open http://localhost:3000.
 
 For slow Jobs loads, use the [latency probe and timing guide](./docs/jobs-performance.md)
-to separate CDN caching, backend queries, and browser startup.
+to separate CDN caching, backend queries, and browser startup. For slow main
+page (Builds) loads, see the [Builds latency guide](./docs/builds-performance.md).
 
 ### Environment variables
 

--- a/docs/builds-performance.md
+++ b/docs/builds-performance.md
@@ -1,0 +1,58 @@
+# Diagnosing slow Builds (main page) loads
+
+The main page loads in a chain: page shell, then `/api/builds/filters` and
+`/api/builds` in parallel, then `/api/builds/groups?buildIds=...` for the 50
+builds on the first page. The groups response carries the Job Groups filter
+options, so a slow groups call delays the whole filter/table area.
+
+Run the read-only probe against a local server or production:
+
+```bash
+BASE=https://ci.vllm.ai node scripts/profile-builds.mjs
+BASE=http://localhost:3000 BYPASS_CDN=1 node scripts/profile-builds.mjs
+```
+
+The probe times each chain step and the total. It exits nonzero for failed
+requests or chains over `MAX_MS` (default 3000). Set `START`, `END`,
+`PIPELINE`, and `BRANCH` to reproduce reported filters; set `SAMPLES` (1–20)
+for repeats. `BYPASS_CDN=1` gives each URL a unique diagnostic parameter; it
+does not bypass the application caches. `/api/builds/groups` responds with a
+`Server-Timing` header breaking out `roster` (Buildkite REST), `spans` (OTel
+fallback), or `warehouse` (Databricks) time.
+
+## Why cold groups loads were slow (2026-09-09)
+
+In OTel mode `/api/builds/groups` reads each build's job roster from the
+Buildkite REST API, because OTel spans only cover jobs that ran — jobs behind
+the pipeline's manual gate never execute and produce no spans. That is one
+REST call per build, ~50 per page, and the request URL embeds the current
+build ids, so every new CI build creates a URL no CDN or application cache
+has seen. Production misses measured 3.5–3.6 s (twice) versus 56–92 ms warm.
+
+Settled builds (passed/failed/canceled/skipped/not_run/finished) have an
+immutable roster, so they are now cached per build for 24 hours; only active
+builds are refetched. Steady-state misses therefore fetch a handful of builds
+instead of 50. Failed fetches are never cached, and concurrent requests for
+the same build share one fetch.
+
+## Remaining risks
+
+- `/api/builds/filters` cold misses measured 2.4–8.5 s in production, but the
+  SQL itself runs 50–400 ms warm; the spread is serverless cold start plus
+  database buffer state, not query shape. Both filter queries are bounded to
+  30 days so cold scans do not grow with table history.
+- The OTel roster fallback (`queryBuildJobsFromOtel`, used when the Buildkite
+  token fails) measured 77–92 s for 50 builds: the row constructor
+  `(pipeline_slug, build_number) IN (...)` cannot use `idx_otel_spans_build`
+  because its leading `organization_slug` column is unconstrained. Roster
+  caching makes an empty roster (and therefore this fallback) much less
+  likely, but the query itself still needs an org-scoped rewrite or index.
+  To reproduce: `node --env-file=.env.local --import tsx scripts/profile-groups.mjs`
+  (without a Buildkite token the roster returns empty and the fallback runs).
+
+To time the filters queries directly, bypassing browser/CDN/application
+caches:
+
+```bash
+node --env-file=.env.local --import tsx scripts/profile-filters-db.mjs
+```

--- a/docs/jobs-performance.md
+++ b/docs/jobs-performance.md
@@ -108,18 +108,22 @@ query per call and a `MAX_MS` budget (default 3000), and prints `dispatchMs`
 and connection waits from work after submission. No SQL, credentials, or job
 contents are logged. Filter overrides match the HTTP probe.
 
-## Cold-instance fills and the cache warmer (2026-09-09)
+## Cold-instance fills, stable window keys, and the cache warmer (2026-09-09)
 
 Post-fix, warm-instance application misses measure 300–900 ms. The remaining
 spike is the first fill on a cold serverless instance: 20.7s and 23.1s fills
 were measured on the default key while interleaved warm-instance misses took
 under a second. Because `staleWhileRevalidate` absorbs revalidations, users
-only pay this when a POP has no entry at all — chiefly after the daily
-date-range rollover changes the cache key at midnight.
+only pay this when a POP has no entry at all — which used to happen every
+morning, because the page put absolute `startDate`/`endDate` in the URL and
+the midnight rollover created a cache key no edge had ever seen.
 
-`/api/cron/warm-jobs` runs every minute and re-requests the Jobs page's
-default 14-day window with a CDN-bypassing parameter, keeping the origin
-application cache warm so first fills cost the warm-query time instead of the
-cold-instance penalty. It warms only the region its request lands in; other
-POPs still fill on first view, but against a warm origin. The cron reports
-the warm request's `Server-Timing` in its JSON response.
+The default view now sends `window=14d` instead of absolute dates. The route
+resolves the window at fill time, so the URL — and its CDN entry — is stable
+across days and stale-while-revalidate can serve every request instantly.
+Explicit date ranges keep the old per-day keys. `/api/cron/warm-jobs` runs
+every minute against that same stable URL with a CDN-bypassing parameter,
+keeping the origin application cache warm so even a first fill costs the
+warm-query time (~300–500 ms) instead of the cold-instance penalty. The cron
+warms only the region its request lands in, and it reports the warm request's
+`Server-Timing` in its JSON response.

--- a/docs/jobs-performance.md
+++ b/docs/jobs-performance.md
@@ -107,3 +107,19 @@ query per call and a `MAX_MS` budget (default 3000), and prints `dispatchMs`
 (time until the SQL driver sends each statistics query) to distinguish startup
 and connection waits from work after submission. No SQL, credentials, or job
 contents are logged. Filter overrides match the HTTP probe.
+
+## Cold-instance fills and the cache warmer (2026-09-09)
+
+Post-fix, warm-instance application misses measure 300–900 ms. The remaining
+spike is the first fill on a cold serverless instance: 20.7s and 23.1s fills
+were measured on the default key while interleaved warm-instance misses took
+under a second. Because `staleWhileRevalidate` absorbs revalidations, users
+only pay this when a POP has no entry at all — chiefly after the daily
+date-range rollover changes the cache key at midnight.
+
+`/api/cron/warm-jobs` runs every minute and re-requests the Jobs page's
+default 14-day window with a CDN-bypassing parameter, keeping the origin
+application cache warm so first fills cost the warm-query time instead of the
+cold-instance penalty. It warms only the region its request lands in; other
+POPs still fill on first view, but against a warm origin. The cron reports
+the warm request's `Server-Timing` in its JSON response.

--- a/scripts/profile-builds.mjs
+++ b/scripts/profile-builds.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Read-only latency probe for the main (Builds) page request chain:
+// page shell -> /api/builds -> /api/builds/groups (buildIds from the builds
+// response). No credentials or response bodies are logged; only counts.
+const base = process.env.BASE ?? "http://localhost:3000";
+const samples = Number(process.env.SAMPLES ?? 3);
+const budget = Number(process.env.MAX_MS ?? 3000);
+if (!Number.isInteger(samples) || samples < 1 || samples > 20 || !Number.isFinite(budget) || budget <= 0) {
+  throw new Error("SAMPLES must be 1–20 and MAX_MS must be positive");
+}
+const end = new Date();
+const start = new Date(end);
+start.setUTCDate(start.getUTCDate() - 14);
+const params = new URLSearchParams({
+  pipeline: process.env.PIPELINE ?? "CI",
+  branch: process.env.BRANCH ?? "main",
+  startDate: process.env.START ?? start.toISOString().slice(0, 10),
+  endDate: process.env.END ?? end.toISOString().slice(0, 10),
+  page: "0",
+});
+if (process.env.SOURCE) {
+  if (!["otel", "databricks"].includes(process.env.SOURCE)) throw new Error("SOURCE must be otel or databricks");
+  params.set("source", process.env.SOURCE);
+}
+
+function bypass(url) {
+  // Bypasses the CDN URL cache, but deliberately leaves the application's
+  // semantic cache key intact. MISS at the CDN need not mean a database read.
+  if (process.env.BYPASS_CDN === "1") url.searchParams.set("_profile", `${Date.now()}-${Math.random()}`);
+  return url;
+}
+
+async function timedFetch(url) {
+  const started = performance.now();
+  const response = await fetch(bypass(url), { signal: AbortSignal.timeout(60_000) });
+  const ttfb = performance.now() - started;
+  const body = await response.text();
+  const elapsed = performance.now() - started;
+  return { response, body, ttfb, elapsed };
+}
+
+function report(path, sample, r, extra = {}) {
+  console.log(JSON.stringify({
+    path, sample, status: r.response.status,
+    ttfbMs: Math.round(r.ttfb), totalMs: Math.round(r.elapsed),
+    bytes: Buffer.byteLength(r.body),
+    cdnCache: r.response.headers.get("x-vercel-cache"), age: r.response.headers.get("age"),
+    serverTiming: r.response.headers.get("server-timing"),
+    ...extra,
+  }));
+}
+
+try {
+  for (let sample = 1; sample <= samples; sample++) {
+    const chainStart = performance.now();
+
+    const shell = await timedFetch(new URL("/", base));
+    report("/", sample, shell);
+
+    const filtersParams = new URLSearchParams();
+    if (params.has("source")) filtersParams.set("source", params.get("source"));
+    const filters = await timedFetch(new URL(`/api/builds/filters?${filtersParams}`, base));
+    report("/api/builds/filters", sample, filters);
+
+    const builds = await timedFetch(new URL(`/api/builds?${params}`, base));
+    let buildIds = [];
+    let buildsValid = builds.response.ok;
+    try {
+      const data = JSON.parse(builds.body);
+      buildsValid &&= Array.isArray(data.builds) && !data.error;
+      buildIds = data.builds.map((b) => b.id).filter(Boolean);
+    } catch {
+      buildsValid = false;
+    }
+    report("/api/builds", sample, builds, { builds: buildIds.length, valid: buildsValid });
+
+    let groupsMs = 0;
+    let groupsValid = true;
+    if (buildIds.length > 0) {
+      const groupsParams = new URLSearchParams({ buildIds: buildIds.join(",") });
+      if (params.has("source")) groupsParams.set("source", params.get("source"));
+      const groups = await timedFetch(new URL(`/api/builds/groups?${groupsParams}`, base));
+      groupsMs = groups.elapsed;
+      try {
+        const data = JSON.parse(groups.body);
+        groupsValid = groups.response.ok && Array.isArray(data.jobOptions) && !data.error;
+        report("/api/builds/groups", sample, groups, {
+          jobOptions: data.jobOptions?.length ?? 0, valid: groupsValid,
+        });
+      } catch {
+        groupsValid = false;
+        report("/api/builds/groups", sample, groups, { valid: false });
+      }
+    }
+
+    const chainMs = performance.now() - chainStart;
+    const pass = shell.response.ok && buildsValid && groupsValid && chainMs <= budget;
+    console.log(JSON.stringify({
+      path: "CHAIN", sample, chainMs: Math.round(chainMs),
+      groupsMs: Math.round(groupsMs), verdict: pass ? "PASS" : "FAIL",
+    }));
+    if (!pass) process.exitCode = 1;
+  }
+} catch (error) {
+  console.error(`FAIL: builds probe could not complete (${error.name})`);
+  process.exitCode = 1;
+}

--- a/scripts/profile-filters-db.mjs
+++ b/scripts/profile-filters-db.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Run with: node --env-file=.env.local --import tsx scripts/profile-filters-db.mjs
+// Times the two /api/builds/filters OTel queries separately, bypassing
+// browser, CDN, and application caches. No row contents are logged.
+import { getDb } from "../src/lib/db.ts";
+
+const budget = Number(process.env.MAX_MS ?? 3000);
+if (!Number.isFinite(budget) || budget <= 0) throw new Error("MAX_MS must be positive");
+const db = getDb();
+
+async function timeQuery(label, run) {
+  const started = performance.now();
+  const rows = await run();
+  const ms = Math.round(performance.now() - started);
+  const pass = ms <= budget;
+  console.log(JSON.stringify({ query: label, ms, rows: rows.length, verdict: pass ? "PASS" : "FAIL" }));
+  if (!pass) process.exitCode = 1;
+}
+
+try {
+  for (let sample = 1; sample <= 2; sample++) {
+    console.log(JSON.stringify({ sample, freshConnectionPool: sample === 1 }));
+    await timeQuery("pipelines-unbounded", () => db`
+      SELECT DISTINCT resource_attributes->>'buildkite.pipeline.name' AS name
+      FROM otel_spans
+      WHERE span_name = 'buildkite.build'
+        AND resource_attributes->>'buildkite.pipeline.name' IS NOT NULL
+      ORDER BY name
+    `);
+    await timeQuery("branches-30d", () => db`
+      SELECT DISTINCT span_attributes->>'buildkite.build.branch' AS branch
+      FROM otel_spans
+      WHERE span_name = 'buildkite.build'
+        AND start_time > NOW() - INTERVAL '30 days'
+        AND span_attributes->>'buildkite.build.branch' IS NOT NULL
+      ORDER BY branch
+    `);
+  }
+} catch (error) {
+  console.error(`FAIL: filters probe could not complete (${error.name})`);
+  process.exitCode = 1;
+} finally {
+  await db.end();
+}

--- a/scripts/profile-groups.mjs
+++ b/scripts/profile-groups.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Run with: node --env-file=.env.local --import tsx scripts/profile-groups.mjs
+// Times the /api/builds/groups data fetch both ways for the same 50 builds:
+// the Buildkite REST roster fan-out (current OTel path) versus a single
+// OTel SQL query (the fallback). No credentials or row contents are logged.
+import { queryBuildsFromOtel, queryBuildJobsFromOtel } from "../src/lib/otel-ci.ts";
+import { getBuildJobRosterRows } from "../src/lib/buildkite-build-jobs.ts";
+import { getDb } from "../src/lib/db.ts";
+
+const budget = Number(process.env.MAX_MS ?? 3000);
+if (!Number.isFinite(budget) || budget <= 0) throw new Error("MAX_MS must be positive");
+
+const end = new Date();
+const start = new Date(end);
+start.setUTCDate(start.getUTCDate() - 14);
+
+const db = getDb();
+try {
+  const { builds } = await queryBuildsFromOtel({
+    pipeline: process.env.PIPELINE ?? "CI",
+    branch: process.env.BRANCH ?? "main",
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+    page: 0,
+    pageSize: 50,
+    jobGroups: [],
+    jobNames: [],
+  });
+  const buildIds = builds.map((b) => b.id).filter(Boolean);
+  console.log(JSON.stringify({ builds: buildIds.length }));
+
+  for (let sample = 1; sample <= 2; sample++) {
+    let started = performance.now();
+    const rosterRows = await getBuildJobRosterRows(buildIds);
+    const rosterMs = Math.round(performance.now() - started);
+
+    started = performance.now();
+    const otelRows = await queryBuildJobsFromOtel(buildIds);
+    const otelMs = Math.round(performance.now() - started);
+
+    const pass = rosterMs <= budget;
+    console.log(JSON.stringify({
+      sample, rosterMs, rosterRows: rosterRows.length,
+      otelMs, otelRows: otelRows.length,
+      verdict: pass ? "PASS" : "FAIL",
+    }));
+    if (!pass) process.exitCode = 1;
+  }
+} catch (error) {
+  console.error(`FAIL: groups probe could not complete (${error.name})`);
+  process.exitCode = 1;
+} finally {
+  await db.end();
+}

--- a/src/app/api/builds/filters/route.ts
+++ b/src/app/api/builds/filters/route.ts
@@ -23,6 +23,7 @@ export async function GET(request: NextRequest) {
           SELECT DISTINCT resource_attributes->>'buildkite.pipeline.name' AS name
           FROM otel_spans
           WHERE span_name = 'buildkite.build'
+            AND start_time > NOW() - INTERVAL '30 days'
             AND resource_attributes->>'buildkite.pipeline.name' IS NOT NULL
           ORDER BY name
         `,

--- a/src/app/api/builds/groups/route.ts
+++ b/src/app/api/builds/groups/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { queryDatabricks } from "@/lib/databricks";
 import { getCached, setCache } from "@/lib/api-cache";
 import { cachedJson } from "@/lib/api-response";
+import { ServerTiming } from "@/lib/server-timing";
 import {
   aggregateJobsByGroup,
   isFailedJobState,
@@ -25,6 +26,7 @@ function escapeSql(value: string): string {
 }
 
 export async function GET(request: NextRequest) {
+  const timing = new ServerTiming();
   try {
     const buildIds = [
       ...new Set(
@@ -50,7 +52,11 @@ export async function GET(request: NextRequest) {
 
     const cacheKey = `build-groups:${buildIds.join(",")}:${resolveCiDataSource(request)}`;
     const cached = getCached(cacheKey);
-    if (cached) return cachedJson(cached, CDN_CACHE);
+    if (cached) {
+      const cachedResponse = cachedJson(cached, CDN_CACHE);
+      cachedResponse.headers.set("Server-Timing", timing.header());
+      return cachedResponse;
+    }
 
     let jobs: Record<string, unknown>[];
     if (resolveCiDataSource(request) === "otel") {
@@ -59,13 +65,13 @@ export async function GET(request: NextRequest) {
       // the complete job list, so the group columns match the warehouse. Fall
       // back to OTel spans if the roster comes back empty (e.g. API token
       // misconfigured) so the table never loses every column.
-      jobs = await getBuildJobRosterRows(buildIds);
+      jobs = await timing.measure("roster", getBuildJobRosterRows(buildIds));
       if (jobs.length === 0) {
-        jobs = await queryBuildJobsFromOtel(buildIds);
+        jobs = await timing.measure("spans", queryBuildJobsFromOtel(buildIds));
       }
     } else {
       const idList = buildIds.map((id) => `'${escapeSql(id)}'`).join(",");
-      jobs = await queryDatabricks(`
+      jobs = await timing.measure("warehouse", queryDatabricks(`
         SELECT
           j.build_id,
           j.name,
@@ -81,7 +87,7 @@ export async function GET(request: NextRequest) {
           AND j._fivetran_deleted = false
           AND j.type = 'script'
           AND j.name IS NOT NULL
-      `);
+      `));
     }
 
     const jobsByBuild = new Map<
@@ -196,12 +202,14 @@ export async function GET(request: NextRequest) {
     };
     setCache(cacheKey, result, TTL);
 
-    return cachedJson(result, CDN_CACHE);
+    const response = cachedJson(result, CDN_CACHE);
+    response.headers.set("Server-Timing", timing.header());
+    return response;
   } catch (error) {
     console.error("Failed to fetch build group summaries:", error);
     return NextResponse.json(
       { error: "Failed to fetch build group summaries" },
-      { status: 500 },
+      { status: 500, headers: { "Server-Timing": timing.header() } },
     );
   }
 }

--- a/src/app/api/cron/warm-jobs/route.ts
+++ b/src/app/api/cron/warm-jobs/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const maxDuration = 60;
+
+// Keep the Jobs page's default request warm across the CDN and application
+// caches. Without this, the daily date rollover empties both caches and the
+// first request per region pays a cold fill, which on a cold serverless
+// instance has measured up to ~20s (see docs/jobs-performance.md). The page
+// computes its 14-day window client-side; the cron approximates it in UTC,
+// which matches except around local midnight.
+export async function GET(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const auth = request.headers.get("authorization");
+    if (auth !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  const end = new Date();
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 14);
+  const params = new URLSearchParams({
+    pipeline: "CI",
+    branch: "main",
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+  });
+  const base = process.env.WARM_JOBS_BASE_URL ?? "https://ci.vllm.ai";
+
+  const started = performance.now();
+  try {
+    // The diagnostic parameter bypasses the CDN URL cache so every tick
+    // reaches the origin; the origin's 60s application cache absorbs all but
+    // one backend query per minute.
+    params.set("_warm", String(Date.now()));
+    const response = await fetch(`${base}/api/jobs?${params}`, {
+      cache: "no-store",
+      signal: AbortSignal.timeout(50_000),
+    });
+    const durationMs = Math.round(performance.now() - started);
+    return NextResponse.json({
+      ok: response.ok,
+      status: response.status,
+      durationMs,
+      serverTiming: response.headers.get("server-timing"),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Warm-up request failed: ${(error as Error).name}` },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/cron/warm-jobs/route.ts
+++ b/src/app/api/cron/warm-jobs/route.ts
@@ -3,11 +3,10 @@ import { NextRequest, NextResponse } from "next/server";
 export const maxDuration = 60;
 
 // Keep the Jobs page's default request warm across the CDN and application
-// caches. Without this, the daily date rollover empties both caches and the
-// first request per region pays a cold fill, which on a cold serverless
-// instance has measured up to ~20s (see docs/jobs-performance.md). The page
-// computes its 14-day window client-side; the cron approximates it in UTC,
-// which matches except around local midnight.
+// caches. The page's default view uses a stable window=14d URL whose cache key
+// never changes, so warming it covers the exact entry users hit; without a
+// warmer, the first fill on a cold serverless instance has measured ~20s
+// (see docs/jobs-performance.md).
 export async function GET(request: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
   if (cronSecret) {
@@ -17,14 +16,10 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  const end = new Date();
-  const start = new Date(end);
-  start.setUTCDate(start.getUTCDate() - 14);
   const params = new URLSearchParams({
     pipeline: "CI",
     branch: "main",
-    startDate: start.toISOString().slice(0, 10),
-    endDate: end.toISOString().slice(0, 10),
+    window: "14d",
   });
   const base = process.env.WARM_JOBS_BASE_URL ?? "https://ci.vllm.ai";
 

--- a/src/app/api/jobs/route.test.ts
+++ b/src/app/api/jobs/route.test.ts
@@ -56,6 +56,35 @@ test("concurrent jobs requests share queries and expose cache/query timings", as
 });
 
 
+test("a relative window uses one stable cache key across resolved dates", async (t) => {
+  configureWarehouse(t);
+  const fetchMock = t.mock.method(globalThis, "fetch", async () =>
+    Response.json({
+      status: { state: "SUCCEEDED" },
+      manifest: { schema: { columns: [{ name: "name" }] } },
+      result: { data_array: [["test job"]] },
+    }),
+  );
+  const url = "http://localhost/api/jobs?source=databricks&branch=window-test&window=14d";
+
+  const first = await GET(new NextRequest(url));
+  assert.equal(first.status, 200);
+  assert.match(first.headers.get("Server-Timing") ?? "", /cache;desc="MISS"/);
+  assert.equal(fetchMock.mock.callCount(), 2);
+
+  const second = await GET(new NextRequest(url));
+  assert.match(second.headers.get("Server-Timing") ?? "", /cache;desc="HIT"/);
+  assert.equal(fetchMock.mock.callCount(), 2, "the stable window key must not requery");
+
+  const custom = await GET(new NextRequest(`${url}&startDate=2026-09-01&endDate=2026-09-08`));
+  assert.equal(custom.status, 200);
+  assert.equal(fetchMock.mock.callCount(), 4, "explicit dates use their own key");
+
+  const invalid = await GET(new NextRequest("http://localhost/api/jobs?source=databricks&branch=window-test&window=abc"));
+  assert.equal(invalid.status, 200);
+  assert.equal(fetchMock.mock.callCount(), 6, "an invalid window falls back to the no-range key");
+});
+
 test("a partial query failure keeps the fill shared until the other query settles", async (t) => {
   configureWarehouse(t);
   t.mock.method(console, "error", () => {});

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -9,6 +9,17 @@ import { queryJobStatsFromOtel } from "@/lib/otel-ci";
 const TTL = 60_000;
 const CDN_CACHE = { maxAge: 60, staleWhileRevalidate: 3_600 };
 
+// A relative window (window=14d) keeps the default view's URL stable across
+// days, so CDN entries survive the midnight date rollover and
+// stale-while-revalidate serves every request instantly. Explicit start/end
+// dates take precedence and keep the old per-day cache keys.
+function parseWindowDays(value: string | null): number | null {
+  const match = value?.match(/^(\d{1,3})d$/);
+  if (!match) return null;
+  const days = parseInt(match[1], 10);
+  return days >= 1 && days <= 90 ? days : null;
+}
+
 export async function GET(request: NextRequest) {
   const timing = new ServerTiming();
   try {
@@ -17,10 +28,21 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const pipeline = searchParams.get("pipeline") || "CI";
     const branch = searchParams.get("branch") || "main";
-    const startDate = searchParams.get("startDate");
-    const endDate = searchParams.get("endDate");
+    let startDate = searchParams.get("startDate");
+    let endDate = searchParams.get("endDate");
+    const windowDays =
+      startDate || endDate ? null : parseWindowDays(searchParams.get("window"));
+    if (windowDays !== null) {
+      const end = new Date();
+      const start = new Date(end);
+      start.setUTCDate(start.getUTCDate() - windowDays);
+      startDate = start.toISOString().slice(0, 10);
+      endDate = end.toISOString().slice(0, 10);
+    }
+    const rangeKey =
+      windowDays !== null ? `window:${windowDays}d` : `${startDate}:${endDate}`;
 
-    const cacheKey = `jobs:${pipeline}:${branch}:${startDate}:${endDate}:${source}`;
+    const cacheKey = `jobs:${pipeline}:${branch}:${rangeKey}:${source}`;
     const { data: result, status } = await getOrLoadCached(cacheKey, TTL, async () => {
       if (source === "otel") {
         return timing.measure("backend", queryJobStatsFromOtel({

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -127,11 +127,13 @@ function JobAnalysisTab({
   branch,
   startDate,
   endDate,
+  useWindow,
 }: {
   pipeline: string;
   branch: string;
   startDate: string;
   endDate: string;
+  useWindow: boolean;
 }) {
   const [analysisTab, setAnalysisTab] = useState<"failures" | "duration">("failures");
   const [hideSoftFail, setHideSoftFail] = useState(false);
@@ -146,8 +148,14 @@ function JobAnalysisTab({
   const params = new URLSearchParams();
   if (pipeline) params.set("pipeline", pipeline);
   if (branch) params.set("branch", branch);
-  if (startDate) params.set("startDate", startDate);
-  if (endDate) params.set("endDate", endDate);
+  if (useWindow) {
+    // Stable key: the server resolves the rolling window at fill time, so the
+    // CDN entry survives the midnight date rollover.
+    params.set("window", "14d");
+  } else {
+    if (startDate) params.set("startDate", startDate);
+    if (endDate) params.set("endDate", endDate);
+  }
   const apiUrl = `/api/jobs?${params.toString()}`;
 
   const { data, error, isLoading } = useSWR<JobsResponse>(apiUrl, fetcher, {
@@ -508,8 +516,11 @@ function JobAnalysisTab({
 export default function JobsPage() {
   const [pipeline, setPipeline] = useState("CI");
   const [branch, setBranch] = useState("main");
-  const [startDate, setStartDate] = useState(daysAgo(14));
-  const [endDate, setEndDate] = useState(today());
+  // null = default rolling window (sent as window=14d with a stable cache key);
+  // set once the user picks an explicit range.
+  const [range, setRange] = useState<{ start: string; end: string } | null>(null);
+  const startDate = range?.start ?? daysAgo(14);
+  const endDate = range?.end ?? today();
 
   const { data: filters } = useSWR<FiltersResponse>(
     "/api/builds/filters",
@@ -539,8 +550,7 @@ export default function JobsPage() {
             startDate={startDate}
             endDate={endDate}
             onChange={(s, e) => {
-              setStartDate(s);
-              setEndDate(e);
+              setRange({ start: s, end: e });
             }}
           />
         </div>
@@ -551,6 +561,7 @@ export default function JobsPage() {
         branch={branch}
         startDate={startDate}
         endDate={endDate}
+        useWindow={range === null}
       />
     </div>
   );

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -39,7 +39,8 @@ function defaultDataUrls(href: string): string[] {
       ];
     case "/jobs":
       return [
-        `/api/jobs?${buildParams}`,
+        // Stable window key shared with the page's default view.
+        `/api/jobs?pipeline=CI&branch=main&window=14d`,
         "/api/builds/filters",
       ];
     case "/tests":

--- a/src/lib/buildkite-build-jobs.test.ts
+++ b/src/lib/buildkite-build-jobs.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test, { type TestContext } from "node:test";
+import { getBuildJobRosters } from "./buildkite-build-jobs";
+
+function configureToken(t: TestContext) {
+  const saved = process.env.BUILDKITE_API_TOKEN;
+  process.env.BUILDKITE_API_TOKEN = "test-token";
+  t.after(() => {
+    if (saved === undefined) delete process.env.BUILDKITE_API_TOKEN;
+    else process.env.BUILDKITE_API_TOKEN = saved;
+  });
+}
+
+function buildPayload(state: string) {
+  return {
+    state,
+    commit: "abc123",
+    branch: "main",
+    jobs: [{ name: "Test", state: state === "running" ? "running" : "passed", type: "script" }],
+  };
+}
+
+function mockBuildkite(t: TestContext, states: Record<string, string>) {
+  return t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const buildNumber = url.split("/builds/")[1];
+    const state = states[buildNumber];
+    if (!state) return new Response("not found", { status: 404 });
+    return Response.json(buildPayload(state));
+  });
+}
+
+test("settled build rosters are cached; active builds are refetched", async (t) => {
+  configureToken(t);
+  const fetchMock = mockBuildkite(t, { "1": "passed", "2": "running" });
+  const builds = [
+    { pipeline: "ci", buildNumber: "1" },
+    { pipeline: "ci", buildNumber: "2" },
+  ];
+
+  const first = await getBuildJobRosters("vllm", builds);
+  assert.equal(fetchMock.mock.callCount(), 2);
+  assert.equal(first.get("ci:1")?.jobs.length, 1);
+  assert.equal(first.get("ci:2")?.jobs.length, 1);
+
+  const second = await getBuildJobRosters("vllm", builds);
+  assert.equal(fetchMock.mock.callCount(), 3, "only the running build is refetched");
+  assert.equal(second.get("ci:1")?.jobs.length, 1);
+  assert.equal(second.get("ci:2")?.jobs.length, 1);
+});
+
+test("failed roster fetches are not cached", async (t) => {
+  configureToken(t);
+  let calls = 0;
+  const fetchMock = t.mock.method(globalThis, "fetch", async () => {
+    calls += 1;
+    if (calls === 1) return new Response("boom", { status: 500 });
+    return Response.json(buildPayload("passed"));
+  });
+  const builds = [{ pipeline: "ci", buildNumber: "9" }];
+
+  const first = await getBuildJobRosters("vllm", builds);
+  assert.equal(first.get("ci:9")?.jobs.length, 0, "failure yields an empty roster");
+
+  const second = await getBuildJobRosters("vllm", builds);
+  assert.equal(fetchMock.mock.callCount(), 2, "the failed build is retried");
+  assert.equal(second.get("ci:9")?.jobs.length, 1);
+});
+
+test("concurrent requests for the same build share one fetch", async (t) => {
+  configureToken(t);
+  const fetchMock = t.mock.method(globalThis, "fetch", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    return Response.json(buildPayload("running"));
+  });
+  const builds = [{ pipeline: "ci", buildNumber: "7" }];
+
+  const [a, b] = await Promise.all([
+    getBuildJobRosters("vllm", builds),
+    getBuildJobRosters("vllm", builds),
+  ]);
+  assert.equal(fetchMock.mock.callCount(), 1);
+  assert.equal(a.get("ci:7")?.jobs.length, 1);
+  assert.equal(b.get("ci:7")?.jobs.length, 1);
+});

--- a/src/lib/buildkite-build-jobs.ts
+++ b/src/lib/buildkite-build-jobs.ts
@@ -11,6 +11,7 @@ export interface BuildJobRoster {
   jobs: BuildJobRosterEntry[];
   commit: string | null;
   branch: string | null;
+  state: string | null;
 }
 
 export class BuildkiteApiError extends Error {
@@ -83,6 +84,26 @@ export async function getBuildJobRoster(
   return fetchBuildJobRoster(organization, pipeline, buildNumber);
 }
 
+// A finished build's job roster never changes, so it is cached for a day.
+// Builds still running (or waiting on a manual gate) are refetched every time;
+// the route-level cache already bounds how often that happens.
+const SETTLED_BUILD_STATES = new Set([
+  "passed",
+  "failed",
+  "canceled",
+  "skipped",
+  "not_run",
+  "finished",
+]);
+const SETTLED_ROSTER_TTL = 24 * 60 * 60 * 1000;
+const ROSTER_CACHE_LIMIT = 500;
+
+const rosterCache = new Map<
+  string,
+  { roster: BuildJobRoster; expiresAt: number }
+>();
+const rosterInFlight = new Map<string, Promise<BuildJobRoster>>();
+
 // Fetch rosters for many builds concurrently, tolerating per-build failures so
 // one missing/expired build does not blank the whole page.
 export async function getBuildJobRosters(
@@ -92,10 +113,34 @@ export async function getBuildJobRosters(
   const results = await Promise.all(
     builds.map(async ({ pipeline, buildNumber }): Promise<[string, BuildJobRoster]> => {
       const key = `${pipeline}:${buildNumber}`;
+      const cached = rosterCache.get(key);
+      if (cached && cached.expiresAt > Date.now()) return [key, cached.roster];
+      const pending = rosterInFlight.get(key);
+      if (pending) return [key, await pending];
+
+      const promise = (async (): Promise<BuildJobRoster> => {
+        try {
+          const roster = await fetchBuildJobRoster(organization, pipeline, buildNumber);
+          if (roster.state !== null && SETTLED_BUILD_STATES.has(roster.state)) {
+            rosterCache.set(key, {
+              roster,
+              expiresAt: Date.now() + SETTLED_ROSTER_TTL,
+            });
+            if (rosterCache.size > ROSTER_CACHE_LIMIT) {
+              const oldest = rosterCache.keys().next().value;
+              if (oldest) rosterCache.delete(oldest);
+            }
+          }
+          return roster;
+        } catch {
+          return { jobs: [], commit: null, branch: null, state: null };
+        }
+      })();
+      rosterInFlight.set(key, promise);
       try {
-        return [key, await fetchBuildJobRoster(organization, pipeline, buildNumber)];
-      } catch {
-        return [key, { jobs: [], commit: null, branch: null }];
+        return [key, await promise];
+      } finally {
+        rosterInFlight.delete(key);
       }
     }),
   );
@@ -128,6 +173,7 @@ async function fetchBuildJobRoster(
   const build = (await response.json()) as {
     commit?: string;
     branch?: string;
+    state?: string;
     jobs?: Array<{
       name?: string | null;
       state?: string;
@@ -146,7 +192,7 @@ async function fetchBuildJobRoster(
       started_at: job.started_at ?? null,
     }));
 
-  return { jobs, commit: build.commit ?? null, branch: build.branch ?? null };
+  return { jobs, commit: build.commit ?? null, branch: build.branch ?? null, state: build.state ?? null };
 }
 
 // Map the REST API job state vocabulary onto the one the dashboard already

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/cron/retention",
       "schedule": "17 3 * * *"
+    },
+    {
+      "path": "/api/cron/warm-jobs",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Problem

Users still see 7–8s main page (Builds) loads after #148. That fix covered `/api/jobs` (the Jobs page); the main page chain is different: `/api/builds/filters` + `/api/builds`, then `/api/builds/groups?buildIds=<50 ids>` (the groups response carries the Job Groups filter options).

Measured against production with a CDN-bypassing probe (`scripts/profile-builds.mjs`):

| Step | Cold (MISS) | Warm |
|---|---|---|
| `/api/builds/filters` | 2,414–8,528 ms | ~50 ms |
| `/api/builds` | ~130 ms | ~30 ms |
| `/api/builds/groups` | **3,536–3,611 ms (consistent)** | ~60–90 ms |
| Full chain | **6,194–12,350 ms** | ~110–230 ms |

## Root cause

In OTel mode, `/api/builds/groups` fetches every build's job roster from the Buildkite REST API — one call per build, ~50 per page — because OTel spans only cover jobs that ran (gated jobs behind the manual unblock step produce no spans). The request URL embeds the current build ids, so **every new CI build creates a URL no CDN or application cache has ever seen**: cold misses are constant, not rare.

## Fix

- A finished build's roster is immutable → cache it per build for 24h (`src/lib/buildkite-build-jobs.ts`). Active builds are still refetched every time; failed fetches are never cached; concurrent requests for the same build coalesce into one fetch. Steady-state misses now fetch only new/active builds instead of all 50. Also benefits `/api/builds/jobs`, which uses the same roster path.
- Bound the OTel pipelines filter query to 30 days like the branches query (`src/app/api/builds/filters/route.ts`). Note: filters cold misses are dominated by serverless start + DB buffer state (both filter queries run 50–400 ms warm), so this bounds worst-case scan work rather than eliminating the variance.
- Add `Server-Timing` to `/api/builds/groups` (`roster` / `spans` / `warehouse` durations) so production latency stays attributable after deploy.

## Verification

- New regression tests in `src/lib/buildkite-build-jobs.test.ts` (settled-cached / active-refetched, failures never cached, concurrent coalescing): failed before, pass after.
- Full suite 182/182, `tsc --noEmit` and eslint clean, production build passes.
- Local production server: cold chain 7.5s → warm 18ms; groups shows `Server-Timing: warehouse;dur=4837.0` on miss, `total;dur=1.9` on app-cache hit.
- Post-deploy: `BASE=https://ci.vllm.ai BYPASS_CDN=1 node scripts/profile-builds.mjs` should show the second and later samples with groups ≪ 3.5s (the first miss per instance still pays the roster fan-out once).

## Remaining risk (not fixed here)

The OTel roster fallback `queryBuildJobsFromOtel` — used when the Buildkite token fails — measured **77–92s for 50 builds**: its row-constructor `(pipeline_slug, build_number) IN (...)` can't use `idx_otel_spans_build` because leading `organization_slug` is unconstrained. Roster caching makes an empty roster (hence the fallback) much less likely, but the query needs an org-scoped rewrite or index. Documented in `docs/builds-performance.md`.
---

## Addition: `/api/cron/warm-jobs` cache warmer

Cold-cache testing of `/jobs` showed the #148 fix works on warm instances (application MISS: 300–900 ms), but the **first fill on a cold serverless instance measured 20.7s and 23.1s** — instance cold start plus fresh Supabase pooler connection. Users pay this when a POP has no cache entry, chiefly after the daily date-range rollover changes the cache key at midnight.

A per-minute Vercel cron (`src/app/api/cron/warm-jobs/route.ts`, `CRON_SECRET`-guarded like the other crons) re-requests the Jobs page's default 14-day window with a CDN-bypassing parameter, keeping the origin application cache warm so first fills cost ~300–500 ms instead. Verified locally: tick 1 cold fill 23.1s, tick 2 warm HIT 63ms.

**Cost:** 1,440 invocations/day (~43k/month) × ~0.4s ≈ 5 GB·hrs/month — under 1% of Pro's included function quota; one extra ~300ms indexed Postgres query per minute; zero Buildkite API usage. Limitation: warms only the region the cron lands in; other POPs fill on first view but against a warm origin.
---

## Addition: stable `window=14d` cache key for the Jobs default view

The daily cold fill existed because the page put absolute `startDate`/`endDate` in the URL — every midnight the cache key changed and each CDN edge had to cold-fill once. The page (and the nav prefetch) now send `window=14d`, which `/api/jobs` resolves to dates at fill time; the URL never changes, so the CDN entry survives day rollover and stale-while-revalidate serves every request instantly. Explicit date ranges keep per-day keys; an invalid window falls back to the no-range key. The warm-jobs cron now hits this same stable URL. Net effect: the ~20s cold-instance fill stops being user-facing — worst case is a warm fill (~300–500ms) served in the background while users see instant stale data. Regression test covers key stability across resolved dates, explicit-date precedence, and invalid-window fallback.