### PR TITLE
Fix author enrichment for Databricks builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ page (Builds) loads, see the [Builds latency guide](./docs/builds-performance.md
 | --- | --- |
 | `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, `DATABRICKS_WAREHOUSE_ID` | Databricks SQL Warehouse access |
 | `DATABASE_URL` | Postgres connection string for queue and GPU samples |
-| `GITHUB_TOKEN` or `GH_TOKEN` | GitHub token used to resolve PR and commit authors for OTel builds and raise test-area discovery limits |
+| `GITHUB_TOKEN` or `GH_TOKEN` | GitHub token used to resolve PR and commit authors for builds and raise test-area discovery limits |
 | `BUILDKITE_API_TOKEN` | Buildkite personal API token; needs `read_suites` for Test Engine, GraphQL API access and `write_builds` for queue promotion, and notification-service scopes only when running the OTel setup script |
 | `BUILDKITE_ORGANIZATION`, `BUILDKITE_TEST_SUITE` | Test Engine organization and suite slug (defaults: `vllm`, `ci-1`) |
 | `BUILDKITE_QUEUE_OPERATOR_TOKEN` | Required to enable queue-job promotion; authorized operators enter it for the current browser tab |

--- a/src/app/api/builds/route.ts
+++ b/src/app/api/builds/route.ts
@@ -5,6 +5,7 @@ import { ensureTestAreaMapping } from "@/lib/test-areas";
 import { getCached, setCache } from "@/lib/api-cache";
 import { cachedJson } from "@/lib/api-response";
 import { resolveCiDataSource } from "@/lib/ci-data-source";
+import { enrichBuildAuthors } from "@/lib/github-build-authors";
 import { queryBuildsFromOtel } from "@/lib/otel-ci";
 
 const PAGE_SIZE = 50;
@@ -180,7 +181,7 @@ export async function GET(request: NextRequest) {
     // Keep the bootstrap response focused on the chart, summary, and build
     // rows. Group summaries and expanded job details are normalized behind
     // dedicated endpoints so the first screen does not carry 10k+ nested jobs.
-    const buildsWithMetadata = builds.map((build) => {
+    const buildsWithMetadata = (await enrichBuildAuthors(builds)).map((build) => {
       const b = build as Record<string, unknown>;
       const traceIdentity = parseBuildkiteBuildUrl(b.web_url);
       // Parse PR number from commit message if not set (e.g. main branch)

--- a/src/app/api/builds/summary/route.ts
+++ b/src/app/api/builds/summary/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/test-areas";
 import { getCached, setCache } from "@/lib/api-cache";
 import { resolveCiDataSource } from "@/lib/ci-data-source";
+import { enrichBuildAuthors } from "@/lib/github-build-authors";
 import { queryBuildJobsFromOtel, queryBuildsFromOtel } from "@/lib/otel-ci";
 
 const MAX_PER_PAGE = 30;
@@ -56,7 +57,7 @@ interface BuildRow {
   created_at: string;
   started_at: string;
   finished_at: string;
-  author: string;
+  author: string | null;
   pr_number: string | null;
   duration_mins: string | null;
 }
@@ -334,7 +335,8 @@ export async function GET(request: NextRequest) {
       `),
     ]);
 
-    const buildIds = builds.map((b) => b.id);
+    const enrichedBuilds = await enrichBuildAuthors(builds);
+    const buildIds = enrichedBuilds.map((b) => b.id);
     const jobsByBuild = new Map<string, { name: string; state: string }[]>();
 
     if (buildIds.length > 0) {
@@ -361,7 +363,7 @@ export async function GET(request: NextRequest) {
       string,
       ReturnType<typeof getTestAreaMappingForCommit>
     >();
-    for (const build of builds) {
+    for (const build of enrichedBuilds) {
       const mappingKey = `${build.branch}:${build.commit_sha}`;
       if (!mappingsByCommit.has(mappingKey)) {
         mappingsByCommit.set(
@@ -370,7 +372,7 @@ export async function GET(request: NextRequest) {
         );
       }
     }
-    const buildsWithGroups = await Promise.all(builds.map(async (b) => {
+    const buildsWithGroups = await Promise.all(enrichedBuilds.map(async (b) => {
       const buildJobs = jobsByBuild.get(b.id) ?? [];
       const mapping = await mappingsByCommit.get(
         `${b.branch}:${b.commit_sha}`,

--- a/src/app/api/cost/route.ts
+++ b/src/app/api/cost/route.ts
@@ -4,6 +4,7 @@ import { getQueueCost } from "@/lib/queue-costs";
 import { getCached, setCache } from "@/lib/api-cache";
 import { cachedJson } from "@/lib/api-response";
 import { resolveCiDataSource } from "@/lib/ci-data-source";
+import { enrichBuildAuthors } from "@/lib/github-build-authors";
 import { queryCostFromOtel } from "@/lib/otel-ci";
 
 export const maxDuration = 55;
@@ -124,7 +125,9 @@ export async function GET(request: NextRequest) {
 
     byQueue = byQueueResult.status === "fulfilled" ? byQueueResult.value : [];
     dailyCost = dailyCostResult.status === "fulfilled" ? dailyCostResult.value : [];
-    byBuildRaw = byBuildResult.status === "fulfilled" ? byBuildResult.value : [];
+    byBuildRaw = await enrichBuildAuthors(
+      byBuildResult.status === "fulfilled" ? byBuildResult.value : [],
+    );
     byJobRaw = byJobResult.status === "fulfilled" ? byJobResult.value : [];
     }
 

--- a/src/lib/github-build-authors.ts
+++ b/src/lib/github-build-authors.ts
@@ -6,7 +6,11 @@ const REPOSITORY_NAME = "vllm";
 const SHA_PATTERN = /^[0-9a-f]{40}$/i;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
-type BuildRow = Record<string, unknown>;
+type BuildRow = {
+  message?: unknown;
+  commit_sha?: unknown;
+  author?: unknown;
+};
 type GitHubBuildRef = { author: string | null; prNumber: string | null };
 
 function pullRequestNumber(build: BuildRow): string | null {
@@ -110,7 +114,14 @@ async function fetchAuthors(keys: string[]): Promise<Map<string, GitHubBuildRef>
   return resolved;
 }
 
-export async function enrichBuildAuthors(builds: BuildRow[]): Promise<BuildRow[]> {
+export async function enrichBuildAuthors<T extends BuildRow>(
+  builds: T[],
+): Promise<
+  (Omit<T, "author" | "pr_number"> & {
+    author: string | null;
+    pr_number: string | null;
+  })[]
+> {
   const normalized = builds.map((build) => {
     const prNumber = pullRequestNumber(build);
     const sha = commitSha(build);
@@ -125,7 +136,9 @@ export async function enrichBuildAuthors(builds: BuildRow[]): Promise<BuildRow[]
     return {
       ...build,
       pr_number: github?.prNumber ?? prNumber,
-      author: github?.author ?? build.author ?? null,
+      author:
+        github?.author ??
+        (typeof build.author === "string" ? build.author : null),
     };
   });
 }


### PR DESCRIPTION
## Summary
- run the existing GitHub author enrichment for the default Databricks Builds path
- apply the same fix to compact build summaries and Costs
- preserve concrete row types and model missing warehouse authors as nullable

## Root cause
PRs #154 and #155 enriched only the optional OTel source. Production defaults to Databricks, so ci.vllm.ai continued returning github_author_username values and null authors.

## Validation
- production repro: Databricks returned xonder/null while OTel returned the resolved author
- npm test: 186 passed
- npm run lint
- npx tsc --noEmit

AI assistance was used to diagnose, implement, and validate this change. Human review is required before merge.