### PR TITLE
feat(builds): add a Duration column to the Builds table

### DIFF
--- a/src/components/builds-table.tsx
+++ b/src/components/builds-table.tsx
@@ -1,11 +1,24 @@
 "use client";
 
-import { Fragment, useState, useCallback, useMemo, type MouseEvent, type ReactNode } from "react";
+import {
+  Fragment,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
 import useSWR from "swr";
 import { BuildWaterfall } from "@/components/build-waterfall";
 import { JobName, jobNameText, splitJobName } from "@/components/job-name";
 import type { GroupStatus } from "@/lib/test-groups";
 import { isOptionalJob, isSoftFailJob } from "@/lib/optional-jobs";
+import {
+  buildDurationDisplay,
+  isBuildInProgress,
+  type BuildDurationKind,
+} from "@/lib/build-duration";
 
 export interface Build {
   id: string;
@@ -214,6 +227,34 @@ function stateTextColor(state: string) {
   }
 }
 
+/**
+ * Current time that re-renders on `intervalMs`. Pass `null` to stop ticking
+ * (the value then only updates when the component re-renders for other
+ * reasons). Used to keep "so far" durations of running builds fresh.
+ */
+function useNow(intervalMs: number | null): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (intervalMs === null) return;
+    const id = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}
+
+function durationColor(kind: BuildDurationKind) {
+  switch (kind) {
+    case "running":
+      return "font-medium text-yellow-600 dark:text-yellow-400";
+    case "queued":
+      return "text-yellow-600 dark:text-yellow-400";
+    case "unknown":
+      return "text-zinc-400 dark:text-zinc-600";
+    default:
+      return "text-zinc-600 dark:text-zinc-400";
+  }
+}
+
 function BuildContext({ build }: { build: Build }) {
   return (
     <p className="mt-1.5 border-t border-zinc-100 pt-1.5 text-zinc-500 dark:border-zinc-800 dark:text-zinc-400">
@@ -351,6 +392,11 @@ export function BuildsTable({
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [expandedBuildId, setExpandedBuildId] = useState<string | null>(null);
   const [hoveredCol, setHoveredCol] = useState<string | null>(null);
+  const hasInProgress = useMemo(
+    () => builds.some((build) => isBuildInProgress(build.state)),
+    [builds],
+  );
+  const now = useNow(hasInProgress ? 30_000 : null);
   const buildIds = useMemo(
     () => builds.map((build) => build.id),
     [builds],
@@ -419,7 +465,7 @@ export function BuildsTable({
   const hasGroups = groupOrder.length > 0;
   const showSkeleton = !hasGroups && Boolean(groupsLoading) && builds.length > 0;
   const skeletonCount = showSkeleton ? SKELETON_GROUP_COLUMNS : 0;
-  const FIXED_COLS = showBranch ? 7 : 6;
+  const FIXED_COLS = showBranch ? 8 : 7;
 
   // Size the header row for the widest rotated label so long group and job
   // names are not clipped at the top of the table.
@@ -460,6 +506,7 @@ export function BuildsTable({
               <th className="px-4 pb-2 text-left align-bottom font-semibold text-zinc-500 dark:text-zinc-400">PR</th>
               <th className="px-4 pb-2 text-left align-bottom font-semibold text-zinc-500 dark:text-zinc-400">Author</th>
               <th className="px-4 pb-2 text-left align-bottom font-semibold text-zinc-500 dark:text-zinc-400">Status</th>
+              <th className="px-4 pb-2 text-left align-bottom font-semibold text-zinc-500 dark:text-zinc-400">Duration</th>
               <th className="px-4 pb-2 text-left align-bottom font-semibold text-zinc-500 dark:text-zinc-400">Message</th>
               {hasGroups &&
                 columns.map((col, i) => {
@@ -576,6 +623,7 @@ export function BuildsTable({
                   build.build_number,
               );
               const isTraceExpanded = expandedBuildId === build.id;
+              const duration = buildDurationDisplay(build, now);
               const startedJobCount = startedJobCountsByBuild[build.id];
 
               return (
@@ -716,6 +764,14 @@ export function BuildsTable({
                         {build.state}
                       </span>
                     )}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-2 text-xs tabular-nums">
+                    <span
+                      className={durationColor(duration.kind)}
+                      title={duration.title}
+                    >
+                      {duration.label}
+                    </span>
                   </td>
                   <td className="max-w-[16rem] truncate px-4 py-2 text-zinc-600 dark:text-zinc-400">
                     {build.message ?? "—"}

--- a/src/lib/build-duration.test.ts
+++ b/src/lib/build-duration.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildDurationDisplay, formatBuildDuration } from "./build-duration";
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+test("formatBuildDuration uses hours and minutes at or above one hour", () => {
+  assert.equal(formatBuildDuration(HOUR), "1h 0m");
+  assert.equal(formatBuildDuration(HOUR + 12 * MIN + 30_000), "1h 12m");
+  assert.equal(formatBuildDuration(3 * HOUR + 59 * MIN), "3h 59m");
+});
+
+test("formatBuildDuration uses minutes and seconds under one hour", () => {
+  assert.equal(formatBuildDuration(48 * MIN + 3_000), "48m 3s");
+  assert.equal(formatBuildDuration(59 * MIN + 59_000), "59m 59s");
+  assert.equal(formatBuildDuration(MIN), "1m 0s");
+});
+
+test("formatBuildDuration drops the minutes part under one minute", () => {
+  assert.equal(formatBuildDuration(45_000), "45s");
+  assert.equal(formatBuildDuration(0), "0s");
+});
+
+test("formatBuildDuration rounds sub-second remainders and rejects bad input", () => {
+  assert.equal(formatBuildDuration(59 * MIN + 59_600), "1h 0m");
+  assert.equal(formatBuildDuration(-1), "—");
+  assert.equal(formatBuildDuration(Number.NaN), "—");
+});
+
+const base = {
+  created_at: "2026-09-11T10:00:00Z",
+  started_at: "2026-09-11T10:02:00Z",
+  finished_at: null as string | null,
+};
+const now = Date.parse("2026-09-11T11:30:00Z");
+
+test("finished builds report start-to-finish duration regardless of state", () => {
+  for (const state of ["passed", "failed", "canceled"]) {
+    const display = buildDurationDisplay(
+      { ...base, state, finished_at: "2026-09-11T11:14:30Z" },
+      now,
+    );
+    assert.equal(display.kind, "finished");
+    assert.equal(display.label, "1h 12m");
+  }
+});
+
+test("running builds report elapsed time so far with a trailing ellipsis", () => {
+  const display = buildDurationDisplay({ ...base, state: "running" }, now);
+  assert.equal(display.kind, "running");
+  assert.equal(display.label, "1h 28m…");
+});
+
+test("scheduled builds that have not started report queue time", () => {
+  const display = buildDurationDisplay(
+    { ...base, state: "scheduled", started_at: null },
+    now,
+  );
+  assert.equal(display.kind, "queued");
+  assert.equal(display.label, "queued 1h 30m");
+});
+
+test("terminal builds with missing timestamps show a dash", () => {
+  const display = buildDurationDisplay(
+    { ...base, state: "canceled", started_at: null },
+    now,
+  );
+  assert.equal(display.kind, "unknown");
+  assert.equal(display.label, "—");
+});
+
+test("elapsed time never goes negative when clocks disagree", () => {
+  const display = buildDurationDisplay(
+    { ...base, state: "running" },
+    Date.parse("2026-09-11T10:01:00Z"),
+  );
+  assert.equal(display.label, "0s…");
+});

--- a/src/lib/build-duration.ts
+++ b/src/lib/build-duration.ts
@@ -1,0 +1,105 @@
+/**
+ * Duration display for build rows.
+ *
+ * Finished builds show wall-clock time from start to finish. Builds that are
+ * still going show how long they have been running so far, and builds that
+ * are queued but not yet started show how long they have been waiting.
+ */
+
+export type BuildDurationKind =
+  | "finished"
+  | "running"
+  | "queued"
+  | "unknown";
+
+export interface BuildDurationDisplay {
+  kind: BuildDurationKind;
+  /** Short text for the table cell, e.g. "1h 12m" or "48m 3s". */
+  label: string;
+  /** Longer hover text explaining what the label measures. */
+  title: string;
+}
+
+const IN_PROGRESS_STATES = new Set([
+  "running",
+  "scheduled",
+  "creating",
+  "blocked",
+  "canceling",
+  "failing",
+]);
+
+/** True for Buildkite states where the build has not reached a final outcome. */
+export function isBuildInProgress(state: string): boolean {
+  return IN_PROGRESS_STATES.has(state);
+}
+
+/**
+ * Format a millisecond duration as `Xh Ym` when an hour or longer, `Xm Ys`
+ * when under an hour, and plain `Xs` under a minute.
+ */
+export function formatBuildDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  const totalSeconds = Math.round(ms / 1_000);
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes >= 60) {
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return `${hours}h ${minutes}m`;
+  }
+  const seconds = totalSeconds % 60;
+  if (totalMinutes === 0) return `${seconds}s`;
+  return `${totalMinutes}m ${seconds}s`;
+}
+
+function parseTime(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export function buildDurationDisplay(
+  build: {
+    state: string;
+    created_at: string | null;
+    started_at: string | null;
+    finished_at: string | null;
+  },
+  now: number = Date.now(),
+): BuildDurationDisplay {
+  const started = parseTime(build.started_at);
+  const finished = parseTime(build.finished_at);
+  const created = parseTime(build.created_at);
+
+  if (started !== null && finished !== null) {
+    return {
+      kind: "finished",
+      label: formatBuildDuration(finished - started),
+      title: "Wall-clock time from first job start to build finish",
+    };
+  }
+
+  const inProgress = isBuildInProgress(build.state);
+
+  if (inProgress && started !== null) {
+    return {
+      kind: "running",
+      label: `${formatBuildDuration(Math.max(0, now - started))}…`,
+      title: "Still running — elapsed since the build started",
+    };
+  }
+
+  if (inProgress && created !== null) {
+    return {
+      kind: "queued",
+      label: `queued ${formatBuildDuration(Math.max(0, now - created))}`,
+      title: "Not started yet — time since the build was created",
+    };
+  }
+
+  return {
+    kind: "unknown",
+    label: "—",
+    title: "Duration unavailable",
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a **Duration** column to the Builds table, between Status and Message.
- Finished builds show start-to-finish wall-clock time: `Xh Ym` at an hour or more, `Xm Ys` under an hour, plain `Xs` under a minute.
- Running builds (including Buildkite's `failing`, which is still in progress) show elapsed time so far with a trailing ellipsis in the running color, e.g. `20m 33s…`, with a tooltip.
- Queued builds that haven't started show `queued Xm Ys` from creation.
- A 30-second tick re-renders in-progress rows so "so far" values don't go stale between the 5-minute SWR refreshes. It only runs while some build on the page is in progress.
- Formatter and display logic live in `src/lib/build-duration.ts` with unit tests.

## Test plan
- [x] `npm test` — 207 pass
- [x] `tsc --noEmit` and `eslint` clean
- [x] Verified in the dev server against live data: finished, running, and failing rows render correctly; expanded timeline row still spans the full table width

🤖 Generated with [Claude Code](https://claude.com/claude-code)