### PR TITLE
Show author display names in Builds and Costs

### DIFF
--- a/src/lib/github-build-authors.test.ts
+++ b/src/lib/github-build-authors.test.ts
@@ -24,12 +24,12 @@ test("uses the PR author instead of the merger or /ci commenter", async (t) => {
     return Response.json({
       data: {
         repository: {
-          item0: { author: { login: "cjackal" } },
+          item0: { author: { login: "cjackal", name: "Chris Jack" } },
           item1: { author: { login: "askliar" } },
           item2: {
-            author: { user: { login: "merge-operator" } },
+            author: { name: "Wei Zhao", user: { login: "wzhao18" } },
             associatedPullRequests: {
-              nodes: [{ number: 55240, author: { login: "FeathBow" } }],
+              nodes: [{ number: 55499, author: { login: "wzhao18", name: "Wei Zhao" } }],
             },
           },
         },
@@ -49,18 +49,18 @@ test("uses the PR author instead of the merger or /ci commenter", async (t) => {
       author: "vLLM CI Bot",
     },
     {
-      message: "Full CI run torch nightly",
-      commit_sha: "c7e9816c6ab0731165a134fd0a9defed6ab1d748",
+      message: "Full CI run - daily",
+      commit_sha: "8c87c333b84c85908b1d11f0044457692277c6f3",
       author: null,
     },
   ]);
 
-  assert.equal(builds[0].author, "cjackal");
+  assert.equal(builds[0].author, "Chris Jack");
   assert.equal(builds[0].pr_number, "55370");
   assert.equal(builds[1].author, "askliar");
   assert.equal(builds[1].pr_number, "55713");
-  assert.equal(builds[2].author, "FeathBow");
-  assert.equal(builds[2].pr_number, "55240");
+  assert.equal(builds[2].author, "Wei Zhao");
+  assert.equal(builds[2].pr_number, "55499");
 });
 
 test("uses linked commit authors and preserves existing metadata otherwise", async (t) => {

--- a/src/lib/github-build-authors.ts
+++ b/src/lib/github-build-authors.ts
@@ -37,9 +37,9 @@ async function fetchAuthors(keys: string[]): Promise<Map<string, GitHubBuildRef>
   const fields = missing.map((key, index) => {
     const [kind, value] = key.split(":", 2);
     if (kind === "pr") {
-      return `item${index}: pullRequest(number: ${value}) { author { login } }`;
+      return `item${index}: pullRequest(number: ${value}) { author { login ... on User { name } } }`;
     }
-    return `item${index}: object(oid: "${value}") { ... on Commit { author { user { login } } associatedPullRequests(first: 1) { nodes { number author { login } } } } }`;
+    return `item${index}: object(oid: "${value}") { ... on Commit { author { name user { login } } associatedPullRequests(first: 1) { nodes { number author { login ... on User { name } } } } } }`;
   });
   const query = `
     query BuildAuthors($owner: String!, $name: String!) {
@@ -78,10 +78,11 @@ async function fetchAuthors(keys: string[]): Promise<Map<string, GitHubBuildRef>
         | {
             author?: {
               login?: string | null;
+              name?: string | null;
               user?: { login?: string | null } | null;
             } | null;
             associatedPullRequests?: {
-              nodes?: { number?: number; author?: { login?: string | null } | null }[];
+              nodes?: { number?: number; author?: { login?: string | null; name?: string | null } | null }[];
             } | null;
           }
         | null
@@ -89,8 +90,10 @@ async function fetchAuthors(keys: string[]): Promise<Map<string, GitHubBuildRef>
       const pullRequest = item?.associatedPullRequests?.nodes?.[0];
       const author = {
         author:
-          item?.author?.login?.trim() ||
+          pullRequest?.author?.name?.trim() ||
           pullRequest?.author?.login?.trim() ||
+          item?.author?.name?.trim() ||
+          item?.author?.login?.trim() ||
           item?.author?.user?.login?.trim() ||
           null,
         prNumber: key.startsWith("pr:")


### PR DESCRIPTION
## Summary
- prefer the GitHub author display name over the login
- fall back to the login when no display name is configured
- apply the result through the existing shared enrichment used by Builds and Costs

## Example
PR #55499 and commit 8c87c33 now resolve to Wei Zhao instead of wzhao18.

## Validation
- focused author enrichment tests: 3 passed
- full test suite: 186 passed
- npm run lint
- npx tsc --noEmit
- verified the GraphQL response for PR #55499 and commit 8c87c33

AI assistance was used to implement and validate this change. Human review is required before merge.