### PR TITLE
Show GPU utilization and memory alongside build/test timelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,46 @@ command invokes pytest, its lightweight pytest plugin sends one child span per
 test node ID. The build timeline groups those spans as job → command → test;
 telemetry errors are warnings and never change the test command's exit status.
 
+### GPU activity in build timelines
+
+Jobs with `ci.gpu.samples` spans gain a **GPU** button on their job, command,
+pytest file/function, and individual test rows. The panel reads samples for the
+exact organization, pipeline, build, job ID, and selected time interval. Its
+charts align with the build time axis; **Zoom to interval** expands short tests.
+Each device has separate utilization and used-memory curves, sample mean
+utilization, peak memory in GiB, and sampling coverage. The GPU fleet page is
+independent; its minute-level host snapshots are never substituted for job data.
+
+The companion vLLM `.buildkite/scripts/ci-otel/ci_gpu.py` collector runs beside
+each traced command and polls container-visible NVIDIA devices once per second.
+It sends batches every 30 seconds through the existing job-scoped OIDC receiver,
+then spools its final batch before the normal job-end trace flush. Samples are
+OTLP span events stored in `otel_spans`. Apply migration `0021` (a concurrent
+partial index for sample expiry), deploy this dashboard change, and merge the
+companion collector to begin receiving
+new data. Existing builds cannot be backfilled. The collector starts automatically
+where command tracing is already enabled; set `CI_INFRA_GPU_SAMPLING=0` in the
+job environment to disable it.
+
+This initial collector covers NVIDIA jobs in the existing trusted CI tracing
+rollout. CPU jobs, uninstrumented jobs, and the currently excluded AMD mirrors
+do not gain GPU controls. Device metrics include other processes sharing that
+device and cannot attribute overlapping pytest/xdist tests individually. A
+subsecond test can finish between polls. NVIDIA's utilization is itself a device
+sampling-window measurement, not a per-test kernel profiler. MIG parent-device
+metrics are deliberately unavailable rather than attributed to the job; see
+the [NVIDIA SMI documentation](https://docs.nvidia.com/deploy/nvidia-smi/).
+
+Missing/invalid readings remain unknown, charts break across gaps, and summaries
+are sample means rather than time-weighted estimates over missing data. Collection
+and upload failures do not fail tests. Uploads have a two-second deadline and can
+introduce sampling gaps; failed periodic batches are dropped to bound memory.
+Only the final batch uses the existing best-effort job-end spool. The read API
+returns at most 16,000 sample events and marks truncation; select a shorter command
+or test when a long job exceeds that limit. The existing daily retention cron
+expires GPU sample batches after seven days without deleting command/test spans.
+Samples retain the existing OIDC branch/pipeline restrictions.
+
 ## Deployment
 
 Deployed on Vercel. The cron jobs in `vercel.json` require Vercel Cron to be enabled on the project.

--- a/migrations/sql/0021_job_gpu_sample_retention.sql
+++ b/migrations/sql/0021_job_gpu_sample_retention.sql
@@ -1,0 +1,5 @@
+-- migrate: no-transaction
+-- Fine-grained samples have a shorter lifetime than command/test timing spans.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_otel_gpu_samples_end
+    ON otel_spans (end_time)
+    WHERE span_name = 'ci.gpu.samples';

--- a/src/app/api/builds/gpu/route.test.ts
+++ b/src/app/api/builds/gpu/route.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+test("GPU queries require an exact job identity and a bounded, positive time interval", async () => {
+  const valid = { organization: "vllm", pipeline: "ci", buildNumber: "42", jobId: "00000000-0000-0000-0000-000000000001", start: "2026-09-11T00:00:00Z", end: "2026-09-11T00:01:00Z" };
+  for (const invalid of [{ jobId: "" }, { buildNumber: "42 OR 1=1" }, { organization: "../vllm" }, { start: "yesterday" }, { end: valid.start }, { end: "2026-10-11T00:00:00Z" }]) {
+    const query = new URLSearchParams({ ...valid, ...invalid });
+    const response = await GET(new NextRequest(`http://localhost/api/builds/gpu?${query}`));
+    assert.equal(response.status, 400);
+  }
+});

--- a/src/app/api/builds/gpu/route.ts
+++ b/src/app/api/builds/gpu/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { parseGpuEvents } from "@/lib/job-gpu";
+
+export const runtime = "nodejs";
+const MAX_SAMPLES = 16_000;
+const SLUG = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,99}$/;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const organization = params.get("organization") ?? "";
+  const pipeline = params.get("pipeline") ?? "";
+  const buildNumber = params.get("buildNumber") ?? "";
+  const jobId = params.get("jobId") ?? "";
+  const start = Date.parse(params.get("start") ?? "");
+  const end = Date.parse(params.get("end") ?? "");
+  if (!SLUG.test(organization) || !SLUG.test(pipeline) || !/^\d{1,12}$/.test(buildNumber) || !UUID.test(jobId)
+    || !Number.isFinite(start) || !Number.isFinite(end) || end <= start || end - start > 7 * 86400_000) {
+    return NextResponse.json({ error: "Invalid GPU trace interval or job identity" }, { status: 400 });
+  }
+  try {
+    const db = getDb();
+    const rows = await db<{ sample: unknown }[]>`
+      SELECT event.value AS sample FROM otel_spans
+      CROSS JOIN LATERAL jsonb_array_elements(span_events) WITH ORDINALITY AS event(value, position)
+      WHERE organization_slug = ${organization}
+        AND pipeline_slug = ${pipeline}
+        AND build_number = ${buildNumber}::bigint
+        AND job_id = ${jobId}
+        AND span_name = 'ci.gpu.samples'
+        AND start_time < ${new Date(end)}
+        AND end_time >= ${new Date(start)}
+        AND event.value->>'name' = 'ci.gpu.sample'
+        AND CASE WHEN event.value->>'timeUnixNano' ~ '^[0-9]{1,20}$'
+          THEN (event.value->>'timeUnixNano')::numeric >= ${start}::numeric * 1000000
+            AND (event.value->>'timeUnixNano')::numeric < ${end}::numeric * 1000000
+          ELSE false END
+      ORDER BY start_time, span_id, event.position
+      LIMIT ${MAX_SAMPLES + 1}
+    `;
+    return NextResponse.json({
+      samples: parseGpuEvents(rows.slice(0, MAX_SAMPLES).map((row) => row.sample), start, end),
+      intervalMs: 1000,
+      truncated: rows.length > MAX_SAMPLES,
+    }, { headers: { "Cache-Control": "private, max-age=5" } });
+  } catch (error) {
+    console.error("Failed to load job GPU samples:", error);
+    return NextResponse.json({ error: "Failed to load GPU samples" }, { status: 500 });
+  }
+}

--- a/src/app/api/builds/trace/route.ts
+++ b/src/app/api/builds/trace/route.ts
@@ -218,6 +218,7 @@ export async function GET(request: NextRequest) {
           OR (
             ${requestedJobId}::text IS NOT NULL
             AND job_id = ${requestedJobId}
+            AND span_name <> 'ci.gpu.samples'
           )
         )
       ORDER BY start_time ASC, duration_ms DESC, span_id ASC
@@ -337,7 +338,19 @@ export async function GET(request: NextRequest) {
           : 0,
       };
     });
-    const lanes = [...jobLanes, ...detailLanes];
+    const gpuJobs = await db<{ job_id: string }[]>`
+      SELECT DISTINCT job_id FROM otel_spans
+      WHERE organization_slug = ${organization}
+        AND pipeline_slug = ${pipeline}
+        AND build_number = ${buildNumber}::bigint
+        AND span_name = 'ci.gpu.samples'
+        AND (${requestedJobId}::text IS NULL OR job_id = ${requestedJobId})
+    `;
+    const gpuJobIds = new Set(gpuJobs.map((row) => row.job_id));
+    const lanes = [...jobLanes, ...detailLanes].map((lane) => ({
+      ...lane,
+      gpuAvailable: lane.jobId !== null && gpuJobIds.has(lane.jobId),
+    }));
 
     const buildSpans = rows.filter(
       (row) => row.span_name === "buildkite.build",

--- a/src/app/api/cron/retention/route.ts
+++ b/src/app/api/cron/retention/route.ts
@@ -8,6 +8,7 @@ export const maxDuration = 55;
 // per-agent Buildkite samples) are kept for 30 days; the 5-minute rollups
 // (gpu_history_5m, host_history_5m) are kept forever as a deliberate choice —
 // they are the long-range history source.
+// One-second job GPU samples are kept for 7 days; command/test spans remain.
 export async function GET(request: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
   if (cronSecret) {
@@ -19,6 +20,12 @@ export async function GET(request: NextRequest) {
 
   try {
     const db = getDb();
+
+    const jobGpuDeleted = await db`
+      DELETE FROM otel_spans
+      WHERE span_name = 'ci.gpu.samples'
+        AND end_time < NOW() - INTERVAL '7 days'
+    `;
 
     const gpuDeleted = await db`
       DELETE FROM gpu_snapshots
@@ -35,6 +42,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({
       ok: true,
+      jobGpuSampleBatchesDeleted: jobGpuDeleted.count,
       gpuSnapshotsDeleted: gpuDeleted.count,
       hostSnapshotsDeleted: hostDeleted.count,
       agentSnapshotsDeleted: agentDeleted.count,

--- a/src/components/build-waterfall.tsx
+++ b/src/components/build-waterfall.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import useSWR from "swr";
 import { JobName, jobNameText } from "@/components/job-name";
 import { buildTestTree, type TestTreeNode } from "@/lib/test-tree";
+import { JobGpuTimeline } from "@/components/job-gpu-timeline";
 
 type LaneKind = "job" | "step" | "command" | "test";
 /** Lanes from the API plus the client-side pytest grouping rows. */
@@ -27,6 +28,7 @@ interface WaterfallLane {
   url: string | null;
   critical: boolean;
   childCount: number;
+  gpuAvailable?: boolean;
   /** Shorter label for tree rows: the part not shown by enclosing groups. */
   displayLabel?: string;
   /** Total tests under a grouping row. */
@@ -213,6 +215,7 @@ export function BuildWaterfall({
   );
   const [loadingJobs, setLoadingJobs] = useState<Set<string>>(() => new Set());
   const [detailErrors, setDetailErrors] = useState<Set<string>>(() => new Set());
+  const [gpuLaneId, setGpuLaneId] = useState<string | null>(null);
   const params = new URLSearchParams({ organization, pipeline, buildNumber });
   const { data, error, isLoading, isValidating, mutate } = useSWR<TraceResponse>(
     `/api/builds/trace?${params.toString()}`,
@@ -574,6 +577,14 @@ export function BuildWaterfall({
                       {isLoadingDetails && <span className="shrink-0 text-[9px] text-cyan-600 dark:text-cyan-400">loading tests…</span>}
                       {hasDetailError && <span className="shrink-0 text-[9px] text-red-600 dark:text-red-400">test trace load failed; select again to retry</span>}
                       <span className="ml-auto shrink-0 font-mono text-[10px] text-zinc-400">{formatDuration(lane.durationMs)}</span>
+                      {lane.jobId && jobLanes.some((job) => job.jobId === lane.jobId && job.gpuAvailable) && (
+                        <button type="button" aria-expanded={gpuLaneId === lane.id}
+                          aria-label={`GPU activity during ${text}`}
+                          onClick={() => setGpuLaneId(gpuLaneId === lane.id ? null : lane.id)}
+                          className={`shrink-0 rounded border px-1.5 py-1 text-[10px] ${gpuLaneId === lane.id ? "border-cyan-400 bg-cyan-50 text-cyan-700 dark:bg-cyan-950 dark:text-cyan-300" : "border-zinc-300 text-zinc-500 hover:text-cyan-600 dark:border-zinc-700"}`}>
+                          GPU
+                        </button>
+                      )}
                     </div>
                     {depth === 0 && (
                       <div className="mt-0.5 flex min-w-0 items-center gap-2 pl-7 font-mono text-[10px] text-zinc-400">
@@ -593,6 +604,12 @@ export function BuildWaterfall({
                       <span role="img" aria-label={detail} title={detail} className={`absolute top-1.5 h-4 min-w-1 rounded-sm ${laneColor(lane)}`} style={{ left: `${runLeft}%`, width: `${Math.max(runWidth, 0.25)}%` }} />
                     )}
                   </div>
+                  {gpuLaneId === lane.id && lane.jobId && (
+                    <JobGpuTimeline key={`${lane.id}-${lane.startTime}-${lane.endTime}`}
+                      organization={organization} pipeline={pipeline} buildNumber={buildNumber}
+                      jobId={lane.jobId} label={text} startTime={lane.startTime} endTime={lane.endTime}
+                      timelineStart={timelineStart} timelineEnd={timelineEnd} />
+                  )}
                 </div>
               );
             })}

--- a/src/components/job-gpu-timeline.tsx
+++ b/src/components/job-gpu-timeline.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+import { gpuSegments, summarizeGpuSamples, type JobGpuResponse, type JobGpuSample } from "@/lib/job-gpu";
+
+interface Props {
+  organization: string;
+  pipeline: string;
+  buildNumber: string;
+  jobId: string;
+  label: string;
+  startTime: string;
+  endTime: string;
+  timelineStart: number;
+  timelineEnd: number;
+}
+
+function gib(bytes: number | null): string {
+  return bytes === null ? "unavailable" : `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
+}
+
+async function fetchGpu(url: string): Promise<JobGpuResponse> {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error("Failed to load GPU samples");
+  return response.json();
+}
+
+export function GpuSampleChart({ samples, start, end, intervalMs }: {
+  samples: JobGpuSample[]; start: number; end: number; intervalMs: number;
+}) {
+  const [hover, setHover] = useState<number | null>(null);
+  const x = (time: number) => (time - start) / Math.max(1, end - start) * 1000;
+  const percent = (point: JobGpuSample, metric: "utilization" | "memoryUsedBytes") => metric === "utilization"
+    ? point.utilization : point.memoryTotalBytes && point.memoryUsedBytes !== null
+      ? 100 * point.memoryUsedBytes / point.memoryTotalBytes : null;
+  const nearest = hover === null ? null : samples.reduce<JobGpuSample | null>((best, point) =>
+    !best || Math.abs(point.timestamp - hover) < Math.abs(best.timestamp - hover) ? point : best, null);
+  const selected = nearest && hover !== null && Math.abs(nearest.timestamp - hover) <= intervalMs * 1.5 ? nearest : null;
+  return (
+    <div className="relative">
+      <svg viewBox="0 0 1000 100" preserveAspectRatio="none" role="img"
+        aria-label="GPU utilization and used memory as percent of device capacity; gaps mean missing samples"
+        className="h-24 w-full overflow-hidden"
+        onMouseLeave={() => setHover(null)}
+        onMouseMove={(event) => {
+          const rect = event.currentTarget.getBoundingClientRect();
+          setHover(start + (event.clientX - rect.left) / rect.width * (end - start));
+        }}>
+        {[0, 25, 50, 75, 100].map((value) => <line key={value} x1="0" x2="1000" y1={100 - value} y2={100 - value} stroke="currentColor" className="text-zinc-200 dark:text-zinc-800" strokeWidth="0.6" />)}
+        {(["utilization", "memoryUsedBytes"] as const).map((metric) => gpuSegments(
+          samples.map((point) => metric === "memoryUsedBytes" && !point.memoryTotalBytes ? { ...point, memoryUsedBytes: null } : point), metric, intervalMs,
+        ).map((segment, index) => (
+          <g key={`${metric}-${index}`} className={metric === "utilization" ? "text-cyan-600 dark:text-cyan-400" : "text-violet-600 dark:text-violet-400"}>
+            {segment.length === 1 ? <circle cx={x(segment[0].timestamp)} cy={99 - (percent(segment[0], metric) ?? 0) * 0.98} r="2" fill="currentColor" /> :
+              <polyline fill="none" stroke="currentColor" strokeWidth="1.5" vectorEffect="non-scaling-stroke" points={segment.map((point) => `${x(point.timestamp)},${99 - (percent(point, metric) ?? 0) * 0.98}`).join(" ")} />}
+          </g>
+        )))}
+        {selected && <line x1={x(selected.timestamp)} x2={x(selected.timestamp)} y1="0" y2="100" stroke="currentColor" strokeDasharray="3 3" className="text-zinc-500" />}
+      </svg>
+      <div className="min-h-5 font-mono text-[10px] text-zinc-500" aria-live="polite">
+        {hover !== null ? selected ? `${new Date(selected.timestamp).toISOString().slice(11, 23)} UTC · GPU ${selected.utilization === null ? "unavailable" : `${selected.utilization}%`} · memory ${gib(selected.memoryUsedBytes)} / ${gib(selected.memoryTotalBytes)}` : "No sample at this time" : "Hover to inspect samples · vertical scale 0–100%"}
+      </div>
+    </div>
+  );
+}
+
+export function JobGpuTimeline(props: Props) {
+  const [focused, setFocused] = useState(false);
+  const start = Date.parse(props.startTime);
+  const end = Math.max(start + 1, Date.parse(props.endTime));
+  const params = new URLSearchParams({
+    organization: props.organization, pipeline: props.pipeline, buildNumber: props.buildNumber,
+    jobId: props.jobId, start: new Date(start).toISOString(), end: new Date(end).toISOString(),
+  });
+  const { data, error, isLoading, mutate } = useSWR<JobGpuResponse>(`/api/builds/gpu?${params}`, fetchGpu, { refreshInterval: 15_000 });
+  const devices = useMemo(() => summarizeGpuSamples(data?.samples ?? [], start, end, data?.intervalMs ?? 1000), [data, start, end]);
+  const axisStart = focused ? start : props.timelineStart;
+  const axisEnd = focused ? end : props.timelineEnd;
+  return (
+    <section aria-label={`GPU samples during ${props.label}`} className="col-span-2 border-y border-cyan-200 bg-white py-3 dark:border-cyan-900 dark:bg-zinc-950">
+      <div className="mb-2 flex items-start justify-between gap-4 text-xs">
+        <div className="min-w-0">
+          <p className="truncate font-medium" title={props.label}>GPU activity during {props.label}</p>
+          <p className="mt-1 text-[11px] text-zinc-500">1s sampling · device activity during this interval, shared by overlapping tests. Short tests may fall between samples.</p>
+        </div>
+        <button type="button" aria-pressed={focused} onClick={() => setFocused(!focused)} className="shrink-0 rounded border border-zinc-300 px-2 py-1 dark:border-zinc-700">
+          {focused ? "Align with build" : "Zoom to interval"}
+        </button>
+      </div>
+      {isLoading && <p className="py-3 text-xs text-zinc-500">Loading GPU samples…</p>}
+      {error && <button type="button" onClick={() => mutate()} className="py-3 text-xs text-red-600">GPU samples could not be loaded. Retry</button>}
+      {data && !error && devices.length === 0 && <p className="py-3 text-xs text-zinc-500">No GPU samples in this interval. This does not mean the GPUs were idle.</p>}
+      {data?.truncated && <p className="mb-2 text-xs text-amber-700">Partial data: this interval exceeds the sample limit. Select a shorter command or test to inspect its full detail.</p>}
+      {devices.length > 0 && <div className="grid grid-cols-[minmax(22rem,34rem)_minmax(28rem,1fr)] gap-4 text-[10px] text-zinc-500">
+        <div><span className="text-cyan-600 dark:text-cyan-400">━ GPU utilization</span> · <span className="text-violet-600 dark:text-violet-400">━ used memory / capacity</span></div>
+        <div className="relative h-5 font-mono">{[0, 0.25, 0.5, 0.75, 1].map((tick) => <span key={tick} className="absolute -translate-x-1/2 first:translate-x-0 last:-translate-x-full" style={{ left: `${tick * 100}%` }}>{((axisStart - props.timelineStart + (axisEnd - axisStart) * tick) / 1000).toFixed(1)}s</span>)}</div>
+      </div>}
+      {devices.map((device) => <div key={device.deviceId} className="grid grid-cols-[minmax(22rem,34rem)_minmax(28rem,1fr)] items-center gap-4 border-t border-zinc-100 py-2 dark:border-zinc-900">
+        <div className="text-xs">
+          <p className="font-medium" title={device.deviceId}>GPU {device.index} · {device.name}</p>
+          <p className="mt-1 font-mono text-[11px]">Sample mean {device.meanUtilization === null ? "unavailable" : `${device.meanUtilization.toFixed(1)}%`} · peak memory {gib(device.peakMemoryBytes)}</p>
+          <p className="mt-1 text-[10px] text-zinc-500">{device.samples.length} samples · {Math.round(device.coverage * 100)}% of 1s intervals have utilization readings</p>
+          {device.samples.some((sample) => sample.status === "unsupported_mig") && <p className="mt-1 text-[11px] text-amber-700">MIG metrics unavailable; parent GPU memory is not attributed to this job.</p>}
+        </div>
+        <GpuSampleChart samples={device.samples} start={axisStart} end={axisEnd} intervalMs={data?.intervalMs ?? 1000} />
+      </div>)}
+    </section>
+  );
+}

--- a/src/lib/job-gpu.test.ts
+++ b/src/lib/job-gpu.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseGpuEvents, summarizeGpuSamples, gpuSegments, type JobGpuSample } from "./job-gpu";
+
+function event(ms: number, attributes: Record<string, unknown> = {}) {
+  return { name: "ci.gpu.sample", timeUnixNano: String(ms * 1e6), attributes: {
+    "gpu.uuid": "GPU-a", "gpu.index": 0, "gpu.name": "H200", "gpu.utilization": 0,
+    "gpu.memory.used": 1024, "gpu.memory.total": 4096, ...attributes,
+  } };
+}
+
+test("intervals are half-open so adjacent tests do not share a boundary sample", () => {
+  const events = [event(999), event(1000), event(1999), event(2000)];
+  assert.deepEqual(parseGpuEvents(events, 1000, 2000).map((s) => s.timestamp), [1000, 1999]);
+  assert.equal(parseGpuEvents(events, 1500, 1600).length, 0);
+});
+
+test("invalid, missing and MIG metrics stay unknown, while measured zero stays zero", () => {
+  const result = parseGpuEvents([
+    event(1000), event(1100, { "gpu.utilization": "N/A", "gpu.memory.used": -1 }),
+    event(1200, { "gpu.utilization": 101, "gpu.memory.used": 5000 }),
+    event(1300, { "gpu.status": "unsupported_mig", "gpu.utilization": 70 }),
+    { name: "other", timeUnixNano: "1000000000" }, null,
+  ], 1000, 2000);
+  assert.equal(result[0].utilization, 0);
+  for (const sample of result.slice(1)) {
+    assert.equal(sample.utilization, null);
+    assert.equal(sample.memoryUsedBytes, null);
+  }
+  assert.equal(result[3].memoryTotalBytes, null);
+});
+
+test("summaries isolate GPU UUIDs, deduplicate retries, and retain coverage gaps", () => {
+  const samples = parseGpuEvents([
+    event(1000, { "gpu.utilization": 20 }), event(2000, { "gpu.utilization": 80 }),
+    event(2000, { "gpu.utilization": 80 }),
+    event(1000, { "gpu.uuid": "GPU-b", "gpu.index": 1, "gpu.utilization": 0 }),
+    event(9000, { "gpu.utilization": 100 }),
+  ], 0, 10_000);
+  const summaries = summarizeGpuSamples(samples, 0, 4000, 1000);
+  assert.equal(summaries[0].samples.length, 2);
+  assert.equal(summaries[0].meanUtilization, 50);
+  assert.equal(summaries[0].coverage, 0.5);
+  assert.equal(summaries[1].meanUtilization, 0);
+  assert.equal(summaries[1].coverage, 0.25);
+  assert.deepEqual(summarizeGpuSamples(samples, 2500, 2700, 1000), []);
+});
+
+test("charts break lines on unknown readings and sampling gaps", () => {
+  const samples = parseGpuEvents([
+    event(0), event(1000), event(2000, { "gpu.utilization": "N/A" }),
+    event(3000), event(7000), event(8000),
+  ], 0, 9000);
+  assert.deepEqual(gpuSegments(samples, "utilization", 1000).map((s) => s.map((p) => p.timestamp)), [[0, 1000], [3000], [7000, 8000]]);
+  assert.equal(gpuSegments(samples, "memoryUsedBytes", 1000).length, 2);
+});
+
+test("unsupported utilization cannot become an idle mean or full coverage", () => {
+  const sample = parseGpuEvents([event(1000, { "gpu.utilization": "N/A" })], 0, 2000)[0] as JobGpuSample;
+  const summary = summarizeGpuSamples([sample], 0, 2000, 1000)[0];
+  assert.equal(summary.meanUtilization, null);
+  assert.equal(summary.coverage, 0);
+  assert.equal(summary.peakMemoryBytes, 1024);
+});

--- a/src/lib/job-gpu.ts
+++ b/src/lib/job-gpu.ts
@@ -1,0 +1,109 @@
+/** Wire contract for ci.gpu.samples spans emitted by the in-container CI helper. */
+export interface JobGpuSample {
+  timestamp: number;
+  deviceId: string;
+  index: number;
+  name: string;
+  utilization: number | null;
+  memoryUsedBytes: number | null;
+  memoryTotalBytes: number | null;
+  status: string | null;
+}
+
+export interface JobGpuResponse {
+  samples: JobGpuSample[];
+  truncated: boolean;
+  intervalMs: number;
+}
+
+function object(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown> : null;
+}
+
+function number(value: unknown, maximum = Number.MAX_SAFE_INTEGER): number | null {
+  if (typeof value !== "number" && typeof value !== "string") return null;
+  if (value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= maximum ? parsed : null;
+}
+
+/** Invalid/unsupported metrics remain unknown, including the entire MIG parent. */
+export function parseGpuEvents(events: unknown, start: number, end: number): JobGpuSample[] {
+  if (!Array.isArray(events)) return [];
+  const samples: JobGpuSample[] = [];
+  for (const value of events) {
+    const event = object(value);
+    if (event?.name !== "ci.gpu.sample") continue;
+    const attributes = object(event.attributes);
+    if (!attributes || typeof attributes["gpu.uuid"] !== "string") continue;
+    const ns = number(event.timeUnixNano, Number.MAX_VALUE);
+    const timestamp = ns === null ? NaN : ns / 1_000_000;
+    const index = number(attributes["gpu.index"], 1024);
+    if (!Number.isFinite(timestamp) || timestamp < start || timestamp >= end || index === null) continue;
+    const status = typeof attributes["gpu.status"] === "string" ? attributes["gpu.status"] : null;
+    const unsupported = status === "unsupported_mig";
+    const total = unsupported ? null : number(attributes["gpu.memory.total"]);
+    samples.push({
+      timestamp,
+      deviceId: attributes["gpu.uuid"].slice(0, 128),
+      index,
+      name: typeof attributes["gpu.name"] === "string" ? attributes["gpu.name"].slice(0, 128) : "GPU",
+      utilization: unsupported ? null : number(attributes["gpu.utilization"], 100),
+      memoryUsedBytes: unsupported ? null : number(attributes["gpu.memory.used"], total ?? undefined),
+      memoryTotalBytes: total && total > 0 ? total : null,
+      status,
+    });
+  }
+  return samples;
+}
+
+export interface GpuDeviceSummary {
+  deviceId: string;
+  index: number;
+  name: string;
+  samples: JobGpuSample[];
+  meanUtilization: number | null;
+  peakMemoryBytes: number | null;
+  coverage: number;
+}
+
+/** Sample means, not time-weighted claims about unobserved work between polls. */
+export function summarizeGpuSamples(samples: JobGpuSample[], start: number, end: number, intervalMs: number): GpuDeviceSummary[] {
+  const devices = new Map<string, Map<number, JobGpuSample>>();
+  for (const sample of samples) {
+    if (sample.timestamp < start || sample.timestamp >= end) continue;
+    const points = devices.get(sample.deviceId) ?? new Map<number, JobGpuSample>();
+    points.set(sample.timestamp, sample);
+    devices.set(sample.deviceId, points);
+  }
+  return [...devices].map(([deviceId, points]) => {
+    const sorted = [...points.values()].sort((a, b) => a.timestamp - b.timestamp);
+    const utilization = sorted.flatMap((p) => p.utilization === null ? [] : [p.utilization]);
+    const memory = sorted.flatMap((p) => p.memoryUsedBytes === null ? [] : [p.memoryUsedBytes]);
+    // Count occupied sampling buckets, so duplicate/closely spaced observations
+    // cannot conceal missing intervals. This is sampling coverage, not GPU busy time.
+    const covered = new Set(sorted.filter((p) => p.utilization !== null).map((p) => Math.floor((p.timestamp - start) / intervalMs))).size;
+    return {
+      deviceId, index: sorted[0].index, name: sorted[0].name, samples: sorted,
+      meanUtilization: utilization.length ? utilization.reduce((a, b) => a + b, 0) / utilization.length : null,
+      peakMemoryBytes: memory.length ? Math.max(...memory) : null,
+      coverage: Math.min(1, covered / Math.max(1, Math.ceil((end - start) / intervalMs))),
+    };
+  }).sort((a, b) => a.index - b.index || a.deviceId.localeCompare(b.deviceId));
+}
+
+/** Never connect across missing readings or collection/upload gaps. */
+export function gpuSegments(samples: JobGpuSample[], metric: "utilization" | "memoryUsedBytes", intervalMs: number): JobGpuSample[][] {
+  const segments: JobGpuSample[][] = [];
+  let current: JobGpuSample[] = [];
+  for (const point of samples) {
+    if (point[metric] === null || (current.length && point.timestamp - current[current.length - 1].timestamp > intervalMs * 2.5)) {
+      if (current.length) segments.push(current);
+      current = [];
+    }
+    if (point[metric] !== null) current.push(point);
+  }
+  if (current.length) segments.push(current);
+  return segments;
+}


### PR DESCRIPTION
The Builds timeline shows command/test duration but cannot show whether GPUs were busy. Add per-device utilization and memory charts for the exact selected job, command, pytest group, or test interval, using one-second samples from the companion vLLM CI collector: https://github.com/vllm-project/vllm/pull/56541 (draft pending a real-GPU canary).

GPU controls appear only when that job has received samples. Charts share the build time axis and can zoom to the selected interval. Each device shows sample mean utilization, peak memory, and sampling coverage. Unknown readings, short tests without samples, and collection gaps remain distinct from measured zero; overlapping tests share device activity and are not attributed individually.

The read API uses exact organization/pipeline/build/job identity, half-open time intervals, and a 16,000-event response limit with explicit truncation. GPU batches stay out of trace-lane pagination. A seven-day retention rule expires only GPU batches, with a concurrent partial index in migration `0021`; command/test timings remain intact.

Rollout: apply migration `0021`, deploy the dashboard, then merge the companion collector. Initial coverage is NVIDIA jobs already enabled for trusted CI command tracing; CPU jobs, AMD mirrors, and historical builds do not gain samples. MIG metrics are reported unavailable. Collection can be disabled with `CI_INFRA_GPU_SAMPLING=0`.

Validation:

- `node --import tsx --test 'src/**/*.test.ts'`: 213 passed.
- `migrations/.venv/bin/python -m pytest migrations/tests -q`: 27 passed.
- ESLint on changed TypeScript, TypeScript check, and `npm run build`: passed.
- Python-generated OTLP decoded through the dashboard, with exact-job OIDC matching and missing-value checks: passed.
- Executed the source query and retention SQL on an isolated Postgres engine (PGlite): job/build/organization isolation, interval boundaries, result limits, and preservation of test timings passed.
- Browser inspection with synthetic active/idle GPU readings: job/command/test controls, axis alignment, zoom, and CPU exclusion verified.

No production migration/deployment or physical-GPU canary was performed. AI assistance was used.
