### PR TITLE
feat(builds): infer a real critical path and group waterfall tests by file/function

### DIFF
--- a/src/app/api/builds/trace/route.ts
+++ b/src/app/api/builds/trace/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { criticalPathIds } from "@/lib/build-critical-path";
 
 export const runtime = "nodejs";
 
@@ -87,24 +88,11 @@ function laneStatus(row: TraceRow): Lane["status"] {
   return "unknown";
 }
 
-function markCompletionFrontier(lanes: Lane[]) {
-  const ordered = [...lanes].sort((a, b) => {
-    const start = Date.parse(a.startTime) - Date.parse(b.startTime);
-    if (start !== 0) return start;
-    return Date.parse(b.endTime) - Date.parse(a.endTime);
-  });
-  let furthestEnd = Number.NEGATIVE_INFINITY;
-  const frontier = new Set<string>();
-  for (const lane of ordered) {
-    const end = Date.parse(lane.endTime);
-    if (end > furthestEnd + 1) {
-      frontier.add(lane.id);
-      furthestEnd = end;
-    }
-  }
+function markCriticalPath(lanes: Lane[]) {
+  const chain = criticalPathIds(lanes);
   return lanes.map((lane) => ({
     ...lane,
-    critical: frontier.has(lane.id),
+    critical: chain.has(lane.id),
   }));
 }
 
@@ -316,7 +304,7 @@ export async function GET(request: NextRequest) {
       jobLaneByJobId.set(jobId, synthetic);
     }
 
-    const jobLanes = markCompletionFrontier(baseJobLanes);
+    const jobLanes = markCriticalPath(baseJobLanes);
     const detailLanes = details.map((row): Lane => {
       const kind = detailKind(row) as "command" | "test";
       const jobParent = row.job_id

--- a/src/components/build-waterfall.tsx
+++ b/src/components/build-waterfall.tsx
@@ -3,13 +3,16 @@
 import { useMemo, useState } from "react";
 import useSWR from "swr";
 import { JobName, jobNameText } from "@/components/job-name";
+import { buildTestTree, type TestTreeNode } from "@/lib/test-tree";
 
 type LaneKind = "job" | "step" | "command" | "test";
+/** Lanes from the API plus the client-side pytest grouping rows. */
+type RowKind = LaneKind | "test-file" | "test-case";
 
 interface WaterfallLane {
   id: string;
   parentId: string | null;
-  kind: LaneKind;
+  kind: RowKind;
   label: string;
   group: string | null;
   stepKey: string | null;
@@ -24,6 +27,16 @@ interface WaterfallLane {
   url: string | null;
   critical: boolean;
   childCount: number;
+  /** Shorter label for tree rows: the part not shown by enclosing groups. */
+  displayLabel?: string;
+  /** Total tests under a grouping row. */
+  testCount?: number;
+  failedCount?: number;
+}
+
+interface VisibleRow {
+  lane: WaterfallLane;
+  depth: number;
 }
 
 interface TraceResponse {
@@ -58,6 +71,8 @@ interface BuildWaterfallProps {
 
 const INITIAL_JOB_LIMIT = 36;
 const TICKS = [0, 0.25, 0.5, 0.75, 1];
+const INDENT_PX = 18;
+const ROW_GRID = "grid-cols-[minmax(22rem,34rem)_minmax(28rem,1fr)]";
 
 async function fetchTrace(url: string): Promise<TraceResponse> {
   const response = await fetch(url);
@@ -108,21 +123,76 @@ function GridLines() {
   );
 }
 
-function laneDepth(lane: WaterfallLane): number {
-  if (lane.kind === "test") return 2;
-  if (lane.kind === "command") return 1;
-  return 0;
+function isJobLane(lane: WaterfallLane): boolean {
+  return lane.kind === "job" || lane.kind === "step";
+}
+
+function isTestGroup(lane: WaterfallLane): boolean {
+  return lane.kind === "test-file" || lane.kind === "test-case";
+}
+
+/** Pytest node IDs contain `::`, which JobName would misread as shortcodes. */
+function laneText(lane: WaterfallLane): string {
+  return isJobLane(lane) ? jobNameText(lane.label) : lane.label;
 }
 
 function laneColor(lane: WaterfallLane): string {
   if (lane.critical) {
     return "border border-amber-500 bg-amber-300 shadow-[0_0_0_1px_rgb(245_158_11_/_0.12)] dark:bg-amber-500";
   }
+  if (isTestGroup(lane)) {
+    // Grouping rows span their children; keep them visually lighter than
+    // the leaf tests so a file row does not read as one giant test.
+    if (lane.status === "failed") return "border border-red-500/70 bg-red-500/25 dark:bg-red-500/30";
+    if (lane.status === "skipped") return "border border-zinc-400/70 bg-zinc-300/50 dark:bg-zinc-600/50";
+    return "border border-emerald-500/70 bg-emerald-500/25 dark:bg-emerald-500/30";
+  }
   if (lane.status === "failed") return "bg-red-500 dark:bg-red-500";
   if (lane.status === "skipped") return "bg-zinc-300 dark:bg-zinc-600";
   if (lane.kind === "test") return "bg-emerald-500 dark:bg-emerald-500";
   if (lane.kind === "command") return "bg-cyan-500 dark:bg-cyan-500";
   return "bg-blue-500 dark:bg-blue-500";
+}
+
+/**
+ * Turn a pytest command's flat test lanes into file → function → parameter
+ * rows. Returns the direct children of the command and registers every
+ * deeper level in `children`.
+ */
+function attachTestTree(
+  commandId: string,
+  tests: WaterfallLane[],
+  children: Map<string, WaterfallLane[]>,
+): WaterfallLane[] {
+  const template = tests[0];
+  const materialize = (nodes: TestTreeNode<WaterfallLane>[], parentId: string): WaterfallLane[] =>
+    nodes.map((node) => {
+      if (node.type === "leaf") {
+        return { ...node.lane, parentId, displayLabel: node.displayLabel };
+      }
+      const row: WaterfallLane = {
+        ...template,
+        id: node.id,
+        parentId,
+        kind: node.kind,
+        label: node.label,
+        startTime: node.startTime,
+        endTime: node.endTime,
+        durationMs: node.durationMs,
+        waitMs: 0,
+        status: node.status,
+        outcome: null,
+        url: null,
+        critical: false,
+        childCount: node.children.length,
+        displayLabel: node.label,
+        testCount: node.testCount,
+        failedCount: node.failedCount,
+      };
+      children.set(node.id, materialize(node.children, node.id));
+      return row;
+    });
+  return materialize(buildTestTree(commandId, tests), commandId);
 }
 
 export function BuildWaterfall({
@@ -134,7 +204,10 @@ export function BuildWaterfall({
 }: BuildWaterfallProps) {
   const [criticalOnly, setCriticalOnly] = useState(false);
   const [showAll, setShowAll] = useState(false);
-  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  // Explicit open/closed choices; rows absent here fall back to their default.
+  const [openOverrides, setOpenOverrides] = useState<Map<string, boolean>>(
+    () => new Map(),
+  );
   const [jobDetails, setJobDetails] = useState<Record<string, WaterfallLane[]>>(
     {},
   );
@@ -150,7 +223,7 @@ export function BuildWaterfall({
     },
   );
 
-  const { jobLanes, childrenByParent } = useMemo(() => {
+  const { jobLanes, childrenByParent, defaultOpen } = useMemo(() => {
     const detailedJobIds = new Set(Object.keys(jobDetails));
     const lanes = [
       ...(data?.lanes ?? []).filter(
@@ -184,8 +257,24 @@ export function BuildWaterfall({
         return Date.parse(a.startTime) - Date.parse(b.startTime);
       });
     }
-    return { jobLanes: roots, childrenByParent: children };
+    // A shard with one test file gains nothing from a collapsed file row, so
+    // that row starts open and the viewer lands directly on the functions.
+    const defaultOpen = new Set<string>();
+    // Snapshot the entries: attaching a tree adds group rows to the map, and
+    // iterating those would regroup the leaves again without end.
+    for (const [parentId, siblings] of [...children]) {
+      if (!siblings.some((lane) => lane.kind === "test")) continue;
+      const tests = siblings.filter((lane) => lane.kind === "test");
+      const others = siblings.filter((lane) => lane.kind !== "test");
+      const grouped = attachTestTree(parentId, tests, children);
+      children.set(parentId, [...others, ...grouped]);
+      const files = grouped.filter((lane) => lane.kind === "test-file");
+      if (files.length === 1 && others.length === 0) defaultOpen.add(files[0].id);
+    }
+    return { jobLanes: roots, childrenByParent: children, defaultOpen };
   }, [data?.lanes, jobDetails]);
+
+  const isOpen = (id: string) => openOverrides.get(id) ?? defaultOpen.has(id);
 
   const visibleJobs = useMemo(() => {
     const filtered = criticalOnly
@@ -201,19 +290,16 @@ export function BuildWaterfall({
     return filtered.filter((lane) => initiallyVisible.has(lane.id));
   }, [criticalOnly, jobLanes, showAll]);
 
-  const visibleLanes = useMemo(() => {
-    const flattened: WaterfallLane[] = [];
-    for (const job of visibleJobs) {
-      flattened.push(job);
-      if (!expanded.has(job.id)) continue;
-      for (const command of childrenByParent.get(job.id) ?? []) {
-        flattened.push(command);
-        if (!expanded.has(command.id)) continue;
-        flattened.push(...(childrenByParent.get(command.id) ?? []));
-      }
-    }
+  const visibleRows = useMemo(() => {
+    const flattened: VisibleRow[] = [];
+    const walk = (lane: WaterfallLane, depth: number) => {
+      flattened.push({ lane, depth });
+      if (!(openOverrides.get(lane.id) ?? defaultOpen.has(lane.id))) return;
+      for (const child of childrenByParent.get(lane.id) ?? []) walk(child, depth + 1);
+    };
+    for (const job of visibleJobs) walk(job, 0);
     return flattened;
-  }, [childrenByParent, expanded, visibleJobs]);
+  }, [childrenByParent, defaultOpen, openOverrides, visibleJobs]);
 
   async function loadJobDetails(jobId: string, jobParentId: string | null) {
     if (jobDetails[jobId] || loadingJobs.has(jobId)) return;
@@ -270,25 +356,18 @@ export function BuildWaterfall({
     if (lane.kind === "command" && lane.jobId && lane.childCount > 0) {
       void loadJobDetails(lane.jobId, lane.parentId);
     }
-    setExpanded((current) => {
-      const next = new Set(current);
-      if (next.has(lane.id)) next.delete(lane.id);
-      else next.add(lane.id);
-      return next;
-    });
+    const open = isOpen(lane.id);
+    setOpenOverrides((current) => new Map(current).set(lane.id, !open));
   }
 
   function toggleAllJobs() {
     const expandableJobs = jobLanes
       .filter((lane) => (childrenByParent.get(lane.id)?.length ?? 0) > 0)
       .map((lane) => lane.id);
-    const allExpanded = expandableJobs.every((id) => expanded.has(id));
-    setExpanded((current) => {
-      const next = new Set(current);
-      for (const id of expandableJobs) {
-        if (allExpanded) next.delete(id);
-        else next.add(id);
-      }
+    const allExpanded = expandableJobs.every((id) => isOpen(id));
+    setOpenOverrides((current) => {
+      const next = new Map(current);
+      for (const id of expandableJobs) next.set(id, !allExpanded);
       return next;
     });
   }
@@ -353,7 +432,7 @@ export function BuildWaterfall({
     (lane) => (childrenByParent.get(lane.id)?.length ?? 0) > 0,
   );
   const allJobsExpanded =
-    expandableJobs.length > 0 && expandableJobs.every((lane) => expanded.has(lane.id));
+    expandableJobs.length > 0 && expandableJobs.every((lane) => isOpen(lane.id));
 
   return (
     <section
@@ -372,8 +451,10 @@ export function BuildWaterfall({
             {isValidating && <span className="text-[11px] text-zinc-400">Checking…</span>}
           </div>
           <p className="mt-1 text-xs leading-5 text-zinc-500 dark:text-zinc-400">
-            Select a traced job to see its commands. Select a pytest command to
-            see every test. Amber jobs are inferred build-limiting work.
+            Select a traced job to see its commands, and a pytest command to see
+            its test files, functions and parameter combinations. Amber jobs are
+            the inferred critical path: the chain of work that set the build&apos;s
+            duration.
           </p>
         </div>
         <div className="flex flex-col items-start gap-3 lg:items-end">
@@ -427,7 +508,7 @@ export function BuildWaterfall({
 
       <div className="overflow-x-auto pb-2">
         <div className="min-w-[760px] px-5">
-          <div className="grid grid-cols-[minmax(16rem,21rem)_minmax(32rem,1fr)] gap-4 border-b border-zinc-200 pb-2 dark:border-zinc-800">
+          <div className={`grid ${ROW_GRID} gap-4 border-b border-zinc-200 pb-2 dark:border-zinc-800`}>
             <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-400">Job / command / test</div>
             <div className="relative h-5 font-mono text-[10px] text-zinc-400">
               {TICKS.map((tick) => (
@@ -439,7 +520,7 @@ export function BuildWaterfall({
           </div>
 
           <div>
-            {visibleLanes.map((lane) => {
+            {visibleRows.map(({ lane, depth }) => {
               const start = Date.parse(lane.startTime);
               const end = Date.parse(lane.endTime);
               const queueStart = Math.max(timelineStart, start - lane.waitMs);
@@ -452,6 +533,7 @@ export function BuildWaterfall({
                 ? Math.max(lane.childCount, children.length)
                 : children.length;
               const isExpandable = displayedChildCount > 0;
+              const open = isOpen(lane.id);
               const isLoadingDetails = Boolean(
                 lane.kind === "command" &&
                 lane.jobId &&
@@ -462,23 +544,33 @@ export function BuildWaterfall({
                 lane.jobId &&
                 detailErrors.has(lane.jobId),
               );
-              const depth = laneDepth(lane);
-              const detail = `${jobNameText(lane.label)} · ${formatTime(lane.startTime)}–${formatTime(lane.endTime)} · ${formatDuration(lane.durationMs)}${lane.outcome ? ` · ${lane.outcome}` : ""}`;
+              const text = laneText(lane);
+              const detail = `${text} · ${formatTime(lane.startTime)}–${formatTime(lane.endTime)} · ${formatDuration(lane.durationMs)}${lane.outcome ? ` · ${lane.outcome}` : ""}${lane.testCount ? ` · ${lane.testCount} tests${lane.failedCount ? `, ${lane.failedCount} failed` : ""}` : ""}`;
               const rowTone = depth === 0 ? "" : depth === 1 ? "bg-cyan-50/35 dark:bg-cyan-950/10" : "bg-emerald-50/30 dark:bg-emerald-950/10";
+              const isGroup = isTestGroup(lane);
+              const countBadge = isGroup
+                ? `${lane.testCount ?? displayedChildCount} ${lane.testCount === 1 ? "test" : "tests"}`
+                : String(displayedChildCount);
 
               return (
-                <div key={lane.id} className={`grid min-h-10 grid-cols-[minmax(16rem,21rem)_minmax(32rem,1fr)] items-center gap-4 border-b border-zinc-200/70 last:border-0 dark:border-zinc-800/70 ${rowTone}`}>
-                  <div className="relative min-w-0 py-1.5" style={{ paddingLeft: `${depth * 18}px` }}>
-                    {depth > 0 && <span aria-hidden="true" className={`absolute inset-y-0 w-px ${depth === 1 ? "left-2 bg-cyan-200 dark:bg-cyan-900" : "left-6 bg-emerald-200 dark:bg-emerald-900"}`} />}
+                <div key={lane.id} className={`grid min-h-10 ${ROW_GRID} items-center gap-4 border-b border-zinc-200/70 last:border-0 dark:border-zinc-800/70 ${rowTone}`}>
+                  <div className="relative min-w-0 py-1.5" style={{ paddingLeft: `${depth * INDENT_PX}px` }}>
+                    {depth > 0 && <span aria-hidden="true" className={`absolute inset-y-0 w-px ${depth === 1 ? "bg-cyan-200 dark:bg-cyan-900" : "bg-emerald-200 dark:bg-emerald-900"}`} style={{ left: `${(depth - 1) * INDENT_PX + 8}px` }} />}
                     <div className="flex items-center gap-1.5">
                       {isExpandable ? (
-                        <button type="button" onClick={() => toggleExpanded(lane)} aria-expanded={expanded.has(lane.id)} aria-label={`${expanded.has(lane.id) ? "Collapse" : "Expand"} ${jobNameText(lane.label)}`} className="dashboard-control flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-500 hover:bg-zinc-200/70 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-100">
-                          <span aria-hidden="true" className={`transition-transform ${expanded.has(lane.id) ? "rotate-90" : ""}`}>›</span>
+                        <button type="button" onClick={() => toggleExpanded(lane)} aria-expanded={open} aria-label={`${open ? "Collapse" : "Expand"} ${text}`} className="dashboard-control flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-500 hover:bg-zinc-200/70 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-100">
+                          <span aria-hidden="true" className={`transition-transform ${open ? "rotate-90" : ""}`}>›</span>
                         </button>
                       ) : <span className="w-6 shrink-0" />}
                       {lane.critical && <span aria-label="Inferred build-limiting job" className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" />}
-                      <span className={`truncate text-xs text-zinc-800 dark:text-zinc-200 ${depth === 0 ? "font-medium" : "font-mono text-[11px]"}`} title={jobNameText(lane.label)}><JobName name={lane.label} /></span>
-                      {isExpandable && <span className="shrink-0 rounded bg-zinc-200/70 px-1.5 py-0.5 font-mono text-[9px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">{displayedChildCount}</span>}
+                      <span
+                        className={`truncate text-xs ${depth === 0 ? "font-medium text-zinc-800 dark:text-zinc-200" : isGroup ? "font-mono text-[11px] font-medium text-zinc-700 dark:text-zinc-300" : "font-mono text-[11px] text-zinc-800 dark:text-zinc-200"}`}
+                        title={text}
+                      >
+                        {isJobLane(lane) ? <JobName name={lane.label} /> : (lane.displayLabel ?? lane.label)}
+                      </span>
+                      {isExpandable && <span className="shrink-0 rounded bg-zinc-200/70 px-1.5 py-0.5 font-mono text-[9px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">{countBadge}</span>}
+                      {isGroup && (lane.failedCount ?? 0) > 0 && <span className="shrink-0 rounded bg-red-100 px-1.5 py-0.5 font-mono text-[9px] font-medium text-red-700 dark:bg-red-950 dark:text-red-300">{lane.failedCount} failed</span>}
                       {isLoadingDetails && <span className="shrink-0 text-[9px] text-cyan-600 dark:text-cyan-400">loading tests…</span>}
                       {hasDetailError && <span className="shrink-0 text-[9px] text-red-600 dark:text-red-400">test trace load failed; select again to retry</span>}
                       <span className="ml-auto shrink-0 font-mono text-[10px] text-zinc-400">{formatDuration(lane.durationMs)}</span>

--- a/src/lib/build-critical-path.test.ts
+++ b/src/lib/build-critical-path.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { criticalPathIds } from "./build-critical-path";
+
+const T0 = Date.parse("2026-09-09T23:00:00Z");
+const at = (seconds: number) => new Date(T0 + seconds * 1_000).toISOString();
+
+function lane(id: string, start: number, end: number) {
+  return { id, startTime: at(start), endTime: at(end) };
+}
+
+/** Bootstrap plus `count` jobs released within a few seconds of it ending. */
+function fanOut(count: number, gateEnd: number, prefix = "job") {
+  return Array.from({ length: count }, (_, index) =>
+    lane(`${prefix}-${index}`, gateEnd + 1 + (index % 8), gateEnd + 600 + index * 30),
+  );
+}
+
+test("a fan-out build yields bootstrap plus the single longest job", () => {
+  // Under the old furthest-end frontier, every job whose end exceeded all
+  // earlier-starting jobs was amber, which in a real nightly was 13 lanes.
+  const lanes = [lane("bootstrap", 0, 50), ...fanOut(12, 50), lane("longest", 55, 62 * 60)];
+
+  assert.deepEqual([...criticalPathIds(lanes)].sort(), ["bootstrap", "longest"]);
+});
+
+test("jobs finishing within a minute of the build end all bound it", () => {
+  const lanes = [
+    lane("bootstrap", 0, 50),
+    ...fanOut(12, 50),
+    lane("xpu", 882, 4477),
+    lane("mi300", 1030, 4470),
+    lane("b200", 2158, 4276),
+  ];
+  const chain = criticalPathIds(lanes);
+
+  assert.ok(chain.has("xpu"));
+  assert.ok(chain.has("mi300"));
+  assert.ok(!chain.has("b200"));
+});
+
+test("a job gated on an image build includes the image build in the chain", () => {
+  const lanes = [
+    lane("bootstrap", 0, 50),
+    ...fanOut(12, 50),
+    lane("build-image", 55, 20 * 60),
+    ...fanOut(20, 20 * 60, "gpu"),
+    lane("gpu-tests", 20 * 60 + 8, 55 * 60),
+  ];
+
+  assert.deepEqual(
+    [...criticalPathIds(lanes)].sort(),
+    ["bootstrap", "build-image", "gpu-tests"],
+  );
+});
+
+test("a job that merely finishes during a start burst is not a gate", () => {
+  // The AMD image build ends at 1015s and releases the AMD shards over the
+  // next 20s. An unrelated H200 job ends at 1030s in the middle of that
+  // burst; under a naive "latest lane to finish before I started" rule it
+  // would be blamed for the MI300 job that started at 1030s.
+  const lanes = [
+    lane("bootstrap", 0, 50),
+    ...fanOut(12, 50),
+    lane("amd-image", 55, 1015),
+    ...Array.from({ length: 40 }, (_, index) =>
+      lane(`amd-${index}`, 1016 + (index % 20), 2000 + index),
+    ),
+    lane("h200-coincidence", 144, 1030),
+    lane("mi300", 1030, 4470),
+  ];
+  const chain = criticalPathIds(lanes);
+
+  assert.deepEqual([...chain].sort(), ["amd-image", "bootstrap", "mi300"]);
+});
+
+test("a long queue wait breaks the chain rather than inventing a predecessor", () => {
+  // The XPU test was gated by an image build at 144s but waited twelve
+  // minutes for an agent. Nothing gated a burst near 882s, so the chain
+  // stops at the test itself instead of blaming whatever ended at 881s.
+  const lanes = [
+    lane("bootstrap", 0, 50),
+    ...fanOut(12, 50),
+    lane("coincidence", 144, 881),
+    lane("xpu", 882, 4477),
+  ];
+
+  assert.deepEqual([...criticalPathIds(lanes)].sort(), ["xpu"]);
+});
+
+test("a small fan-out in a large build is not a gate", () => {
+  // 200 lanes: a lane whose end happens to precede six starts is noise.
+  const lanes = [
+    lane("bootstrap", 0, 50),
+    ...fanOut(190, 50),
+    lane("coincidence", 60, 300),
+    ...Array.from({ length: 6 }, (_, index) => lane(`late-${index}`, 302 + index, 900)),
+    lane("longest", 305, 7200),
+  ];
+
+  assert.deepEqual([...criticalPathIds(lanes)].sort(), ["longest"]);
+});
+
+test("a tiny build with no fan-out marks only the last job", () => {
+  const chain = criticalPathIds([lane("a", 0, 50), lane("b", 55, 600), lane("c", 60, 300)]);
+  assert.deepEqual([...chain], ["b"]);
+});
+
+test("empty and malformed input yield an empty chain", () => {
+  assert.equal(criticalPathIds([]).size, 0);
+  assert.equal(
+    criticalPathIds([{ id: "x", startTime: "nope", endTime: "nope" }]).size,
+    0,
+  );
+});

--- a/src/lib/build-critical-path.ts
+++ b/src/lib/build-critical-path.ts
@@ -1,0 +1,115 @@
+export interface CriticalPathLane {
+  id: string;
+  startTime: string;
+  endTime: string;
+}
+
+/** Lanes finishing within this of the build's end all bound its duration. */
+const TERMINAL_WINDOW_MS = 60_000;
+/** Clock skew between agents: a gate may appear to end just after a start. */
+const TOLERANCE_MS = 2_000;
+/** A gate releases at least this many starts within GATE_WINDOW_MS, or 5% of
+ *  the build's lanes if larger: in a 460-job build, six starts inside any
+ *  given 15s is routine and proves nothing. */
+const GATE_MIN_FANOUT = 5;
+const GATE_MIN_FANOUT_RATIO = 0.05;
+const GATE_WINDOW_MS = 15_000;
+/** Starts in the window before a gate ended count against it: a burst that
+ *  was already under way means the lane merely finished during it. */
+const GATE_ONSET_PENALTY = 3;
+/** A lane starting within this long after a gate ended is attributed to it. */
+const ATTRIBUTION_WINDOW_MS = 60_000;
+
+interface ParsedLane {
+  id: string;
+  start: number;
+  end: number;
+}
+
+interface Gate extends ParsedLane {
+  score: number;
+}
+
+/**
+ * Buildkite spans carry neither `depends_on` nor a usable queue wait, so a
+ * dependency is recognised by its effect: when a gating job (bootstrap, an
+ * image build) finishes, a burst of dependants starts within seconds. A lane
+ * that merely finishes while such a burst is already under way is not a gate,
+ * which is what the onset penalty rejects.
+ */
+function findGates(lanes: ParsedLane[]): Gate[] {
+  const starts = lanes.map((lane) => lane.start).sort((a, b) => a - b);
+  const countStarts = (from: number, to: number) => {
+    // Inclusive [from, to] on a sorted array.
+    let low = 0;
+    let high = starts.length;
+    while (low < high) {
+      const mid = (low + high) >>> 1;
+      if (starts[mid] < from) low = mid + 1;
+      else high = mid;
+    }
+    let count = 0;
+    for (let index = low; index < starts.length && starts[index] <= to; index++) count++;
+    return count;
+  };
+  const minFanout = Math.max(
+    GATE_MIN_FANOUT,
+    Math.ceil(lanes.length * GATE_MIN_FANOUT_RATIO),
+  );
+  const gates: Gate[] = [];
+  for (const lane of lanes) {
+    const after = countStarts(lane.end - TOLERANCE_MS + 1, lane.end + GATE_WINDOW_MS);
+    const before = countStarts(lane.end - GATE_WINDOW_MS, lane.end - TOLERANCE_MS);
+    if (after < minFanout || before * GATE_ONSET_PENALTY > after) continue;
+    gates.push({ ...lane, score: after - GATE_ONSET_PENALTY * before });
+  }
+  return gates;
+}
+
+/**
+ * Infer the chain of lanes that set the build's duration.
+ *
+ * The lanes that finish last (within a minute of the build's end) are
+ * build-limiting by definition. Each is then traced back through the gate it
+ * most plausibly waited on: the strongest gate that ended shortly before it
+ * started. The result is the critical path, typically one or two long jobs
+ * plus the image builds and bootstrap that gated them, rather than every job
+ * that briefly held the furthest end time while the build fanned out.
+ */
+export function criticalPathIds(lanes: CriticalPathLane[]): Set<string> {
+  const chain = new Set<string>();
+  const parsed: ParsedLane[] = lanes
+    .map((lane) => ({
+      id: lane.id,
+      start: Date.parse(lane.startTime),
+      end: Date.parse(lane.endTime),
+    }))
+    .filter((lane) => Number.isFinite(lane.start) && Number.isFinite(lane.end));
+  if (parsed.length === 0) return chain;
+
+  const buildEnd = Math.max(...parsed.map((lane) => lane.end));
+  const gates = findGates(parsed);
+  const pending = parsed.filter((lane) => lane.end >= buildEnd - TERMINAL_WINDOW_MS);
+  for (const lane of pending) chain.add(lane.id);
+
+  while (pending.length > 0) {
+    const lane = pending.pop() as ParsedLane;
+    let predecessor: Gate | null = null;
+    for (const gate of gates) {
+      if (chain.has(gate.id)) continue;
+      if (gate.end > lane.start + TOLERANCE_MS) continue;
+      if (lane.start - gate.end > ATTRIBUTION_WINDOW_MS) continue;
+      if (
+        !predecessor ||
+        gate.score > predecessor.score ||
+        (gate.score === predecessor.score && gate.end > predecessor.end)
+      ) {
+        predecessor = gate;
+      }
+    }
+    if (!predecessor) continue;
+    chain.add(predecessor.id);
+    pending.push(predecessor);
+  }
+  return chain;
+}

--- a/src/lib/test-tree.test.ts
+++ b/src/lib/test-tree.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildTestTree, parseTestNodeId } from "./test-tree";
+
+const T0 = Date.parse("2026-09-09T23:00:00Z");
+const at = (seconds: number) => new Date(T0 + seconds * 1_000).toISOString();
+
+function leaf(
+  label: string,
+  start: number,
+  end: number,
+  status: "passed" | "failed" | "skipped" | "unknown" = "passed",
+) {
+  return { id: label, label, startTime: at(start), endTime: at(end), status };
+}
+
+test("parseTestNodeId splits file, function and parameters", () => {
+  assert.deepEqual(
+    parseTestNodeId("tests/models/test_hybrid.py::test_models[model0-5-True]"),
+    { file: "tests/models/test_hybrid.py", testCase: "test_models", params: "[model0-5-True]" },
+  );
+  assert.deepEqual(parseTestNodeId("tests/a.py::TestX::test_y"), {
+    file: "tests/a.py",
+    testCase: "TestX::test_y",
+    params: null,
+  });
+  assert.deepEqual(parseTestNodeId("tests/a.py::test_z[a[b]-c]"), {
+    file: "tests/a.py",
+    testCase: "test_z",
+    params: "[a[b]-c]",
+  });
+  assert.deepEqual(parseTestNodeId("not-a-nodeid"), {
+    file: "not-a-nodeid",
+    testCase: null,
+    params: null,
+  });
+});
+
+test("tests group into file → function → parameter combination", () => {
+  const tree = buildTestTree("cmd", [
+    leaf("tests/a.py::test_x[p1]", 10, 20),
+    leaf("tests/a.py::test_x[p2]", 20, 35, "failed"),
+    leaf("tests/a.py::test_plain", 35, 40),
+    leaf("tests/b.py::test_y[q]", 0, 5),
+  ]);
+
+  assert.equal(tree.length, 2);
+  const [fileB, fileA] = tree;
+  assert.equal(fileB.type, "group");
+  assert.equal(fileA.type, "group");
+  if (fileB.type !== "group" || fileA.type !== "group") return;
+
+  // Ordered by first start.
+  assert.equal(fileB.label, "tests/b.py");
+  assert.equal(fileA.label, "tests/a.py");
+  assert.equal(fileA.kind, "test-file");
+  assert.equal(fileA.testCount, 3);
+  assert.equal(fileA.failedCount, 1);
+  assert.equal(fileA.status, "failed");
+  assert.equal(fileA.durationMs, 30_000);
+  assert.equal(fileA.id, "cmd::file:tests/a.py");
+
+  const [caseX, plain] = fileA.children;
+  assert.equal(caseX.type, "group");
+  if (caseX.type !== "group") return;
+  assert.equal(caseX.kind, "test-case");
+  assert.equal(caseX.label, "test_x");
+  assert.equal(caseX.testCount, 2);
+  assert.deepEqual(
+    caseX.children.map((child) => child.type === "leaf" && child.displayLabel),
+    ["[p1]", "[p2]"],
+  );
+
+  // An unparametrized function is a leaf directly under its file.
+  assert.equal(plain.type, "leaf");
+  assert.equal(plain.type === "leaf" && plain.displayLabel, "test_plain");
+});
+
+test("node IDs without :: stay as direct children", () => {
+  const tree = buildTestTree("cmd", [leaf("setup", 0, 1)]);
+  assert.equal(tree.length, 1);
+  assert.equal(tree[0].type, "leaf");
+});
+
+test("a group of only skipped tests reads as skipped", () => {
+  const tree = buildTestTree("cmd", [
+    leaf("tests/a.py::test_x[p1]", 0, 1, "skipped"),
+    leaf("tests/a.py::test_x[p2]", 1, 2, "skipped"),
+  ]);
+  assert.equal(tree[0].type === "group" && tree[0].status, "skipped");
+});

--- a/src/lib/test-tree.ts
+++ b/src/lib/test-tree.ts
@@ -1,0 +1,179 @@
+/**
+ * Group flat pytest node IDs into a file → test function → parameter tree
+ * for the build waterfall, so a shard with thousands of parametrized cases
+ * reads as a handful of files and functions until the viewer drills in.
+ */
+
+export type TestStatus = "passed" | "failed" | "skipped" | "unknown";
+
+export interface TestNodeIdParts {
+  /** Path of the test module, e.g. `tests/models/test_hybrid.py`. */
+  file: string;
+  /** Function (and class) name, e.g. `TestX::test_models`; null without `::`. */
+  testCase: string | null;
+  /** Parametrize suffix including brackets, e.g. `[model0-5-True]`. */
+  params: string | null;
+}
+
+export function parseTestNodeId(nodeid: string): TestNodeIdParts {
+  const separator = nodeid.indexOf("::");
+  if (separator === -1) return { file: nodeid, testCase: null, params: null };
+  const file = nodeid.slice(0, separator);
+  const rest = nodeid.slice(separator + 2);
+  const bracket = rest.indexOf("[");
+  if (bracket === -1 || !rest.endsWith("]")) {
+    return { file, testCase: rest, params: null };
+  }
+  return { file, testCase: rest.slice(0, bracket), params: rest.slice(bracket) };
+}
+
+export interface TestLeafLike {
+  id: string;
+  label: string;
+  startTime: string;
+  endTime: string;
+  status: TestStatus;
+}
+
+export interface TestTreeGroup<T extends TestLeafLike> {
+  type: "group";
+  kind: "test-file" | "test-case";
+  id: string;
+  /** Short label shown in the row: file path or function name. */
+  label: string;
+  startTime: string;
+  endTime: string;
+  durationMs: number;
+  status: TestStatus;
+  testCount: number;
+  failedCount: number;
+  children: TestTreeNode<T>[];
+}
+
+export interface TestTreeLeaf<T extends TestLeafLike> {
+  type: "leaf";
+  /** The part of the node ID not already shown by the enclosing groups. */
+  displayLabel: string;
+  lane: T;
+}
+
+export type TestTreeNode<T extends TestLeafLike> =
+  | TestTreeGroup<T>
+  | TestTreeLeaf<T>;
+
+function byStart<T extends TestLeafLike>(a: TestTreeNode<T>, b: TestTreeNode<T>) {
+  const startA = a.type === "leaf" ? a.lane.startTime : a.startTime;
+  const startB = b.type === "leaf" ? b.lane.startTime : b.startTime;
+  return Date.parse(startA) - Date.parse(startB);
+}
+
+function summarize<T extends TestLeafLike>(
+  kind: TestTreeGroup<T>["kind"],
+  id: string,
+  label: string,
+  children: TestTreeNode<T>[],
+): TestTreeGroup<T> {
+  children.sort(byStart);
+  let start = Number.POSITIVE_INFINITY;
+  let end = Number.NEGATIVE_INFINITY;
+  let testCount = 0;
+  let failedCount = 0;
+  let passedCount = 0;
+  let skippedCount = 0;
+  for (const child of children) {
+    if (child.type === "leaf") {
+      start = Math.min(start, Date.parse(child.lane.startTime));
+      end = Math.max(end, Date.parse(child.lane.endTime));
+      testCount += 1;
+      if (child.lane.status === "failed") failedCount += 1;
+      else if (child.lane.status === "passed") passedCount += 1;
+      else if (child.lane.status === "skipped") skippedCount += 1;
+    } else {
+      start = Math.min(start, Date.parse(child.startTime));
+      end = Math.max(end, Date.parse(child.endTime));
+      testCount += child.testCount;
+      failedCount += child.failedCount;
+      if (child.status === "passed") passedCount += 1;
+      else if (child.status === "skipped") skippedCount += 1;
+    }
+  }
+  const status: TestStatus =
+    failedCount > 0
+      ? "failed"
+      : skippedCount > 0 && passedCount === 0 && skippedCount === children.length
+        ? "skipped"
+        : passedCount > 0
+          ? "passed"
+          : "unknown";
+  return {
+    type: "group",
+    kind,
+    id,
+    label,
+    startTime: new Date(start).toISOString(),
+    endTime: new Date(end).toISOString(),
+    durationMs: Math.max(0, end - start),
+    status,
+    testCount,
+    failedCount,
+    children,
+  };
+}
+
+/**
+ * Build the tree for one pytest command. Tests whose node ID has no `::`
+ * stay as direct children. A function without parameters sits directly
+ * under its file; a parametrized function gets its own group whose leaves
+ * show only the parameter combination.
+ */
+export function buildTestTree<T extends TestLeafLike>(
+  parentId: string,
+  tests: T[],
+): TestTreeNode<T>[] {
+  const files = new Map<string, Map<string, TestTreeLeaf<T>[]>>();
+  const loose: TestTreeNode<T>[] = [];
+  const unparametrized = new Map<string, TestTreeLeaf<T>[]>();
+
+  for (const lane of tests) {
+    const parts = parseTestNodeId(lane.label);
+    if (parts.testCase === null) {
+      loose.push({ type: "leaf", displayLabel: lane.label, lane });
+      continue;
+    }
+    const cases = files.get(parts.file) ?? new Map<string, TestTreeLeaf<T>[]>();
+    files.set(parts.file, cases);
+    if (parts.params === null) {
+      const key = `${parts.file}::${parts.testCase}`;
+      const direct = unparametrized.get(key) ?? [];
+      direct.push({ type: "leaf", displayLabel: parts.testCase, lane });
+      unparametrized.set(key, direct);
+      if (!cases.has(parts.testCase)) cases.set(parts.testCase, []);
+      continue;
+    }
+    const leaves = cases.get(parts.testCase) ?? [];
+    leaves.push({ type: "leaf", displayLabel: parts.params, lane });
+    cases.set(parts.testCase, leaves);
+  }
+
+  const roots: TestTreeNode<T>[] = [...loose];
+  for (const [file, cases] of files) {
+    const fileId = `${parentId}::file:${file}`;
+    const children: TestTreeNode<T>[] = [];
+    for (const [testCase, leaves] of cases) {
+      const direct = unparametrized.get(`${file}::${testCase}`) ?? [];
+      if (leaves.length === 0) {
+        children.push(...direct);
+        continue;
+      }
+      children.push(
+        summarize("test-case", `${fileId}::case:${testCase}`, testCase, [
+          ...direct,
+          ...leaves,
+        ]),
+      );
+    }
+    roots.push(summarize("test-file", fileId, file, children));
+  }
+  roots.sort(byStart);
+  return roots;
+}


### PR DESCRIPTION
## Why

The build timeline marked 13 "build-limiting" jobs on a nightly. The old rule flagged every job whose end exceeded all earlier-starting jobs, which in a fan-out build is just a staircase of unrelated parallel jobs. Test rows were also unreadable: every parametrized case was listed flat with its full node ID in a 21rem column.

## What

**Critical path inference** (`src/lib/build-critical-path.ts`, used by `/api/builds/trace`)
- Spans carry no `depends_on`, and `buildkite.job.wait_time_ms` is 0 on every build checked, so the chain is inferred from timing.
- Jobs finishing within a minute of the build end are build-limiting. Each is traced back through the gate it waited on.
- A gate is a lane whose end is followed by a burst of starts (at least max(5, 5% of lanes) within 15s) with few starts just before it. That onset check rejects jobs that merely finished during someone else's burst.

| Build | Before | After |
|---|---|---|
| 88057 (460 jobs) | 13 | 3: AMD image build, then MI300 Multimodal and the XPU test |
| 88100 | 6 | 3: AMD image build and the two MI300/MI355 jobs it gated |
| 88180 | 5 | 1 |

**Test grouping** (`src/lib/test-tree.ts`, `build-waterfall.tsx`)
- A pytest command expands to file rows, then test functions, then parameter combinations. Each level is collapsed with a test count, failed count and span duration; a command with a single file starts with that file open.
- Leaf rows show only the bracketed parameters. Group bars draw lighter and outlined so a file row does not read as one giant test.
- Label column widens to 34rem. Test node IDs no longer pass through the emoji-shortcode parser, which mangled `Class::method` names.

## Verification

- `npm test` (198 passing, including new tests for both helpers), `tsc --noEmit`, `eslint .` clean.
- Checked in the dev server against build 88057: summary reads 3 build-limiting, the filter shows exactly those three, and the `models/language/generation` pytest command expands to 5 files → `test_models` (20 tests) → parameter rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
