### PR TITLE
Sync hover cursor across build timeline and GPU charts

### DIFF
--- a/src/components/build-waterfall.tsx
+++ b/src/components/build-waterfall.tsx
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import { JobName, jobNameText } from "@/components/job-name";
 import { buildTestTree, type TestTreeNode } from "@/lib/test-tree";
 import { JobGpuTimeline } from "@/components/job-gpu-timeline";
+import { TimelineCursorProvider, TimelineHoverArea } from "@/components/timeline-cursor";
 
 type LaneKind = "job" | "step" | "command" | "test";
 /** Lanes from the API plus the client-side pytest grouping rows. */
@@ -438,6 +439,7 @@ export function BuildWaterfall({
     expandableJobs.length > 0 && expandableJobs.every((lane) => isOpen(lane.id));
 
   return (
+    <TimelineCursorProvider>
     <section
       aria-label={`Build ${buildNumber} waterfall`}
       className="sticky left-0 w-[calc(100vw-2rem)] max-w-[1376px] border-t border-zinc-200 bg-zinc-50/80 sm:w-[calc(100vw-3rem)] lg:w-[calc(100vw-4rem)] dark:border-zinc-800 dark:bg-zinc-900/35"
@@ -593,17 +595,19 @@ export function BuildWaterfall({
                       </div>
                     )}
                   </div>
-                  <div className="relative h-7">
-                    <GridLines />
-                    {queueWidth > 0.08 && depth === 0 && (
-                      <span aria-hidden="true" className="absolute top-2 h-3 rounded-l-sm bg-zinc-300 dark:bg-zinc-700" style={{ left: `${queueLeft}%`, width: `${Math.max(queueWidth, 0.2)}%`, backgroundImage: "repeating-linear-gradient(135deg, transparent, transparent 3px, rgb(255 255 255 / 0.35) 3px, rgb(255 255 255 / 0.35) 4px)" }} />
-                    )}
-                    {lane.url ? (
-                      <a href={lane.url} target="_blank" rel="noopener noreferrer" aria-label={detail} title={detail} className={`absolute top-1.5 h-4 min-w-1 rounded-sm transition-[filter] hover:brightness-110 ${laneColor(lane)}`} style={{ left: `${runLeft}%`, width: `${Math.max(runWidth, 0.25)}%` }} />
-                    ) : (
-                      <span role="img" aria-label={detail} title={detail} className={`absolute top-1.5 h-4 min-w-1 rounded-sm ${laneColor(lane)}`} style={{ left: `${runLeft}%`, width: `${Math.max(runWidth, 0.25)}%` }} />
-                    )}
-                  </div>
+                  <TimelineHoverArea start={timelineStart} end={timelineEnd} className="flex min-h-7 self-stretch items-center">
+                    <div className="relative h-7 w-full">
+                      <GridLines />
+                      {queueWidth > 0.08 && depth === 0 && (
+                        <span aria-hidden="true" className="absolute top-2 h-3 rounded-l-sm bg-zinc-300 dark:bg-zinc-700" style={{ left: `${queueLeft}%`, width: `${Math.max(queueWidth, 0.2)}%`, backgroundImage: "repeating-linear-gradient(135deg, transparent, transparent 3px, rgb(255 255 255 / 0.35) 3px, rgb(255 255 255 / 0.35) 4px)" }} />
+                      )}
+                      {lane.url ? (
+                        <a href={lane.url} target="_blank" rel="noopener noreferrer" aria-label={detail} title={detail} className={`absolute top-1.5 h-4 min-w-1 rounded-sm transition-[filter] hover:brightness-110 ${laneColor(lane)}`} style={{ left: `${runLeft}%`, width: `${Math.max(runWidth, 0.25)}%` }} />
+                      ) : (
+                        <span role="img" aria-label={detail} title={detail} className={`absolute top-1.5 h-4 min-w-1 rounded-sm ${laneColor(lane)}`} style={{ left: `${runLeft}%`, width: `${Math.max(runWidth, 0.25)}%` }} />
+                      )}
+                    </div>
+                  </TimelineHoverArea>
                   {gpuLaneId === lane.id && lane.jobId && (
                     <JobGpuTimeline key={`${lane.id}-${lane.startTime}-${lane.endTime}`}
                       organization={organization} pipeline={pipeline} buildNumber={buildNumber}
@@ -628,5 +632,6 @@ export function BuildWaterfall({
         <span>Last span received {formatTime(summary.latestReceivedAt)}{data.truncated ? " · first 5,000 spans" : ""}</span>
       </div>
     </section>
+    </TimelineCursorProvider>
   );
 }

--- a/src/components/job-gpu-timeline.tsx
+++ b/src/components/job-gpu-timeline.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import useSWR from "swr";
+import { TimelineHoverArea, useTimelineHoverTime } from "@/components/timeline-cursor";
 import { gpuSegments, summarizeGpuSamples, type JobGpuResponse, type JobGpuSample } from "@/lib/job-gpu";
 
 interface Props {
@@ -29,7 +30,7 @@ async function fetchGpu(url: string): Promise<JobGpuResponse> {
 export function GpuSampleChart({ samples, start, end, intervalMs }: {
   samples: JobGpuSample[]; start: number; end: number; intervalMs: number;
 }) {
-  const [hover, setHover] = useState<number | null>(null);
+  const hover = useTimelineHoverTime();
   const x = (time: number) => (time - start) / Math.max(1, end - start) * 1000;
   const percent = (point: JobGpuSample, metric: "utilization" | "memoryUsedBytes") => metric === "utilization"
     ? point.utilization : point.memoryTotalBytes && point.memoryUsedBytes !== null
@@ -39,25 +40,21 @@ export function GpuSampleChart({ samples, start, end, intervalMs }: {
   const selected = nearest && hover !== null && Math.abs(nearest.timestamp - hover) <= intervalMs * 1.5 ? nearest : null;
   return (
     <div className="relative">
-      <svg viewBox="0 0 1000 100" preserveAspectRatio="none" role="img"
-        aria-label="GPU utilization and used memory as percent of device capacity; gaps mean missing samples"
-        className="h-24 w-full overflow-hidden"
-        onMouseLeave={() => setHover(null)}
-        onMouseMove={(event) => {
-          const rect = event.currentTarget.getBoundingClientRect();
-          setHover(start + (event.clientX - rect.left) / rect.width * (end - start));
-        }}>
-        {[0, 25, 50, 75, 100].map((value) => <line key={value} x1="0" x2="1000" y1={100 - value} y2={100 - value} stroke="currentColor" className="text-zinc-200 dark:text-zinc-800" strokeWidth="0.6" />)}
-        {(["utilization", "memoryUsedBytes"] as const).map((metric) => gpuSegments(
-          samples.map((point) => metric === "memoryUsedBytes" && !point.memoryTotalBytes ? { ...point, memoryUsedBytes: null } : point), metric, intervalMs,
-        ).map((segment, index) => (
-          <g key={`${metric}-${index}`} className={metric === "utilization" ? "text-cyan-600 dark:text-cyan-400" : "text-violet-600 dark:text-violet-400"}>
-            {segment.length === 1 ? <circle cx={x(segment[0].timestamp)} cy={99 - (percent(segment[0], metric) ?? 0) * 0.98} r="2" fill="currentColor" /> :
-              <polyline fill="none" stroke="currentColor" strokeWidth="1.5" vectorEffect="non-scaling-stroke" points={segment.map((point) => `${x(point.timestamp)},${99 - (percent(point, metric) ?? 0) * 0.98}`).join(" ")} />}
-          </g>
-        )))}
-        {selected && <line x1={x(selected.timestamp)} x2={x(selected.timestamp)} y1="0" y2="100" stroke="currentColor" strokeDasharray="3 3" className="text-zinc-500" />}
-      </svg>
+      <TimelineHoverArea start={start} end={end}>
+        <svg viewBox="0 0 1000 100" preserveAspectRatio="none" role="img"
+          aria-label="GPU utilization and used memory as percent of device capacity; gaps mean missing samples"
+          className="h-24 w-full overflow-hidden">
+          {[0, 25, 50, 75, 100].map((value) => <line key={value} x1="0" x2="1000" y1={100 - value} y2={100 - value} stroke="currentColor" className="text-zinc-200 dark:text-zinc-800" strokeWidth="0.6" />)}
+          {(["utilization", "memoryUsedBytes"] as const).map((metric) => gpuSegments(
+            samples.map((point) => metric === "memoryUsedBytes" && !point.memoryTotalBytes ? { ...point, memoryUsedBytes: null } : point), metric, intervalMs,
+          ).map((segment, index) => (
+            <g key={`${metric}-${index}`} className={metric === "utilization" ? "text-cyan-600 dark:text-cyan-400" : "text-violet-600 dark:text-violet-400"}>
+              {segment.length === 1 ? <circle cx={x(segment[0].timestamp)} cy={99 - (percent(segment[0], metric) ?? 0) * 0.98} r="2" fill="currentColor" /> :
+                <polyline fill="none" stroke="currentColor" strokeWidth="1.5" vectorEffect="non-scaling-stroke" points={segment.map((point) => `${x(point.timestamp)},${99 - (percent(point, metric) ?? 0) * 0.98}`).join(" ")} />}
+            </g>
+          )))}
+        </svg>
+      </TimelineHoverArea>
       <div className="min-h-5 font-mono text-[10px] text-zinc-500" aria-live="polite">
         {hover !== null ? selected ? `${new Date(selected.timestamp).toISOString().slice(11, 23)} UTC · GPU ${selected.utilization === null ? "unavailable" : `${selected.utilization}%`} · memory ${gib(selected.memoryUsedBytes)} / ${gib(selected.memoryTotalBytes)}` : "No sample at this time" : "Hover to inspect samples · vertical scale 0–100%"}
       </div>

--- a/src/components/timeline-cursor.tsx
+++ b/src/components/timeline-cursor.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+const HoverTime = createContext<number | null>(null);
+const SetHoverTime = createContext<(time: number | null) => void>(() => {});
+
+/** Share a timestamp, rather than a pixel offset, across independently zoomed axes. */
+export function TimelineCursorProvider({ children }: { children: ReactNode }) {
+  const [time, setTime] = useState<number | null>(null);
+  return (
+    <SetHoverTime.Provider value={setTime}>
+      <HoverTime.Provider value={time}>{children}</HoverTime.Provider>
+    </SetHoverTime.Provider>
+  );
+}
+
+export function useTimelineHoverTime() {
+  return useContext(HoverTime);
+}
+
+function TimelineCursor({ start, end }: { start: number; end: number }) {
+  const time = useTimelineHoverTime();
+  if (time === null || time < start || time > end || end <= start) return null;
+  return <span aria-hidden="true" data-timeline-cursor={time}
+    className="pointer-events-none absolute inset-y-0 z-10 border-l border-dashed border-zinc-500 dark:border-zinc-400"
+    style={{ left: `${(time - start) / (end - start) * 100}%` }} />;
+}
+
+/** Only the cursor subscribes to movement; the waterfall rows need not rerender. */
+export function TimelineHoverArea({ start, end, className = "", children }: {
+  start: number; end: number; className?: string; children: ReactNode;
+}) {
+  const setTime = useContext(SetHoverTime);
+  return (
+    <div className={`relative ${className}`} data-timeline-start={start} data-timeline-end={end}
+      onMouseLeave={() => setTime(null)}
+      onMouseMove={(event) => {
+        const rect = event.currentTarget.getBoundingClientRect();
+        if (rect.width > 0 && end > start) {
+          const fraction = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
+          setTime(start + fraction * (end - start));
+        }
+      }}>
+      {children}
+      <TimelineCursor start={start} end={end} />
+    </div>
+  );
+}


### PR DESCRIPTION
Hovering GPU utilization previously showed a cursor only on that device's chart, making it difficult to correlate a sample with the green pytest bars. Share one hover timestamp across the build waterfall and all GPU charts, so hovering either a job/command/test track or a GPU plot marks the same time everywhere and updates every GPU readout.

Each axis projects the timestamp independently, including when GPU charts are zoomed to a selected interval. Cursors stay visible over missing samples, hide outside a zoomed time range, and clear together when the pointer leaves the time axis. The overlay does not intercept existing bar links or expansion controls.

Validation:
- Browser-verified using build #88448's real two-L4 telemetry: all 14 cursor markers align; GPU-to-test and test-to-GPU movement update both device readouts.
- Verified zoomed timestamp mapping, missing samples, out-of-range cursor hiding, and mouse-leave clearing.
- `npm run build` (including TypeScript), targeted ESLint, and `git diff --check` pass.
