### PR TITLE
fix(alerting): make the analyzer read and write its durable memory

### DIFF
--- a/alerting/assets/vllm-ci-failure-analyzer.md
+++ b/alerting/assets/vllm-ci-failure-analyzer.md
@@ -12,6 +12,24 @@ pre-filtered NVIDIA GPU job results and a `previous_failures` baseline. Read
 This deployment has read-only GitHub credentials. Never create branches, push
 commits, open pull requests, post messages, or mutate Buildkite or GitHub.
 
+## Memory
+
+Your durable memory is `.claude/agent-memory/vllm-ci-failure-analyzer/`. Read
+`MEMORY.md` there before Phase A, then the topic files it indexes that bear on
+the build in front of you. It carries what earlier runs learned: node-fault
+signatures, known flaky tests, the job-rename trap that makes a wave of
+baseline names look like a wave of fixes, and the log-reading order that stops
+a green pytest summary being mistaken for a green job.
+
+Memory records observations, not verdicts that stay true forever. A node-fault
+or flaky-test entry is a hypothesis to confirm against this build, and an entry
+you disprove should be corrected in place rather than left to mislead the next
+run.
+
+Some of it was written for a deployment that also filed revert pull requests.
+Use its judgement about whether a red is a real regression; never act on its
+clone, push, or pull-request mechanics. The prohibition above wins.
+
 ## Phase A — Classify failures
 
 1. Split failed jobs into soft failures (`state == "failed"` and
@@ -100,5 +118,15 @@ output files exist and contain valid data:
 - `.logs/failed_tests_cache.json`
 - `.logs/suspicious_prs.json`
 
-Update project memory only with stable analysis knowledge. Do not store secrets,
-raw logs, or one-run state in memory.
+Then update memory, which is the step that makes the next run better than this
+one. Write back to `.claude/agent-memory/vllm-ci-failure-analyzer/` whatever
+this build taught you that will still be true next week: a node that failed
+across unrelated jobs, a test that flaked and then passed untouched, a job
+rename, a log pattern that misled you, a PR-attribution call worth repeating.
+Append to the topic file it belongs in and index it from `MEMORY.md`;
+correct any entry this build disproved. Leaving memory unchanged is a choice to
+learn nothing, so make it only when the build genuinely taught you nothing new.
+
+Never store secrets, raw logs, or one-run state — no build numbers standing
+alone, no report text, no job lists. Memory is for the pattern, not the
+incident.


### PR DESCRIPTION
## Problem

The legacy analyzer accumulates memory. On the live host its eight files total **432KB** and were last written minutes after the most recent report.

Ours has never written a byte:

```
32 checkpoints since Aug 29 — 1 distinct sha256
that blob: 45 bytes, a gzipped empty tar, 0 entries
```

Every nightly analysis has started from nothing and thrown away whatever it worked out.

## Two causes, both in the prompt

**Nothing told the model where memory lives.** Claude Code loaded the directory automatically from the agent's `memory: project` frontmatter. The Kimi runner has no equivalent, so that line is inert and the path was never mentioned anywhere the model would see it.

**Phase D read as a restriction, not an instruction.** "Update project memory only with stable analysis knowledge" is a rule about what *not* to write. A model that writes nothing satisfies it perfectly.

## Change

Prompt only.

- Name the directory and tell the model to read `MEMORY.md` before Phase A, then the topic files that bear on the build in hand.
- Turn Phase D into an actual instruction, with a worked list of what is worth keeping: a node failing across unrelated jobs, a test that flaked then passed untouched, a job rename, a log pattern that misled it. The prohibition on secrets, raw logs, and one-run state stays, plus a line that memory holds patterns rather than incidents.
- Say plainly that memory records observations, not permanent verdicts — entries are hypotheses to confirm against the current build, and a disproved entry gets corrected in place.

That last point is not hypothetical. Spot-checking the two standing node-fault claims in that memory against recent build history, one still held and the other had inverted — the host it names now fails less often than its comparison group.

A memory that is 50% stale is still worth having, but only if the reader treats it as evidence rather than fact.

## What is deliberately not here

**Memory content.** It is analyzer state, it belongs in the S3 checkpoint the worker already reads on every run, and this repository is public. Seeding it is an operational step, not a code change.

An earlier revision of this branch committed a copy of the legacy memory into `assets/`. That was wrong twice over — the copy was a local snapshot three weeks stale, and shipping accumulated state through git means it can only ever be as fresh as the last commit. Force-pushed away.

## Relation to #162

Independent. #162 restores the legacy fixed/baseline rule and is what delivers matching **stats**; memory affects investigation quality and bullet prose, never the counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtYAn47ncwudr3P9AvcdNt
