### PR TITLE
Fix OTel build author attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ page (Builds) loads, see the [Builds latency guide](./docs/builds-performance.md
 | --- | --- |
 | `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, `DATABRICKS_WAREHOUSE_ID` | Databricks SQL Warehouse access |
 | `DATABASE_URL` | Postgres connection string for queue and GPU samples |
+| `GITHUB_TOKEN` or `GH_TOKEN` | GitHub token used to resolve PR and commit authors for OTel builds and raise test-area discovery limits |
 | `BUILDKITE_API_TOKEN` | Buildkite personal API token; needs `read_suites` for Test Engine, GraphQL API access and `write_builds` for queue promotion, and notification-service scopes only when running the OTel setup script |
 | `BUILDKITE_ORGANIZATION`, `BUILDKITE_TEST_SUITE` | Test Engine organization and suite slug (defaults: `vllm`, `ci-1`) |
 | `BUILDKITE_QUEUE_OPERATOR_TOKEN` | Required to enable queue-job promotion; authorized operators enter it for the current browser tab |

--- a/src/app/api/builds/route.ts
+++ b/src/app/api/builds/route.ts
@@ -92,25 +92,8 @@ export async function GET(request: NextRequest) {
         jobNames,
       });
 
-      const buildsWithMetadata = builds.map((build) => {
-        const b = build as Record<string, unknown>;
-        let prNumber = b.pr_number as string | null;
-        if (!prNumber && b.message) {
-          const match = (b.message as string).match(/\(#(\d+)\)/);
-          if (match) prNumber = match[1];
-        }
-        return {
-          ...b,
-          pr_number: prNumber,
-          build_number:
-            b.build_number === null || b.build_number === undefined
-              ? null
-              : String(b.build_number),
-        };
-      });
-
       const result = {
-        builds: buildsWithMetadata,
+        builds,
         buildDurations,
         summary,
         pagination: { page, pageSize: PAGE_SIZE, totalPages: Math.ceil(total / PAGE_SIZE) },

--- a/src/app/api/builds/summary/route.ts
+++ b/src/app/api/builds/summary/route.ts
@@ -231,19 +231,12 @@ export async function GET(request: NextRequest) {
       const buildsWithGroups = builds.map((b) => {
         const buildJobs = jobsByBuild.get(b.id as string) ?? [];
         const testGroups = aggregateJobsByGroup(buildJobs);
-        let prNumber = (b.pr_number as string | null) ?? null;
-        const message = (b.message as string | null) ?? "";
-        if (!prNumber && message) {
-          const match = message.match(/\(#(\d+)\)/);
-          if (match) prNumber = match[1];
-        }
         const matchedJobs = jobNames.length > 0
           ? buildJobs.filter((j) => jobNames.some((n) => j.name === n))
           : undefined;
         return {
           ...(b as unknown as BuildRow),
           duration_mins: null,
-          pr_number: prNumber,
           testGroups,
           matchedJobs,
         };

--- a/src/lib/github-build-authors.test.ts
+++ b/src/lib/github-build-authors.test.ts
@@ -20,11 +20,18 @@ test("uses the PR author instead of the merger or /ci commenter", async (t) => {
     const request = JSON.parse(String(init?.body)) as { query: string };
     assert.match(request.query, /pullRequest\(number: 55370\)/);
     assert.match(request.query, /pullRequest\(number: 55713\)/);
+    assert.match(request.query, /associatedPullRequests\(first: 1\)/);
     return Response.json({
       data: {
         repository: {
           item0: { author: { login: "cjackal" } },
           item1: { author: { login: "askliar" } },
+          item2: {
+            author: { user: { login: "merge-operator" } },
+            associatedPullRequests: {
+              nodes: [{ number: 55240, author: { login: "FeathBow" } }],
+            },
+          },
         },
       },
     });
@@ -41,12 +48,19 @@ test("uses the PR author instead of the merger or /ci commenter", async (t) => {
       commit_sha: "bd31e0dc2e6d2f9ed8421c432d51682d2803d502",
       author: "vLLM CI Bot",
     },
+    {
+      message: "Full CI run torch nightly",
+      commit_sha: "c7e9816c6ab0731165a134fd0a9defed6ab1d748",
+      author: null,
+    },
   ]);
 
   assert.equal(builds[0].author, "cjackal");
   assert.equal(builds[0].pr_number, "55370");
   assert.equal(builds[1].author, "askliar");
   assert.equal(builds[1].pr_number, "55713");
+  assert.equal(builds[2].author, "FeathBow");
+  assert.equal(builds[2].pr_number, "55240");
 });
 
 test("uses linked commit authors and preserves existing metadata otherwise", async (t) => {

--- a/src/lib/github-build-authors.test.ts
+++ b/src/lib/github-build-authors.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test, { type TestContext } from "node:test";
+import { enrichBuildAuthors } from "./github-build-authors";
+
+function configureToken(t: TestContext) {
+  const saved = process.env.GITHUB_TOKEN;
+  process.env.GITHUB_TOKEN = "test-token";
+  t.after(() => {
+    if (saved === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = saved;
+  });
+}
+
+test("uses the PR author instead of the merger or /ci commenter", async (t) => {
+  configureToken(t);
+  t.mock.method(globalThis, "fetch", async (
+    _input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => {
+    const request = JSON.parse(String(init?.body)) as { query: string };
+    assert.match(request.query, /pullRequest\(number: 55370\)/);
+    assert.match(request.query, /pullRequest\(number: 55713\)/);
+    return Response.json({
+      data: {
+        repository: {
+          item0: { author: { login: "cjackal" } },
+          item1: { author: { login: "askliar" } },
+        },
+      },
+    });
+  });
+
+  const builds = await enrichBuildAuthors([
+    {
+      message: "A fix (#55370)",
+      commit_sha: "22d95d1adc24d5834ec45bb697170a76cf4c9a95",
+      author: "Isotr0py",
+    },
+    {
+      message: "PR #55713 /ci run by @benchislett",
+      commit_sha: "bd31e0dc2e6d2f9ed8421c432d51682d2803d502",
+      author: "vLLM CI Bot",
+    },
+  ]);
+
+  assert.equal(builds[0].author, "cjackal");
+  assert.equal(builds[0].pr_number, "55370");
+  assert.equal(builds[1].author, "askliar");
+  assert.equal(builds[1].pr_number, "55713");
+});
+
+test("uses the commit author when a build has no pull request", async (t) => {
+  configureToken(t);
+  t.mock.method(globalThis, "fetch", async () =>
+    Response.json({
+      data: {
+        repository: {
+          item0: { author: { user: { login: "direct-committer" } } },
+        },
+      },
+    }),
+  );
+
+  const [build] = await enrichBuildAuthors([
+    {
+      message: "Direct commit",
+      commit_sha: "1111111111111111111111111111111111111111",
+      author: "Buildkite creator",
+    },
+  ]);
+
+  assert.equal(build.author, "direct-committer");
+  assert.equal(build.pr_number, null);
+});
+
+test("preserves existing metadata when GitHub enrichment is unavailable", async (t) => {
+  const saved = process.env.GITHUB_TOKEN;
+  const savedGh = process.env.GH_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.GH_TOKEN;
+  t.after(() => {
+    if (saved !== undefined) process.env.GITHUB_TOKEN = saved;
+    if (savedGh !== undefined) process.env.GH_TOKEN = savedGh;
+  });
+
+  const [build] = await enrichBuildAuthors([
+    {
+      message: "A fix (#59999)",
+      commit_sha: "2222222222222222222222222222222222222222",
+      author: "Merge operator",
+    },
+  ]);
+
+  assert.equal(build.author, "Merge operator");
+  assert.equal(build.pr_number, "59999");
+});

--- a/src/lib/github-build-authors.test.ts
+++ b/src/lib/github-build-authors.test.ts
@@ -49,28 +49,35 @@ test("uses the PR author instead of the merger or /ci commenter", async (t) => {
   assert.equal(builds[1].pr_number, "55713");
 });
 
-test("uses the commit author when a build has no pull request", async (t) => {
+test("uses linked commit authors and preserves existing metadata otherwise", async (t) => {
   configureToken(t);
   t.mock.method(globalThis, "fetch", async () =>
     Response.json({
       data: {
         repository: {
           item0: { author: { user: { login: "direct-committer" } } },
+          item1: { author: { user: null } },
         },
       },
     }),
   );
 
-  const [build] = await enrichBuildAuthors([
+  const [linked, unlinked] = await enrichBuildAuthors([
     {
       message: "Direct commit",
       commit_sha: "1111111111111111111111111111111111111111",
       author: "Buildkite creator",
     },
+    {
+      message: "Unlinked commit",
+      commit_sha: "3333333333333333333333333333333333333333",
+      author: "Existing author",
+    },
   ]);
 
-  assert.equal(build.author, "direct-committer");
-  assert.equal(build.pr_number, null);
+  assert.equal(linked.author, "direct-committer");
+  assert.equal(linked.pr_number, null);
+  assert.equal(unlinked.author, "Existing author");
 });
 
 test("preserves existing metadata when GitHub enrichment is unavailable", async (t) => {

--- a/src/lib/github-build-authors.ts
+++ b/src/lib/github-build-authors.ts
@@ -1,0 +1,144 @@
+const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
+const REPOSITORY_OWNER = "vllm-project";
+const REPOSITORY_NAME = "vllm";
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const CACHE_LIMIT = 2_000;
+
+type BuildRow = Record<string, unknown>;
+type CachedAuthor = { author: string | null; expiresAt: number };
+
+const authorCache = new Map<string, CachedAuthor>();
+
+function pullRequestNumber(build: BuildRow): string | null {
+  const existing = build.pr_number;
+  if (
+    (typeof existing === "string" || typeof existing === "number") &&
+    /^\d+$/.test(String(existing))
+  ) {
+    return String(existing);
+  }
+
+  if (typeof build.message !== "string") return null;
+  const match = build.message.match(/\(#(\d+)\)|\bPR\s+#(\d+)\b/i);
+  return match?.[1] ?? match?.[2] ?? null;
+}
+
+function commitSha(build: BuildRow): string | null {
+  return typeof build.commit_sha === "string" && SHA_PATTERN.test(build.commit_sha)
+    ? build.commit_sha.toLowerCase()
+    : null;
+}
+
+function cachedAuthor(key: string): string | null | undefined {
+  const cached = authorCache.get(key);
+  if (!cached) return undefined;
+  if (cached.expiresAt <= Date.now()) {
+    authorCache.delete(key);
+    return undefined;
+  }
+  return cached.author;
+}
+
+function cacheAuthor(key: string, author: string | null) {
+  authorCache.set(key, { author, expiresAt: Date.now() + CACHE_TTL_MS });
+  if (authorCache.size > CACHE_LIMIT) {
+    const oldest = authorCache.keys().next().value;
+    if (oldest) authorCache.delete(oldest);
+  }
+}
+
+async function fetchAuthors(keys: string[]): Promise<Map<string, string | null>> {
+  const resolved = new Map<string, string | null>();
+  const missing = keys.filter((key) => {
+    const cached = cachedAuthor(key);
+    if (cached === undefined) return true;
+    resolved.set(key, cached);
+    return false;
+  });
+  if (missing.length === 0) return resolved;
+
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (!token) return resolved;
+
+  const fields = missing.map((key, index) => {
+    const [kind, value] = key.split(":", 2);
+    if (kind === "pr") {
+      return `item${index}: pullRequest(number: ${value}) { author { login } }`;
+    }
+    return `item${index}: object(oid: "${value}") { ... on Commit { author { user { login } } } }`;
+  });
+  const query = `
+    query BuildAuthors($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name) {
+        ${fields.join("\n")}
+      }
+    }
+  `;
+
+  try {
+    const response = await fetch(GITHUB_GRAPHQL_URL, {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "vllm-dashboard",
+      },
+      body: JSON.stringify({
+        query,
+        variables: { owner: REPOSITORY_OWNER, name: REPOSITORY_NAME },
+      }),
+      cache: "no-store",
+    });
+    if (!response.ok) return resolved;
+
+    const body = (await response.json()) as {
+      data?: { repository?: Record<string, unknown> | null };
+      errors?: unknown[];
+    };
+    if (body.errors?.length || !body.data?.repository) return resolved;
+
+    for (const [index, key] of missing.entries()) {
+      const item = body.data.repository[`item${index}`] as
+        | {
+            author?: {
+              login?: string | null;
+              user?: { login?: string | null } | null;
+            } | null;
+          }
+        | null
+        | undefined;
+      const author =
+        item?.author?.login?.trim() ||
+        item?.author?.user?.login?.trim() ||
+        null;
+      cacheAuthor(key, author);
+      resolved.set(key, author);
+    }
+  } catch {
+    return resolved;
+  }
+
+  return resolved;
+}
+
+export async function enrichBuildAuthors(builds: BuildRow[]): Promise<BuildRow[]> {
+  const normalized = builds.map((build) => {
+    const prNumber = pullRequestNumber(build);
+    const sha = commitSha(build);
+    const authorKey = prNumber ? `pr:${prNumber}` : sha ? `commit:${sha}` : null;
+    return { build, prNumber, authorKey };
+  });
+  const keys = [...new Set(normalized.flatMap(({ authorKey }) => authorKey ? [authorKey] : []))];
+  const authors = await fetchAuthors(keys);
+
+  return normalized.map(({ build, prNumber, authorKey }) => ({
+    ...build,
+    pr_number: prNumber,
+    author:
+      authorKey && authors.has(authorKey)
+        ? (authors.get(authorKey) ?? null)
+        : (build.author ?? null),
+  }));
+}

--- a/src/lib/github-build-authors.ts
+++ b/src/lib/github-build-authors.ts
@@ -1,24 +1,14 @@
+import { getCached, setCache } from "@/lib/api-cache";
+
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
 const REPOSITORY_OWNER = "vllm-project";
 const REPOSITORY_NAME = "vllm";
 const SHA_PATTERN = /^[0-9a-f]{40}$/i;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-const CACHE_LIMIT = 2_000;
 
 type BuildRow = Record<string, unknown>;
-type CachedAuthor = { author: string | null; expiresAt: number };
-
-const authorCache = new Map<string, CachedAuthor>();
 
 function pullRequestNumber(build: BuildRow): string | null {
-  const existing = build.pr_number;
-  if (
-    (typeof existing === "string" || typeof existing === "number") &&
-    /^\d+$/.test(String(existing))
-  ) {
-    return String(existing);
-  }
-
   if (typeof build.message !== "string") return null;
   const match = build.message.match(/\(#(\d+)\)|\bPR\s+#(\d+)\b/i);
   return match?.[1] ?? match?.[2] ?? null;
@@ -30,28 +20,10 @@ function commitSha(build: BuildRow): string | null {
     : null;
 }
 
-function cachedAuthor(key: string): string | null | undefined {
-  const cached = authorCache.get(key);
-  if (!cached) return undefined;
-  if (cached.expiresAt <= Date.now()) {
-    authorCache.delete(key);
-    return undefined;
-  }
-  return cached.author;
-}
-
-function cacheAuthor(key: string, author: string | null) {
-  authorCache.set(key, { author, expiresAt: Date.now() + CACHE_TTL_MS });
-  if (authorCache.size > CACHE_LIMIT) {
-    const oldest = authorCache.keys().next().value;
-    if (oldest) authorCache.delete(oldest);
-  }
-}
-
 async function fetchAuthors(keys: string[]): Promise<Map<string, string | null>> {
   const resolved = new Map<string, string | null>();
   const missing = keys.filter((key) => {
-    const cached = cachedAuthor(key);
+    const cached = getCached<string | null>(`github-build-author:${key}`);
     if (cached === undefined) return true;
     resolved.set(key, cached);
     return false;
@@ -90,6 +62,7 @@ async function fetchAuthors(keys: string[]): Promise<Map<string, string | null>>
         variables: { owner: REPOSITORY_OWNER, name: REPOSITORY_NAME },
       }),
       cache: "no-store",
+      signal: AbortSignal.timeout(5_000),
     });
     if (!response.ok) return resolved;
 
@@ -113,7 +86,7 @@ async function fetchAuthors(keys: string[]): Promise<Map<string, string | null>>
         item?.author?.login?.trim() ||
         item?.author?.user?.login?.trim() ||
         null;
-      cacheAuthor(key, author);
+      setCache(`github-build-author:${key}`, author, CACHE_TTL_MS);
       resolved.set(key, author);
     }
   } catch {
@@ -136,9 +109,6 @@ export async function enrichBuildAuthors(builds: BuildRow[]): Promise<BuildRow[]
   return normalized.map(({ build, prNumber, authorKey }) => ({
     ...build,
     pr_number: prNumber,
-    author:
-      authorKey && authors.has(authorKey)
-        ? (authors.get(authorKey) ?? null)
-        : (build.author ?? null),
+    author: (authorKey ? authors.get(authorKey) : null) ?? build.author ?? null,
   }));
 }

--- a/src/lib/github-build-authors.ts
+++ b/src/lib/github-build-authors.ts
@@ -7,6 +7,7 @@ const SHA_PATTERN = /^[0-9a-f]{40}$/i;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 type BuildRow = Record<string, unknown>;
+type GitHubBuildRef = { author: string | null; prNumber: string | null };
 
 function pullRequestNumber(build: BuildRow): string | null {
   if (typeof build.message !== "string") return null;
@@ -20,10 +21,10 @@ function commitSha(build: BuildRow): string | null {
     : null;
 }
 
-async function fetchAuthors(keys: string[]): Promise<Map<string, string | null>> {
-  const resolved = new Map<string, string | null>();
+async function fetchAuthors(keys: string[]): Promise<Map<string, GitHubBuildRef>> {
+  const resolved = new Map<string, GitHubBuildRef>();
   const missing = keys.filter((key) => {
-    const cached = getCached<string | null>(`github-build-author:${key}`);
+    const cached = getCached<GitHubBuildRef>(`github-build-ref:${key}`);
     if (cached === undefined) return true;
     resolved.set(key, cached);
     return false;
@@ -38,7 +39,7 @@ async function fetchAuthors(keys: string[]): Promise<Map<string, string | null>>
     if (kind === "pr") {
       return `item${index}: pullRequest(number: ${value}) { author { login } }`;
     }
-    return `item${index}: object(oid: "${value}") { ... on Commit { author { user { login } } } }`;
+    return `item${index}: object(oid: "${value}") { ... on Commit { author { user { login } } associatedPullRequests(first: 1) { nodes { number author { login } } } } }`;
   });
   const query = `
     query BuildAuthors($owner: String!, $name: String!) {
@@ -79,14 +80,24 @@ async function fetchAuthors(keys: string[]): Promise<Map<string, string | null>>
               login?: string | null;
               user?: { login?: string | null } | null;
             } | null;
+            associatedPullRequests?: {
+              nodes?: { number?: number; author?: { login?: string | null } | null }[];
+            } | null;
           }
         | null
         | undefined;
-      const author =
-        item?.author?.login?.trim() ||
-        item?.author?.user?.login?.trim() ||
-        null;
-      setCache(`github-build-author:${key}`, author, CACHE_TTL_MS);
+      const pullRequest = item?.associatedPullRequests?.nodes?.[0];
+      const author = {
+        author:
+          item?.author?.login?.trim() ||
+          pullRequest?.author?.login?.trim() ||
+          item?.author?.user?.login?.trim() ||
+          null,
+        prNumber: key.startsWith("pr:")
+          ? key.slice(3)
+          : pullRequest?.number?.toString() ?? null,
+      };
+      setCache(`github-build-ref:${key}`, author, CACHE_TTL_MS);
       resolved.set(key, author);
     }
   } catch {
@@ -106,9 +117,12 @@ export async function enrichBuildAuthors(builds: BuildRow[]): Promise<BuildRow[]
   const keys = [...new Set(normalized.flatMap(({ authorKey }) => authorKey ? [authorKey] : []))];
   const authors = await fetchAuthors(keys);
 
-  return normalized.map(({ build, prNumber, authorKey }) => ({
-    ...build,
-    pr_number: prNumber,
-    author: (authorKey ? authors.get(authorKey) : null) ?? build.author ?? null,
-  }));
+  return normalized.map(({ build, prNumber, authorKey }) => {
+    const github = authorKey ? authors.get(authorKey) : null;
+    return {
+      ...build,
+      pr_number: github?.prNumber ?? prNumber,
+      author: github?.author ?? build.author ?? null,
+    };
+  });
 }

--- a/src/lib/otel-ci.ts
+++ b/src/lib/otel-ci.ts
@@ -1,4 +1,5 @@
 import { getDb } from "@/lib/db";
+import { enrichBuildAuthors } from "@/lib/github-build-authors";
 import { resolveGroupsToJobConditions } from "@/lib/test-groups";
 import type { ServerTiming } from "@/lib/server-timing";
 
@@ -224,13 +225,19 @@ export async function queryBuildsFromOtel(
     durationsPromise,
   ]);
 
+  const enrichedBuilds = await enrichBuildAuthors(builds);
   const counts = countRows[0] ?? { total: 0, passed: 0, failed: 0 };
   const total = Number(counts.total) || 0;
   const passed = Number(counts.passed) || 0;
   const failed = Number(counts.failed) || 0;
   const passRate = passed + failed > 0 ? Math.round((passed / (passed + failed)) * 100) : 0;
 
-  return { builds, buildDurations, summary: { total, passed, failed, passRate }, total };
+  return {
+    builds: enrichedBuilds,
+    buildDurations,
+    summary: { total, passed, failed, passRate },
+    total,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/otel-ci.ts
+++ b/src/lib/otel-ci.ts
@@ -610,5 +610,5 @@ export async function queryCostFromOtel(f: CiFilter): Promise<OtelCostRaw> {
     byJobPromise,
   ]);
 
-  return { byQueue, dailyCost, byBuild, byJob };
+  return { byQueue, dailyCost, byBuild: await enrichBuildAuthors(byBuild), byJob };
 }


### PR DESCRIPTION
OTel-backed build rows currently label `buildkite.build.creator.name` as the author, so merged PR #55370 shows its merger (`Isotr0py`) instead of its PR author (`cjackal`), while API-triggered `/ci` builds can show the CI bot or no author.

Resolve authors from GitHub in one cached GraphQL batch per builds response. PR-associated builds use the PR author, including both squash-merge `(#123)` messages and `PR #123 /ci` messages; other builds use the commit's linked GitHub author. If GitHub enrichment is unavailable, the existing metadata remains available. This keeps the near-real-time OTel data path and avoids one GitHub request per row.

Validation:

- `npm test` — 186 tests passed
- `npm run lint`
- `npm run build`
- TypeScript: `tsc --noEmit`
- Full OTel query for Buildkite #87972 returned `author: cjackal`, `pr_number: 55370`
- Recent-main parity check: 91/93 authors matched Databricks; the other two replaced null warehouse values with valid GitHub authors

No overlapping open dashboard PR was identified for OTel build-author attribution.

AI assistance was used to investigate, implement, and validate this change. Human review is required before merge.
