### PR TITLE
fix(alerting): restore the legacy Full CI fixed/baseline rule

### DIFF
--- a/alerting/CONTEXT.md
+++ b/alerting/CONTEXT.md
@@ -25,7 +25,7 @@ The ordered relationship between one Full CI Run and its preceding scheduled Ful
 _Avoid_: Diff, report
 
 **Full CI Failure Condition**:
-One job's classification in a Full CI Comparison: new, recurring, or fixed, with a cause and PR attribution. A fixed condition requires a positively observed pass; a fixing PR is recorded only when verified merged.
+One job's classification in a Full CI Comparison: new, recurring, or fixed, with a cause and PR attribution. A job is fixed when it was in the baseline and is neither a hard nor a soft failure this run, so the baseline cannot retain names that no longer exist; a fixing PR is recorded only when verified merged.
 _Avoid_: Incident, resolution state
 
 **Analyzer Checkpoint**:

--- a/alerting/analyzer.py
+++ b/alerting/analyzer.py
@@ -349,6 +349,23 @@ def _hard_failures(jobs: list[FullCIJobOutcome]) -> set[str]:
     return {job.name for job in jobs if job.state == "failed" and not job.soft_failed}
 
 
+def _soft_failures(jobs: list[FullCIJobOutcome]) -> set[str]:
+    return {job.name for job in jobs if job.state == "failed" and job.soft_failed}
+
+
+def _fixed(jobs: list[FullCIJobOutcome], cache: FailureCache) -> set[str]:
+    """The legacy rule: a baseline name that is no longer failing is fixed.
+
+    Preserved verbatim from the pre-script's agent contract — fixed is
+    ``previous - hard - soft``, so a job that is missing or unfinished this
+    run also leaves the baseline. Requiring a positively observed pass instead
+    looks stricter but strands renamed and retired job names in the baseline
+    forever, because a name that no longer exists can never be observed
+    passing.
+    """
+    return set(cache.failed_tests) - _hard_failures(jobs) - _soft_failures(jobs)
+
+
 def _amd_failure_payload(
     build: Mapping[str, Any], jobs: list[FullCIJobOutcome]
 ) -> dict[str, Any] | None:
@@ -454,6 +471,7 @@ def _build_summary(
             "failed": len(_hard_failures(jobs)),
             "new": len(_hard_failures(jobs) - set(cache.failed_tests)),
             "recurring": len(_hard_failures(jobs) & set(cache.failed_tests)),
+            "fixed": len(_fixed(jobs, cache)),
             "scheduled": sum(1 for job in jobs if job.state == "scheduled"),
             # Cascaded and unfinished-terminal jobs are not failures, but the
             # old report gave them their own sections and the analyzer model
@@ -662,10 +680,8 @@ class FullCIAnalysisHandler:
             return False  # newer comparisons cannot overtake this baseline
 
         cache = self._store.failure_cache_before(context.current.scheduled_at)
-        passed = {job.name for job in jobs if job.state == "passed"}
-        expected_failures = _hard_failures(jobs) | (
-            set(cache.failed_tests) - passed
-        )
+        # The next baseline is exactly this run's hard failures; see _fixed.
+        expected_failures = _hard_failures(jobs)
         checkpoint = self._store.latest_checkpoint()
         if checkpoint is None:
             # First-ever analysis has no durable memory yet; it starts empty
@@ -785,8 +801,7 @@ class FullCIAnalysisHandler:
                     culprit_pr=prior.culprit_pr if prior is not None else None,
                 )
             )
-        passed = {job.name for job in jobs if job.state == "passed"}
-        for name in sorted((previous - hard) & passed):
+        for name in sorted(_fixed(jobs, cache)):
             prior = self._store.prior_condition(name, before=before)
             conditions.append(self._passed_condition(name, prior))
         return tuple(conditions)

--- a/alerting/assets/vllm-ci-failure-analyzer.md
+++ b/alerting/assets/vllm-ci-failure-analyzer.md
@@ -16,14 +16,16 @@ commits, open pull requests, post messages, or mutate Buildkite or GitHub.
 
 1. Split failed jobs into soft failures (`state == "failed"` and
    `soft_failed == true`) and hard failures (`state == "failed"` and not soft).
-2. Current hard failures enter the durable baseline. A prior failure leaves it
-   only after a positively observed pass; missing and unfinished jobs remain.
+2. The next baseline is exactly this run's hard failures. Nothing carries
+   forward: a name that is not a hard failure this run leaves the baseline.
 3. New failures are hard-failure names absent from
    `previous_failures.failed_tests`.
 4. Recurring failures are hard-failure names present in that baseline.
-5. Fixed tests are baseline names now positively observed with `state ==
-   "passed"`. Missing, scheduled, waiting-failed, canceled, timed-out, and
-   soft-failed jobs are not fixed.
+5. Fixed tests are baseline names that are neither a hard nor a soft failure
+   this run — `previous - hard - soft`. A missing or unfinished job is fixed
+   by that rule; this is deliberate, because a renamed or retired job name can
+   never be observed passing and would otherwise sit in the baseline forever.
+   Never derive the count yourself: it is `stats.fixed`.
 6. Jobs in state `waiting_failed`, `timed_out`, or `canceled` are neither hard
    nor soft failures and never enter the baseline. `waiting_failed` means an
    upstream step (usually an image build) failed and the job never ran — a
@@ -64,7 +66,8 @@ Write `.logs/ci_report.txt` as Slack mrkdwn, without posting it. Start with:
 Every number on the Stats line comes from the summary's precomputed `stats`
 object: X = `stats.passed`, Y = `stats.failed` (hard failures only). Never count
 the `jobs` array yourself — it is too long to count reliably. The
-`(N new, M recurring)` breakdown uses `stats.new` and `stats.recurring` and
+`(N new, M recurring)` breakdown uses `stats.new` and `stats.recurring`, the
+fixed section's count is `stats.fixed`, and
 appears only when `stats.failed` > 0 and `stats.has_previous_data` is true;
 otherwise show just `Y failed`. If `stats.scheduled` > 0, append
 `, S scheduled` to the Stats line using `stats.scheduled`. Add sections for new, recurring, fixed,
@@ -92,9 +95,10 @@ link labels or backticks render as literal text in Slack.
 ## Phase D — Update outputs
 
 Write `.logs/failed_tests_cache.json` with current `build_number`, current
-`commit`, and a sorted unique `failed_tests` list containing current hard
-failures plus prior failures not positively observed passing. Verify all three
-output files exist and contain valid data:
+`commit`, and a sorted unique `failed_tests` list containing exactly this run's
+hard failures (new + recurring). Do not include soft failures and do not carry
+any prior failure forward. Verify all three output files exist and contain
+valid data:
 
 - `.logs/ci_report.txt`
 - `.logs/failed_tests_cache.json`

--- a/alerting/tests/test_analyzer.py
+++ b/alerting/tests/test_analyzer.py
@@ -128,9 +128,7 @@ def well_behaved(
         for job in summary["jobs"]
         if job["state"] == "failed" and not job["soft_failed"]
     }
-    previous = set(summary["previous_failures"]["failed_tests"])
-    passed = {job["name"] for job in summary["jobs"] if job["state"] == "passed"}
-    durable_failures = sorted(hard | (previous - passed))
+    durable_failures = sorted(hard)
     (logs / "ci_report.txt").write_text(report)
     (logs / "failed_tests_cache.json").write_text(
         json.dumps(
@@ -637,6 +635,7 @@ def test_materialized_working_files_match_skill_contract(tmp_path: Path) -> None
         "failed": 1,
         "new": 0,
         "recurring": 1,
+        "fixed": 0,
         "scheduled": 0,
         "cascaded": 0,
         "timed_out": 0,
@@ -784,7 +783,7 @@ def test_first_ever_analysis_without_any_checkpoint_starts_with_empty_memory() -
     assert harness.store.analyses()[0].current_build_id == run2.build_id
 
 
-def test_fixed_requires_a_positively_observed_pass() -> None:
+def test_fixed_is_every_baseline_name_no_longer_failing() -> None:
     run1 = make_run(1, RUN1_AT)
     run2 = make_run(2, RUN2_AT)
     harness = Harness(
@@ -828,16 +827,53 @@ def test_fixed_requires_a_positively_observed_pass() -> None:
         for condition in analysis.conditions
         if condition.lifecycle is FailureLifecycle.FIXED
     }
-    assert set(fixed) == {"Fixed Job"}
-    assert fixed["Fixed Job"].summary == "passed without a verified cause"
-    assert all(condition.fixing_pr is None for condition in fixed.values())
-    assert set(analysis.failure_cache.failed_tests) == {
+    # The legacy rule: previous - hard - soft. Missing and unfinished jobs are
+    # fixed; only the still-soft-failing job stays out of the fixed set.
+    assert set(fixed) == {
+        "Fixed Job",
         "Timed Out Job",
         "Running Job",
         "Canceled Job",
         "Scheduled Job",
         "Absent Job",
-        "Soft Job",
+    }
+    assert fixed["Fixed Job"].summary == "passed without a verified cause"
+    assert all(condition.fixing_pr is None for condition in fixed.values())
+    # Nothing carries forward: this run had no hard failures, so the next
+    # baseline is empty and retired names cannot accumulate in it.
+    assert set(analysis.failure_cache.failed_tests) == set()
+
+
+def test_a_renamed_job_leaves_the_baseline_instead_of_accumulating() -> None:
+    """Regression: the baseline must not keep names that no longer exist.
+
+    Production build #88259's baseline had collected `(H200) Core Operation
+    Kernels Shard 3` and three other names that had been renamed or retired
+    builds earlier. Carrying a prior failure forward until it is observed
+    passing makes that permanent, because the old name never runs again.
+    """
+    run1 = make_run(1, RUN1_AT)
+    run2 = make_run(2, RUN2_AT)
+    harness = Harness(
+        runs=[run1, run2],
+        builds={
+            2: build_json(
+                2,
+                mostly_passing_jobs(
+                    [("(H200 MIG 35GB) Kernels Shard 3", "failed", False)],
+                    total=120,
+                ),
+                scheduled_at=RUN2_AT,
+            )
+        },
+    )
+    harness.seed_analysis(run1, failed_tests=("(H200) Kernels Shard 3",))
+
+    harness.analyze()
+
+    analysis = harness.store.analyses()[-1]
+    assert set(analysis.failure_cache.failed_tests) == {
+        "(H200 MIG 35GB) Kernels Shard 3"
     }
 
 


### PR DESCRIPTION
## Problem

Our Full CI report drifted from the legacy one it replaces. Comparing builds #88197 and #88259 against old prod's Slack posts:

| | legacy | ours | actual |
|---|---|---|---|
| #88259 fixed | 11 | **8** | 11 |
| #88197 new / recurring | 11 / 4 | **12 / 5** | 11 / 6 |

The cause is a rule the port changed. Legacy defined a fixed test as `previous - hard - soft` and wrote the next baseline as exactly that run's hard failures. The port instead required a positively observed pass before a name could leave the baseline, and carried everything else forward.

That is stricter in appearance only. A renamed or retired job can never be observed passing, so it sits in the baseline permanently. The live baseline written by build #88419 holds 7 names and 4 of them are dead:

```
:nvidia: (H200) Core Operation Kernels Shard 3     ← renamed at build #88173
:nvidia: (H200) Spec Decode AL DFlash Nightly      ← renamed at build #88173
:nvidia: (H200) Spec Decode N-Gram + Suffix        ← renamed at build #88173
CPU-Language Generation and Pooling Model Tests    ← main-CI job, never runs in Full CI
```

## Change

`_fixed()` is now the single definition of the rule. `stats["fixed"]`, `expected_failures`, and `_classify` all call it, and the analyzer prompt reads `stats.fixed` rather than deriving the count itself.

That consolidation is the point. The rule previously existed in six places — the prompt's Phase A, the prompt's Phase D, `expected_failures`, `_classify`, the `CONTEXT.md` glossary, and the `well_behaved` test fake — which is why correcting it in one place never held.

## Verification

Replaying builds 88057 → 88197 → 88259 through the restored rule against real Buildkite job data:

```
#88057: 315 passed,  7 failed ( 7 new, 0 recurring), fixed  0, baseline_in  0
#88197: 307 passed, 17 failed (11 new, 6 recurring), fixed  1, baseline_in  7
#88259: 316 passed,  7 failed ( 1 new, 6 recurring), fixed 11, baseline_in 17
baseline carried into the next build: 7 names
```

`fixed 11` and `11 new` now match legacy exactly, and the baseline holds steady instead of growing. The one remaining difference from legacy — #88197's 6 recurring against legacy's 4 — is not a rule difference: legacy fired at the 95% completeness gate while two jobs were still running. That gate is deliberately unchanged.

A new test, `test_a_renamed_job_leaves_the_baseline_instead_of_accumulating`, fails if carry-forward returns.

## Deploy note

No migration needed. The first analysis after deploy rewrites the baseline from that run's hard failures and self-heals. Expect the four dead names to appear once under "Fixed" in that first report, then never again.

## Out of scope, worth knowing

The analyzer's S3 memory is inert — 32 checkpoints since Aug 29, all the same 45-byte empty tarball, no seed memory shipped in `assets/`. Legacy shipped a populated `agent-memory/vllm-ci-failure-analyzer/` with accumulated operational knowledge. That is a real gap from legacy but it is a capability question, not this counting bug, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtYAn47ncwudr3P9AvcdNt